### PR TITLE
[Frontend] Fix server setup concurrency bug in tests

### DIFF
--- a/pkg/frontend/frontend_test.go
+++ b/pkg/frontend/frontend_test.go
@@ -76,7 +76,6 @@ func newServer() *mockCloudPluginServer {
 
 func setupServer(port int) {
 	lis, err := net.Listen("tcp", fmt.Sprintf("localhost:%d", port))
-	fmt.Println("got here")
 	if err != nil {
 		log.Fatalf("failed to listen: %v", err)
 	}


### PR DESCRIPTION
Previously, the entire `setupServer` was in a goroutine, meaning the server might not be setup in time before the rest of the test is run (i.e. requests are made to the server). This fixes it by simply limiting the goroutine to the actual `grpcServer.Serve` call.