### PR TITLE
[Infra] Specify permissions for docs workflows

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -15,8 +15,8 @@ on:
       - features/*
       - release/*
     paths:
-      docs/**
-      .github/workflows/docs.yaml
+      - docs/**
+      - .github/workflows/docs.yaml
 
 env:
   # Python

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -16,6 +16,7 @@ on:
       - release/*
     paths:
       docs/**
+      .github/workflows/docs.yaml
 
 env:
   # Python
@@ -24,6 +25,9 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Check out repo
         uses: actions/checkout@v3


### PR DESCRIPTION
Dependabot PRs need these permissions specified (https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#changing-github_token-permissions).