### PR TITLE
Add support to build docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM alpine:3.19
+
+# Populated during the build process, for example, with 'darwin_arm64' or 'linux_amd64'.
+ARG TARGETOS
+ARG TARGETARCH
+
+ENV TARGET_DIR=${TARGETOS}_${TARGETARCH}
+
+# Copy binary
+RUN mkdir -p /usr/local/bin
+COPY ./dist/$TARGET_DIR/release/glide /usr/local/bin/glide
+COPY ./dist/$TARGET_DIR/release/glided /usr/local/bin/glided
+
+ENTRYPOINT ["/usr/local/bin/glided", "startup" "config.yaml"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,4 @@ RUN mkdir -p /usr/local/bin
 COPY ./dist/$TARGET_DIR/release/glide /usr/local/bin/glide
 COPY ./dist/$TARGET_DIR/release/glided /usr/local/bin/glided
 
-ENTRYPOINT ["/usr/local/bin/glided", "startup" "config.yaml"]
+ENTRYPOINT ["/usr/local/bin/glided", "startup", "config.yaml"]

--- a/build/build.mk
+++ b/build/build.mk
@@ -1,5 +1,8 @@
 BASE_PACKAGE_NAME := github.com/paraglider-project/paraglider
 OUT_DIR := ./dist
+IMAGE_VERSION ?= latest
+IMAGE_ORG ?= paraglider-project
+IMAGE_BASE ?= ghcr.io/$(IMAGE_ORG)
 
 GOOS ?= $(shell go env GOOS)
 GOARCH ?= $(shell go env GOARCH)
@@ -100,6 +103,9 @@ BINARY_TARGETS:=$(foreach ITEM,$(BINARIES),build-$(ITEM))
 
 .PHONY: build-binaries
 build-binaries: $(BINARY_TARGETS) ## Builds all go binaries.
+
+push-image: build-binaries
+	docker buildx build --platform $(GOOS)/$(GOARCH) --progress=plain --rm --tag $(IMAGE_BASE)/paraglider:$(IMAGE_VERSION) --push -f ./Dockerfile .
 
 .PHONY: clean
 clean: ## Cleans output directory.


### PR DESCRIPTION
Docker images gets published in : 
https://github.com/orgs/paraglider-project/packages/container/package/paraglider

Next step would be add releases

Note: For now, I added config.yaml (as config argument for glided startup) which can be provided when executing the docker. 
`docker run -v /path/to/your/config.yaml:/config.yaml ghcr.io/paraglider-project/paraglider:latest`

However, we should see if we can simplify this further.