### PR TITLE
[Bug Fix] Compile proto files before linting

### DIFF
--- a/build/build.mk
+++ b/build/build.mk
@@ -108,8 +108,6 @@ clean: ## Cleans output directory.
 
 # Due to https://github.com/golangci/golangci-lint/issues/580, we need to add --fix for windows
 .PHONY: lint 
-lint: compile-protoc run-lint
-
-run-lint: ## Runs golangci-lint
+lint: compile-protoc ## Runs golangci-lint
 	$(GOLANGCI_LINT) run --fix --timeout 5m
 


### PR DESCRIPTION
`make lint` would encounter an error locally if you had not built (the protobuf files were not there). I added compile-protoc to the lint target. I also removed some of the unnecessary prints from adding compile-protoc.