### PR TITLE
Add Codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @paraglider-project/maintainers


### PR DESCRIPTION
Defines the owners of each file so that we can require an owner approve each PR

Explanation: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners