### PR TITLE
Add a Dev Container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,23 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/go
+{
+	"name": "Go",
+	"image": "mcr.microsoft.com/devcontainers/go:0-1.20",
+	"features": {
+		"ghcr.io/guiyomh/features/golangci-lint:0": {
+			"version": "latest"
+		},
+		"ghcr.io/jungaretti/features/make:1": {}
+	},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	"postCreateCommand": "./.devcontainer/postCreate.sh"
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/.devcontainer/postCreate.sh
+++ b/.devcontainer/postCreate.sh
@@ -1,0 +1,4 @@
+#! /bin/sh
+
+set -ex
+go install gotest.tools/gotestsum@latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,8 @@ Please send pull requests for all changes, even if they are urgent.
 
 This section lists the prerequisites for working with the repository. Most contributors should start with the basic prerequisites. Depending on the task you need to perform, you may need to install more tools.
 
+We also provide a [Devcontainer](https://code.visualstudio.com/docs/devcontainers/containers) for working with this repository without installing prerequisites. Keep reading for instructions.
+
 ### Operating system
 
 We support developing on macOS, Linux and Windows with [WSL](https://docs.microsoft.com/windows/wsl/install).
@@ -71,11 +73,21 @@ Install both of these and then follow the steps in the *Quick Start* for the Go 
 
 The extension will walk you through an automated install of some additional tools that match your installed version of Go.
 
-#### Launching VSCode
+#### Launching VS Code
 
 The best way to launch VS Code for Go is to do *File* -> *Open Folder* on the repository. 
 
 You can easily do this from the command shell with `code .`, which opens the current directory as a folder in VS Code.
+
+### Using the Dev Container
+
+Dev Containers allow you to run a development environment using VS Code inside a container. If you want to try this:
+
+- Install [Docker](https://code.visualstudio.com/docs/devcontainers/containers#_system-requirements)
+- Install [VS Code](https://code.visualstudio.com/)
+- Install the [Dev Container extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)
+
+Now when you open the Invisinets repo, you will be prompted with the option to open in a Dev Container. This will take a few minutes the first time to download and build the container, but will be much faster on subsequent opens.
 
 ### Additional Tools
 


### PR DESCRIPTION
This change adds support for a Dev Container and instructions for using it. The Dev Container contains all of the required and optional tools used to work with the repo.