### PR TITLE
[GCP] Fix GitHub Actions authentication

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -221,10 +221,10 @@ jobs:
           path: ./dist/cache
           key: code-coverage-${{ github.sha }}-${{ github.run_number }}
       - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v1    
+        uses: google-github-actions/auth@v1
         if: matrix.target_arch == 'amd64' && matrix.target_os == 'linux'
         with:
-          workload_identity_provider: 'projects/112338121957/locations/global/workloadIdentityPools/github-actions-pool/providers/github-actions-provider'
+          workload_identity_provider: 'projects/112338121957/locations/global/workloadIdentityPools/github/providers/invisinets'
           service_account: 'invisinets-cicd@invisinets-cicd.iam.gserviceaccount.com'
       - name: 'Az CLI login'
         uses: azure/login@v1


### PR DESCRIPTION
Seems like something went wrong with GCP test permissions when we transferred ownership of the repo to a new org. GCP authentication was fine but running integration tests failed due to permission issues.

We may have to do this again after we find a new name for this project (#180). Keeping in mind #181 as well.