### PR TITLE
[GCP] Randomize resource names in integration test

### DIFF
--- a/pkg/gcp/plugin.go
+++ b/pkg/gcp/plugin.go
@@ -40,10 +40,13 @@ type GCPPluginServer struct {
 
 // GCP
 // Naming convention loosely follows https://cloud.google.com/architecture/best-practices-vpc-design#naming
+var ( // declared var instead of const so it can be modified in integration tests
+	vpcName = "invisinets-vpc" // Invisinets VPC name
+	vpcURL  = "global/networks/" + vpcName
+)
+
 const (
 	networkInterface      = "nic0"
-	vpcName               = "invisinets-vpc" // Invisinets VPC name
-	vpcURL                = "global/networks/" + vpcName
 	networkTagPrefix      = "invisinets-permitlist-" // Prefixe for GCP tags related to invisinets
 	firewallNamePrefix    = "fw-" + networkTagPrefix // Prefixe for firewall names related to invisinets
 	firewallNameMaxLength = 62                       // GCP imposed max length for firewall name


### PR DESCRIPTION
If two PRs are running checks, they may overlap and attempt to create a resource that's already been created or delete one that's already been deleted. This fixes the problem by appending uuids to VMs and VPCs. Subnet names don't have to be changed as they are unique within the context of a VPC.