### PR TITLE
Add "glide tag list" support

### DIFF
--- a/internal/cli/glide/rule/get/get.go
+++ b/internal/cli/glide/rule/get/get.go
@@ -62,7 +62,10 @@ func (e *executor) Execute(cmd *cobra.Command, args []string) error {
 	}
 
 	// Print the rules
-	fmt.Fprintf(e.writer, "Permit list for %s:\n%+v\n", args[1], permitList)
+	fmt.Fprintf(e.writer, "Permit list for %s:\n", args[1])
+	for i, rule := range permitList {
+		fmt.Fprintf(e.writer, "%d. %v\n", i, rule)
+	}
 
 	return nil
 }

--- a/internal/cli/glide/tag/list/list.go
+++ b/internal/cli/glide/tag/list/list.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2023 The Paraglider Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package list
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	common "github.com/paraglider-project/paraglider/internal/cli/common"
+	"github.com/paraglider-project/paraglider/internal/cli/glide/settings"
+	"github.com/paraglider-project/paraglider/pkg/client"
+	"github.com/spf13/cobra"
+)
+
+func NewCommand() (*cobra.Command, *executor) {
+	executor := &executor{writer: os.Stdout, cliSettings: settings.Global}
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List tags with their mappings",
+		Args:  cobra.NoArgs,
+		RunE:  executor.Execute,
+	}
+	return cmd, executor
+}
+
+type executor struct {
+	common.CommandExecutor
+	writer      io.Writer
+	cliSettings settings.CLISettings
+}
+
+func (e *executor) Execute(cmd *cobra.Command, args []string) error {
+
+	c := client.Client{ControllerAddress: e.cliSettings.ServerAddr}
+	tagMappings, err := c.ListTags()
+	if err != nil {
+		return err
+	}
+	// Print the tags
+	for i, tagMap := range tagMappings {
+		fmt.Fprintf(e.writer, "%d). %v\n", i, tagMap)
+	}
+	return nil
+}

