### PR TITLE
[Azure] initialize fake server in `azure_sdk_handler_test` once instead of before every single test

### DIFF
--- a/pkg/azure_plugin/azure_sdk_handler_test.go
+++ b/pkg/azure_plugin/azure_sdk_handler_test.go
@@ -84,7 +84,7 @@ func (d *dummyToken) GetToken(ctx context.Context, optsWW policy.TokenRequestOpt
 func setup() {
 	urlToResponse = initializeReqRespMap()
 	setupFakeServer(urlToResponse)
-	azureSDKHandlerTest := &azureSDKHandler{}
+	azureSDKHandlerTest = &azureSDKHandler{}
 	azureSDKHandlerTest.resourceGroupName = rgName
 	azureSDKHandlerTest.subscriptionID = subID
 	err := azureSDKHandlerTest.InitializeClients(&dummyToken{})


### PR DESCRIPTION
Currently the fake server in `azure_sdk_handler_test` is initialized in every single test, and that would also mean getting a new port for each test which is unnecessary.

I'm using [sync.Once](https://pkg.go.dev/sync#Once.Do) instead of init() for initialization here.
`sync.Once` ensures that the initialization code is executed only once when it's invoked.

If we were to use init(), the code inside it would execute when the package is imported anywhere,
potentially causing the server to be initialized and start listening even if we're not running the tests.
By using sync.Once, we defer the initialization until it's actually needed during test execution.

Using sync.Once also handles concurrent tests. It guarantees that the initialization is performed only once,
regardless of how many test functions might be running concurrently.

**Note**
This is a temporary solution as it will not be needed when we refactor the code to use azure's fake server. Refer to[ this issue](https://github.com/NetSys/invisinets/issues/32)