### PR TITLE
Fix build tag typo

### DIFF
--- a/pkg/azure/naming_test.go
+++ b/pkg/azure/naming_test.go
@@ -1,4 +1,5 @@
-// go:build unit
+//go:build unit
+
 /*
 Copyright 2023 The Paraglider Authors.
 

--- a/pkg/azure/resources_test.go
+++ b/pkg/azure/resources_test.go
@@ -1,4 +1,5 @@
-// go:build unit
+//go:build unit
+
 /*
 Copyright 2023 The Paraglider Authors.
 

--- a/pkg/gcp/resources_test.go
+++ b/pkg/gcp/resources_test.go
@@ -1,4 +1,5 @@
-// go:build unit
+//go:build unit
+
 /*
 Copyright 2023 The Paraglider Authors.
 


### PR DESCRIPTION
These tests were still running for integration and multicloud because there wasn't a space.