### PR TITLE
[Hotfix] Fix missing undefined changed files variable

### DIFF
--- a/pkg/gcp/plugin_integration_test.go
+++ b/pkg/gcp/plugin_integration_test.go
@@ -13,7 +13,7 @@ Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
-limitations under the License.A
+limitations under the License.
 */
 
 package gcp


### PR DESCRIPTION
Accidentally had removed a line which defined what were the changed directories for integration testing in #45. This was the `$changed_paths`, which ended up being empty all the time.