### PR TITLE
Install latest version of gopls

### DIFF
--- a/.devcontainer/postCreate.sh
+++ b/.devcontainer/postCreate.sh
@@ -10,6 +10,7 @@ sudo apt-get update
 sudo apt-get -y install redis
 
 set -ex
+go install golang.org/x/tools/gopls@latest
 go install gotest.tools/gotestsum@latest
 go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
 go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest

--- a/README.md
+++ b/README.md
@@ -14,21 +14,3 @@ See the [contributing guide](./CONTRIBUTING.md) for ways to contribute and instr
 
 This project has adopted the code of conduct defined by the Contributor Covenant to clarify expected behavior in our community.
 For more information, see the [Contributor Covenant Code of Conduct 2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).
-
-## Known Issues
-
-### `gopls` Linting Issue in Testing Files on Package Declartion Line
-You may see the following error from `gopls` in the `*_test.go` files.
-
-```
-This file is within module ".", which is not included in your workspace.
-To fix this problem, you can add a go.work file that uses this directory.
-See the documentation for more information on setting up your workspace:
-https://github.com/golang/tools/blob/master/gopls/doc/workspace.md.
-```
-
-This is due to a known issue within `gopls` (https://github.com/golang/go/issues/29202). You can work around this in VS Code by specifying the following in your `settings.json`.
-
-```
-"go.buildTags": "unit,integration"
-```


### PR DESCRIPTION
~~Previous versions of gopls used to have an issue with build tags (see deleted README section for more details). This was resolved in v0.15 according to https://github.com/golang/go/issues/29202 (we used to have v0.12 that got installed through gotestsum).~~ Nevermind turns out it's not actually fix.