### PR TITLE
Add github action for build/test/lint/coverage

### DIFF
--- a/.github/scripts/get_release_version.py
+++ b/.github/scripts/get_release_version.py
@@ -1,0 +1,77 @@
+# This script parses release version from Git references and set the parsed version to
+# environment variables, REL_VERSION and REL_CHANNEL.
+
+# We set the environment variable REL_CHANNEL based on the kind of build. This is used for
+# versioning of our assets.
+#
+# REL_CHANNEL is:
+# 'latest': for most builds
+# 'latest': for PR builds
+# '1.0.0-rc1' (the full version): for a tagged prerelease
+# '1.0' (major.minor): for a tagged release
+
+# You can test this script manually by setting some environment variables and running it:
+#  touch env.txt summary.txt
+#  export GITHUB_ENV="$(pwd)/env.txt"
+#  export GITHUB_STEP_SUMMARY="$(pwd)/summary.txt"
+#  export GITHUB_REF=<the value you want to test>
+#
+# Example pre-release tag:
+#  export GITHUB_REF=refs/tags/v1.0.0-rc1
+# Example release tag:
+#  export GITHUB_REF=refs/tags/v1.0.0
+# Example pull-request:
+#  export GITHUB_REF=refs/pull/42/head
+#
+# Running the script will write the environment variables to env.txt and the summary to summary.txt
+
+from enum import Enum
+import os
+import re
+
+class BuildType(Enum):
+    UNKNOWN = 1
+    PULL_REQUEST = 2
+    NORMAL = 3
+    PRERELEASE = 4
+    RELEASE = 5
+
+# From https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
+# Group 'version' returns the whole version other named groups return the components:
+# major, minor, patch, prerelease, buildmetadata
+tag_ref_regex = r"^refs/tags/v(?P<version>0|(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)$"
+pull_ref_regex = r"^refs/pull/(.*)/(.*)$"
+
+github_ref = os.getenv("GITHUB_REF")
+
+def decide_versions() -> tuple[BuildType, str, str]: 
+    if github_ref is None:
+        return (BuildType.UNKNOWN, "latest", "latest")
+    
+    match = re.search(pull_ref_regex, github_ref)
+    if match is not None:
+        return (BuildType.PULL_REQUEST, "pr-{}".format(match.group(1)), "latest")
+
+    match = re.search(tag_ref_regex, github_ref)
+    if match is not None and match.group("prerelease") is not None:
+        return (BuildType.PRERELEASE, match.group("version"), match.group("version"))
+    elif match is not None:
+        return (BuildType.RELEASE, match.group("version"), "{}.{}".format(match.group("major"), match.group("minor")))
+
+    # We end up here for a build of any other branch (eg: a build of main).
+    return (BuildType.Normal, "latest", "latest")
+
+build_type, version, channel = decide_versions()
+with open(os.getenv("GITHUB_ENV"), "a") as github_env, open(os.getenv("GITHUB_STEP_SUMMARY"), "a") as github_step_summary:
+    # Set environment variables for the build to use
+    github_env.write("REL_VERSION={}\n".format(version))
+    github_env.write("REL_CHANNEL={}\n".format(channel))
+
+    summary = """This is a {} build based on ref '{}'. Setting:
+
+    - REL_VERSION={}
+    - REL_CHANNEL={}""".format(build_type, github_ref, version, channel)
+
+    # Print description for debugging
+    print(summary)
+    github_step_summary.write(summary)

