### PR TITLE
Add build tags for client and CLI

### DIFF
--- a/internal/cli/inv/namespace/get/get_test.go
+++ b/internal/cli/inv/namespace/get/get_test.go
@@ -1,3 +1,5 @@
+//go:build unit
+
 /*
 Copyright 2023 The Invisinets Authors.
 

--- a/internal/cli/inv/namespace/set/set_test.go
+++ b/internal/cli/inv/namespace/set/set_test.go
@@ -1,3 +1,5 @@
+//go:build unit
+
 /*
 Copyright 2023 The Invisinets Authors.
 

--- a/internal/cli/inv/resource/create/create_test.go
+++ b/internal/cli/inv/resource/create/create_test.go
@@ -1,3 +1,5 @@
+//go:build unit
+
 /*
 Copyright 2023 The Invisinets Authors.
 

--- a/internal/cli/inv/rule/add/add_test.go
+++ b/internal/cli/inv/rule/add/add_test.go
@@ -1,3 +1,5 @@
+//go:build unit
+
 /*
 Copyright 2023 The Invisinets Authors.
 

--- a/internal/cli/inv/rule/delete/delete_test.go
+++ b/internal/cli/inv/rule/delete/delete_test.go
@@ -1,3 +1,5 @@
+//go:build unit
+
 /*
 Copyright 2023 The Invisinets Authors.
 

--- a/internal/cli/inv/rule/get/get_test.go
+++ b/internal/cli/inv/rule/get/get_test.go
@@ -1,3 +1,5 @@
+//go:build unit
+
 /*
 Copyright 2023 The Invisinets Authors.
 

--- a/internal/cli/inv/server/get/get_test.go
+++ b/internal/cli/inv/server/get/get_test.go
@@ -1,3 +1,5 @@
+//go:build unit
+
 /*
 Copyright 2023 The Invisinets Authors.
 

--- a/internal/cli/inv/server/set/set_test.go
+++ b/internal/cli/inv/server/set/set_test.go
@@ -1,3 +1,5 @@
+//go:build unit
+
 /*
 Copyright 2023 The Invisinets Authors.
 

--- a/internal/cli/inv/tag/delete/delete_test.go
+++ b/internal/cli/inv/tag/delete/delete_test.go
@@ -1,3 +1,5 @@
+//go:build unit
+
 /*
 Copyright 2023 The Invisinets Authors.
 

--- a/internal/cli/inv/tag/get/get_test.go
+++ b/internal/cli/inv/tag/get/get_test.go
@@ -1,3 +1,5 @@
+//go:build unit
+
 /*
 Copyright 2023 The Invisinets Authors.
 

--- a/internal/cli/inv/tag/set/set_test.go
+++ b/internal/cli/inv/tag/set/set_test.go
@@ -1,3 +1,5 @@
+//go:build unit
+
 /*
 Copyright 2023 The Invisinets Authors.
 

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -1,3 +1,5 @@
+//go:build unit
+
 /*
 Copyright 2023 The Invisinets Authors.
 


### PR DESCRIPTION
Tests were missing build tags causing these tests to run on integration and multicloud tests.