### PR TITLE
[Infra] Group dependabot updates by package ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,7 +12,7 @@ updates:
     groups:
       all:
         patterns:
-          - ".*"
+          - "*"
         update-types:
           - "minor"
           - "patch"
@@ -23,7 +23,7 @@ updates:
     groups:
       all:
         patterns:
-          - ".*"
+          - "*"
         update-types:
           - "minor"
           - "patch"
@@ -34,7 +34,7 @@ updates:
     groups:
       all:
         patterns:
-          - ".*"
+          - "*"
         update-types:
           - "minor"
           - "patch"
@@ -45,7 +45,7 @@ updates:
     groups:
       all:
         patterns:
-          - ".*"
+          - "*"
         update-types:
           - "minor"
           - "patch"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,15 +9,43 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "monthly"
+    groups:
+      all:
+        patterns:
+          - ".*"
+        update-types:
+          - "minor"
+          - "patch"
   - package-ecosystem: "devcontainers" 
     directory: "/" 
     schedule:
       interval: "monthly"
+    groups:
+      all:
+        patterns:
+          - ".*"
+        update-types:
+          - "minor"
+          - "patch"
   - package-ecosystem: "pip" 
     directory: "/" 
     schedule:
       interval: "monthly"
+    groups:
+      all:
+        patterns:
+          - ".*"
+        update-types:
+          - "minor"
+          - "patch"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "monthly"
+    groups:
+      all:
+        patterns:
+          - ".*"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
This will consolidate all Go updates into one PR, Python updates into one PR, etc. This will help declutter our PR page as well as reduce having to handle `go.sum` merge conflicts.

I configured it to only group for minor and patch version updates. Major version updates will still be created in their own PR.