--- a/.github/scripts/transform_test_results.py
+++ b/.github/scripts/transform_test_results.py
@@ -1,0 +1,54 @@
+# parse an xml file and transform it into a junit xml file
+# that can be used by the github actions junit reporter
+# Path: .github/scripts/transform-test-results.py
+
+import re
+import sys
+import xml.etree.ElementTree
+
+def main():
+    if len(sys.argv) != 4:
+        print("Usage: transform-test-results.py <repository root> <input file> <output file>")
+        sys.exit(1)
+
+    repository_root = sys.argv[1]
+    input_file = sys.argv[2]
+    output_file = sys.argv[3]
+
+    print(f"Processing {input_file}")
+    pattern = re.compile(r"\tError Trace:\t(.*):(\d+)")
+    et = xml.etree.ElementTree.parse(input_file)
+    for testcase in et.findall('./testsuite/testcase'):
+        failure = testcase.find('./failure')
+        if failure is None:
+            continue
+        
+        # Extract file name by matching regex pattern in the text
+        # it will look like \tError Trace:\tfilename:line
+        match = pattern.search(failure.text)
+        if match is None:
+            continue
+
+        file = match.group(1)
+        line = match.group(2)
+
+        # The filename will contain the fully-qualified path, and we need to turn that into
+        # a relative path from the repository root
+        if not file.startswith(repository_root):
+            print(f"Could not find repository name in file path: {file}")
+            continue
+
+        file = file[len(repository_root) + 1:]
+        
+        testcase.attrib["file"] = file
+        testcase.attrib["line"] = line
+        failure.attrib["file"] = file
+        failure.attrib["line"] = line
+
+    
+    # Write back to file
+    print(f"Writing {output_file}")
+    et.write(output_file)
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,206 @@
+name: Build and Test
+on:
+  push:
+    branches:
+      - main
+      - release/*
+    tags:
+      - v*
+  pull_request:
+    branches:
+      - main
+      - features/*
+      - release/*
+
+concurrency:
+  # Cancel the previously triggered build for only PR build.
+  group: build-${github.ref}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+env:
+  # Go version to install
+  GOVER: '^1.20'
+  GOPROXY: https://proxy.golang.org
+  
+  # gotestsum version - see: https://github.com/gotestyourself/gotestsum
+  GOTESTSUMVERSION: 1.10.0
+
+jobs:
+  build:
+    name: Build ${{ matrix.target_os }}_${{ matrix.target_arch }} binaries
+    runs-on: ubuntu-latest
+    env:
+      GOOS: ${{ matrix.target_os }}
+      GOARCH: ${{ matrix.target_arch }}
+      GOPROXY: https://proxy.golang.org
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target_os: linux
+            target_arch: arm
+          - target_os: linux
+            target_arch: arm64
+          - target_os: linux
+            target_arch: amd64
+          - target_os: windows
+            target_arch: amd64
+          - target_os: darwin
+            target_arch: amd64
+          - target_os: darwin
+            target_arch: arm64
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v3
+      - name: Set up Go ${{ env.GOVER }}
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ env.GOVER }}
+      - name: Get Go Cache path
+        id: go-cache-paths
+        run: |
+          echo "go-build=$(go env GOCACHE)" >> $GITHUB_OUTPUT
+          echo "go-mod=$(go env GOMODCACHE)" >> $GITHUB_OUTPUT
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ${{ steps.go-cache-paths.outputs.go-build }}
+            ${{ steps.go-cache-paths.outputs.go-mod }}
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+      - name: Restore the previous coverage
+        uses: actions/cache/restore@v3
+        with:
+          path: ./dist/cache
+          key: code-coverage-
+      - name: Parse release version and set environment variables
+        run: python ./.github/scripts/get_release_version.py
+      - name: Make build
+        run: make build
+      - name: Run linter
+        if: matrix.target_arch == 'amd64' && matrix.target_os == 'linux'  
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: 'latest'
+          args: --timeout=10m
+      - name: Run make test (unit tests)
+        if: matrix.target_arch == 'amd64' && matrix.target_os == 'linux'
+        env:
+          GOTESTSUM_OPTS: '--junitfile ./dist/unit_test/results.xml'
+          GOTEST_OPTS: '-race -coverprofile ./dist/unit_test/coverage_original.out'
+        run: |
+          go install gotest.tools/gotestsum@v${{ env.GOTESTSUMVERSION }}
+          mkdir -p ./dist/unit_test
+          make test
+      # The test results file output by gotestsum is missing file and line number on the XML elements
+      # which is needed for the annotations to work. This script adds the missing information.
+      - name: 'Transform unit test results'
+        # Always is REQUIRED here. Otherwise, the action will be skipped when the unit tests fail, which
+        # defeats the purpose. YES it is counterintuitive. This applies to all of the actions in this file.
+        if: always() && matrix.target_arch == 'amd64' && matrix.target_os == 'linux'
+        id: 'process_files'
+        shell: 'bash'
+        working-directory: ${{ github.workspace }}
+        env:
+          INPUT_DIRECTORY: ./dist/unit_test/
+        run: |
+          echo "repository root is $GITHUB_WORKSPACE"
+
+          INPUT_FILES="$INPUT_DIRECTORY*.xml"
+          mkdir -p "$INPUT_DIRECTORY/processed"
+          for INPUT_FILE in $INPUT_FILES
+          do
+            DIRECTORY=$(dirname -- "$INPUT_FILE")
+            FILENAME=$(basename -- "$INPUT_FILE")
+            FILENAME="${FILENAME%.*}"
+            OUTPUT_FILE="${DIRECTORY}/processed/${FILENAME}.xml"
+            echo "processing test results in $INPUT_FILE to add line and file info..."
+            python3 ./.github/scripts/transform_test_results.py $GITHUB_WORKSPACE "$INPUT_FILE" "$OUTPUT_FILE"
+            echo "wrote ${OUTPUT_FILE}"
+          done
+      - name: 'Create unit test result report'
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        if: always() && matrix.target_arch == 'amd64' && matrix.target_os == 'linux'
+        with:
+          check_name: 'Unit Test Results'
+          files: |
+            ./dist/unit_test/processed/*.xml
+      - name: 'Upload unit test results'
+        uses: actions/upload-artifact@v3
+        if: always() && matrix.target_arch == 'amd64' && matrix.target_os == 'linux'
+        with:
+          name: unit_test_results
+          path: |
+            ./dist/unit_test/*.xml 
+            ./dist/unit_test/processed/*.xml 
+      - name: Generate unit-test coverage files
+        if: matrix.target_arch == 'amd64' && matrix.target_os == 'linux'
+        run: |
+          # Remove mock, generated files, and datamodels from original coverage output.
+          cat ./dist/unit_test/coverage_original.out | grep -v  "mock" | grep -v  "zz_"  > $COVERAGE_FILE
+          # Generate reports.
+          $GO_TOOL_COVER -func=$COVERAGE_FILE -o ./dist/unit_test/coverage.txt
+          $GO_TOOL_COVER -html=$COVERAGE_FILE -o ./dist/unit_test/coverage.html
+          # Parse total coverage rate from report.
+          UT_COVERAGE=`cat ./dist/unit_test/coverage.txt | grep total: | grep -Eo '[0-9]+\.[0-9]+'`
+          echo "Test coverage : $UT_COVERAGE"
+
+          echo "ut_coverage=$UT_COVERAGE" >> $GITHUB_ENV
+
+          mkdir -p ./dist/cache
+          MAIN_COVERAGE=0
+          if [ -f "./dist/cache/ut_coverage.txt" ]; then
+            MAIN_COVERAGE=$(cat ./dist/cache/ut_coverage.txt | grep total: | grep -Eo '[0-9]+\.[0-9]+')
+          fi
+          echo "main_coverage=$MAIN_COVERAGE" >> $GITHUB_ENV
+
+          if (( $(echo "$UT_COVERAGE < $MAIN_COVERAGE" | bc -l) )) ; then
+            COLOR=red
+          else
+            COLOR=green
+          fi
+          
+          DIFF_RATE=$(echo "$UT_COVERAGE-$MAIN_COVERAGE" | bc -l)
+          echo "diff_coverage=$DIFF_RATE" >> $GITHUB_ENV
+
+          echo "coverage_img=https://img.shields.io/badge/coverage-$UT_COVERAGE%25-$COLOR" >> $GITHUB_ENV
+          # copy coverage to cache
+          cp ./dist/unit_test/coverage.txt ./dist/cache/
+        env:
+          COVERAGE_FILE: ./dist/unit_test/coverage.out
+          GO_TOOL_COVER: go tool cover
+      - name: Upload unit-test coverage artifact
+        if: matrix.target_arch == 'amd64' && matrix.target_os == 'linux'
+        uses: actions/upload-artifact@v3
+        with:
+          name: unit_test_coverage
+          path: |
+            ./dist/unit_test/coverage_original.out
+            ./dist/unit_test/coverage.out
+            ./dist/unit_test/coverage.txt
+            ./dist/unit_test/coverage.html
+      - name: Add coverage result comment
+        if: matrix.target_arch == 'amd64' && matrix.target_os == 'linux' && github.event.pull_request && github.event.pull_request.head.repo.full_name == github.repository
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: testcov-${{ github.run_id }}
+          number: ${{ github.event.pull_request.number }}
+          hide: true
+          hide_classify: OUTDATED
+          message: |
+            ![${{ env.ut_coverage }}](${{ env.coverage_img }})
+
+            For the detailed report, please go to `Checks tab`, click `Build and Test`, and then download `unit_test_coverage` artifact at the bottom of build page.
+
+            * Your PR branch coverage: ${{ env.ut_coverage }} %
+            * main branch coverage: ${{ env.main_coverage }} %
+            * diff coverage: ${{ env.diff_coverage }} %
+
+            > The coverage result does not include the functional test results. 
+      - name: Save coverage (only main push)
+        uses: actions/cache/save@v3
+        if: matrix.target_arch == 'amd64' && matrix.target_os == 'linux' && github.ref == 'refs/heads/main'
+        with:
+          path: ./dist/cache
+          key: code-coverage-${{ github.sha }}-${{ github.run_number }}


### PR DESCRIPTION
This change adds a github actions workflow for building, testing, linting, and checking code coverage.

It does the following things for a pull request:

- Sets versions
- Builds
- Runs golint ci
- Runs unit tests
- Generates a unit test summary
- Generates a code coverage report

It does the following for builds/pushes:

- Sets versions
- Builds
- Runs golint ci
- Runs unit tests
- Generates a unit test summary
- Updates the stored code coverage baseline (pushes to main only)