### PR TITLE
Revert title of index page to Welcome to Paraglider and remove logo

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,14 +1,5 @@
-|
-
-.. image:: ./_static/paraglider-color-darkmode.png
-    :width: 300
-    :alt: Paraglider Logo
-    :class: no-scaled-link, only-dark
-
-.. image:: ./_static/paraglider-color-lightmode.png
-   :width: 300
-   :alt: Paraglider Logo
-   :class: no-scaled-link, only-light
+Welcome to Paraglider!
+======================================
 
 .. raw:: html
 


### PR DESCRIPTION
Otherwise there are two logos side by side on index.