### PR TITLE
Increase integration test timeout to 30m

### DIFF
--- a/build/test.mk
+++ b/build/test.mk
@@ -26,7 +26,7 @@ test: ## Runs unit tests in the internal and pkg folders
 
 .PHONY: integration-test
 integration-test:
-	$(GOTEST_CMD) -tags=integration -timeout 20m
+	$(GOTEST_CMD) -tags=integration -timeout 30m
 
 .PHONY: multicloud-test
 multicloud-test:


### PR DESCRIPTION
The integration tests timeout sporadically (e.g, https://github.com/invisinets/invisinets/actions/runs/8623645216/job/23637210437?pr=186), presumably due to resource deletion not happening fast enough.