--- a/internal/cli/glide/tag/list/list_test.go
+++ b/internal/cli/glide/tag/list/list_test.go
@@ -1,0 +1,46 @@
+//go:build unit
+
+/*
+Copyright 2023 The Paraglider Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package list
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/paraglider-project/paraglider/internal/cli/glide/settings"
+	fake "github.com/paraglider-project/paraglider/pkg/fake/orchestrator/rest"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTagListExecute(t *testing.T) {
+	server := &fake.FakeOrchestratorRESTServer{}
+	serverAddr := server.SetupFakeOrchestratorRESTServer()
+
+	cmd, executor := NewCommand()
+	executor.cliSettings = settings.CLISettings{ServerAddr: serverAddr}
+	var output bytes.Buffer
+	executor.writer = &output
+
+	// list the tags
+	err := executor.Execute(cmd, nil)
+
+	assert.Nil(t, err)
+	assert.Contains(t, output.String(), fake.ListFakeTagMapping()[0].TagName)
+	assert.Contains(t, output.String(), fake.ListFakeTagMapping()[1].TagName)
+	assert.Contains(t, output.String(), fake.ListFakeTagMapping()[2].TagName)
+}

--- a/internal/cli/glide/tag/tag.go
+++ b/internal/cli/glide/tag/tag.go
@@ -19,6 +19,7 @@ package tag
 import (
 	"github.com/paraglider-project/paraglider/internal/cli/glide/tag/delete"
 	"github.com/paraglider-project/paraglider/internal/cli/glide/tag/get"
+	"github.com/paraglider-project/paraglider/internal/cli/glide/tag/list"
 	"github.com/paraglider-project/paraglider/internal/cli/glide/tag/set"
 	"github.com/spf13/cobra"
 )
@@ -35,6 +36,8 @@ func NewCommand() *cobra.Command {
 	cmd.AddCommand(getCmd)
 	setCmd, _ := set.NewCommand()
 	cmd.AddCommand(setCmd)
+	listCmd, _ := list.NewCommand()
+	cmd.AddCommand(listCmd)
 
 	return cmd
 }

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -199,6 +199,24 @@ func (c *Client) ResolveTag(tag string) ([]*tagservicepb.TagMapping, error) {
 	return tagMappings.Mappings, nil
 }
 
+// ListTags lists all tags and their mappings
+func (c *Client) ListTags() ([]*tagservicepb.TagMapping, error) {
+	path := orchestrator.GetFormatterString(orchestrator.ListTagURL)
+
+	respBytes, err := c.sendRequest(path, http.MethodGet, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	tagMappings := tagservicepb.TagMappingList{}
+	err = json.Unmarshal(respBytes, &tagMappings)
+	if err != nil {
+		return nil, err
+	}
+
+	return tagMappings.Mappings, nil
+}
+
 // Set a tag as a member of a group or as a mapping to a URI/IP
 func (c *Client) SetTag(tag string, tagMapping *tagservicepb.TagMapping) error {
 	path := fmt.Sprintf(orchestrator.GetFormatterString(orchestrator.SetTagURL), tag)

--- a/pkg/fake/orchestrator/rest/fake_orchestrator_rest_server.go
+++ b/pkg/fake/orchestrator/rest/fake_orchestrator_rest_server.go
@@ -160,6 +160,7 @@ func (s *FakeOrchestratorRESTServer) SetupFakeOrchestratorRESTServer() string {
 			http.Error(w, fmt.Sprintf("unsupported request: %s %s", r.Method, path), http.StatusBadRequest)
 			return
 		}
+
 		switch {
 		// List Namespaces
 		case urlMatches(path, orchestrator.ListNamespacesURL) && r.Method == http.MethodGet:

--- a/pkg/fake/orchestrator/rest/fake_orchestrator_rest_server.go
+++ b/pkg/fake/orchestrator/rest/fake_orchestrator_rest_server.go
@@ -110,6 +110,25 @@ func GetFakeTagMappingLeafTags(tagName string) []*tagservicepb.TagMapping {
 	}
 }
 
+func ListFakeTagMapping() []*tagservicepb.TagMapping {
+	return []*tagservicepb.TagMapping{
+		{
+			TagName:   "tag1",
+			ChildTags: []string{"member1", "member2"},
+		},
+		{
+			TagName: "member1",
+			Uri:     proto.String("resource/uri"),
+			Ip:      proto.String("1.1.1.1"),
+		},
+		{
+			TagName: "member2",
+			Uri:     proto.String("resource/uri"),
+			Ip:      proto.String("2.2.2.2"),
+		},
+	}
+}
+
 func GetFakeNamespaces() map[string][]config.CloudDeployment {
 	return map[string][]config.CloudDeployment{
 		"namespace1": {
@@ -141,7 +160,6 @@ func (s *FakeOrchestratorRESTServer) SetupFakeOrchestratorRESTServer() string {
 			http.Error(w, fmt.Sprintf("unsupported request: %s %s", r.Method, path), http.StatusBadRequest)
 			return
 		}
-
 		switch {
 		// List Namespaces
 		case urlMatches(path, orchestrator.ListNamespacesURL) && r.Method == http.MethodGet:
@@ -224,6 +242,16 @@ func (s *FakeOrchestratorRESTServer) SetupFakeOrchestratorRESTServer() string {
 				return
 			}
 			return
+		// Tag List
+		case urlMatches(path, orchestrator.ListTagURL):
+			if r.Method == http.MethodGet {
+				err := s.writeResponse(w, tagservicepb.TagMappingList{Mappings: ListFakeTagMapping()})
+				if err != nil {
+					http.Error(w, fmt.Sprintf("error writing response: %s", err), http.StatusInternalServerError)
+					return
+				}
+				return
+			}
 		// Tag Get/Delete
 		case urlMatches(path, orchestrator.GetTagURL):
 			if r.Method == http.MethodDelete {

--- a/pkg/tag_service/tag_service.go
+++ b/pkg/tag_service/tag_service.go
@@ -251,7 +251,7 @@ func (s *tagServiceServer) ListTags(c context.Context, e *emptypb.Empty) (*tagse
 		tagMapping, err := s.GetTag(c, &tagservicepb.Tag{TagName: tag})
 		if err != nil {
 			// Ignore errors
-			utils.Log.Println("Failed to get tag mapping of %s: %v", tag, err)
+			utils.Log.Printf("Failed to get tag mapping of %s: %v\n", tag, err)
 			continue
 		}
 		resolvedTagList = append(resolvedTagList, tagMapping)

--- a/pkg/tag_service/tag_service.go
+++ b/pkg/tag_service/tag_service.go
@@ -29,6 +29,7 @@ import (
 	redis "github.com/redis/go-redis/v9"
 
 	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/emptypb"
 )
 
 type tagServiceServer struct {
@@ -192,10 +193,10 @@ func (s *tagServiceServer) GetTag(c context.Context, tag *tagservicepb.Tag) (*ta
 func (s *tagServiceServer) _resolveTags(c context.Context, tags []string, resolvedTags []*tagservicepb.TagMapping) ([]*tagservicepb.TagMapping, error) {
 	for _, tag := range tags {
 		// If the tag is an IP, it is already resolved
-		isIp := isIpAddrOrCidr(tag)
-		if isIp {
-			ip_tag := &tagservicepb.TagMapping{TagName: "", Uri: nil, Ip: &tag}
-			resolvedTags = append(resolvedTags, ip_tag)
+		isIP := isIpAddrOrCidr(tag)
+		if isIP {
+			ipTag := &tagservicepb.TagMapping{TagName: "", Uri: nil, Ip: &tag}
+			resolvedTags = append(resolvedTags, ipTag)
 		} else {
 			// Get the tag record type since may be hash (if name value) or set (if parent tag)
 			valType, err := s.client.Type(c, tag).Result()
@@ -239,6 +240,22 @@ func (s *tagServiceServer) ResolveTag(c context.Context, tag *tagservicepb.Tag) 
 	}
 
 	return &tagservicepb.TagMappingList{Mappings: resolvedTags}, nil
+}
+
+// Resolve a list of tags into all base-level IPs
+func (s *tagServiceServer) ListTags(c context.Context, e *emptypb.Empty) (*tagservicepb.TagMappingList, error) {
+	var resolvedTagList []*tagservicepb.TagMapping
+	tags := s.client.Keys(c, "*").Val()
+	for _, tag := range tags {
+		tagMapping, err := s.GetTag(c, &tagservicepb.Tag{TagName: tag})
+		if err != nil {
+			// Ignore errors
+			continue
+		}
+		resolvedTagList = append(resolvedTagList, tagMapping)
+	}
+
+	return &tagservicepb.TagMappingList{Mappings: resolvedTagList}, nil
 }
 
 // Delete a member of a tag

--- a/pkg/tag_service/tag_service.go
+++ b/pkg/tag_service/tag_service.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 
 	tagservicepb "github.com/paraglider-project/paraglider/pkg/tag_service/tagservicepb"
+	utils "github.com/paraglider-project/paraglider/pkg/utils"
 	redis "github.com/redis/go-redis/v9"
 
 	"google.golang.org/grpc"
@@ -250,6 +251,7 @@ func (s *tagServiceServer) ListTags(c context.Context, e *emptypb.Empty) (*tagse
 		tagMapping, err := s.GetTag(c, &tagservicepb.Tag{TagName: tag})
 		if err != nil {
 			// Ignore errors
+			utils.Log.Println("Failed to get tag mapping of %s: %v", tag, err)
 			continue
 		}
 		resolvedTagList = append(resolvedTagList, tagMapping)

--- a/pkg/tag_service/tagservicepb/tagservice.proto
+++ b/pkg/tag_service/tagservicepb/tagservice.proto
@@ -16,6 +16,7 @@ limitations under the License.
 
 syntax = "proto3";
 package tagservicepb;
+import "google/protobuf/empty.proto";
 
 option go_package="github.com/paraglider-project/paraglider/pkg/tag_service/tagservicepb";
 
@@ -23,6 +24,7 @@ service TagService {
     rpc SetTag(TagMapping) returns (BasicResponse) {}
     rpc GetTag(Tag) returns (TagMapping) {}
     rpc ResolveTag(Tag) returns (TagMappingList) {}
+    rpc ListTags(google.protobuf.Empty) returns (TagMappingList) {}
     rpc DeleteTagMember(TagMapping) returns (BasicResponse) {}
     rpc DeleteTag(Tag) returns (BasicResponse) {}
     rpc Subscribe(Subscription) returns (BasicResponse) {}


### PR DESCRIPTION
Returns tag mappings 
Example : 

```
$ glide tag list
0). tag_name:"ibmvm1"  child_tags:"default.ibm.vm-1"
1). tag_name:"default.ibm.vm-1"  uri:"/resourcegroup/2d6e51c90e42424b8757d5a481e2450e/zone/us-east-1/instance/0757_7764d121-6465-4c70-a791-6fce774dd2fb"  ip:"10.0.0.9"
2). tag_name:"prod"  child_tags:"ibmvm1"
3). tag_name:"ibmvm2"  child_tags:"default.ibm.vm-2"
4). tag_name:"default.ibm.vm-2"  uri:"/resourcegroup/2d6e51c90e42424b8757d5a481e2450e/zone/us-east-1/instance/0757_006cd7db-1795-4b68-a380-1a6f023b8f65"  ip:"10.0.0.10"
```
