### PR TITLE
Add support for CLI namespace set.

### DIFF
--- a/internal/cli/glide/namespace/get/get.go
+++ b/internal/cli/glide/namespace/get/get.go
@@ -23,6 +23,7 @@ import (
 
 	common "github.com/paraglider-project/paraglider/internal/cli/common"
 	"github.com/paraglider-project/paraglider/internal/cli/glide/settings"
+	"github.com/paraglider-project/paraglider/pkg/client"
 	"github.com/spf13/cobra"
 )
 
@@ -53,7 +54,14 @@ func (e *executor) Validate(cmd *cobra.Command, args []string) error {
 }
 
 func (e *executor) Execute(cmd *cobra.Command, args []string) error {
-	fmt.Fprintf(e.writer, "Active namespace: %s\n", e.cliSettings.ActiveNamespace)
+	c := client.Client{ControllerAddress: e.cliSettings.ServerAddr}
+	namespace, err := c.GetNamespace()
+
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(e.writer, "Active namespace: %s\n", &namespace)
 
 	return nil
 }

--- a/internal/cli/glide/namespace/get/get.go
+++ b/internal/cli/glide/namespace/get/get.go
@@ -61,7 +61,7 @@ func (e *executor) Execute(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	fmt.Fprintf(e.writer, "Active namespace: %s\n", &namespace)
+	fmt.Fprintf(e.writer, "Active namespace: %s\n", namespace)
 
 	return nil
 }

--- a/internal/cli/glide/namespace/get/get_test.go
+++ b/internal/cli/glide/namespace/get/get_test.go
@@ -34,10 +34,10 @@ func TestNamespaceGetExecute(t *testing.T) {
 	cmd, executor := NewCommand()
 	var output bytes.Buffer
 	executor.writer = &output
-	executor.cliSettings = settings.CLISettings{ActiveNamespace: "default", ServerAddr: serverAddr}
+	executor.cliSettings = settings.CLISettings{ServerAddr: serverAddr}
 
 	err := executor.Execute(cmd, []string{})
 
 	assert.Nil(t, err)
-	assert.Contains(t, output.String(), executor.cliSettings.ActiveNamespace)
+	assert.Contains(t, output.String(), executor.cliSettings.ServerAddr)
 }

--- a/internal/cli/glide/namespace/set/set.go
+++ b/internal/cli/glide/namespace/set/set.go
@@ -67,7 +67,14 @@ func (e *executor) Validate(cmd *cobra.Command, args []string) error {
 }
 
 func (e *executor) Execute(cmd *cobra.Command, args []string) error {
-	e.cliSettings.ActiveNamespace = args[0]
+	c := client.Client{ControllerAddress: e.cliSettings.ServerAddr}
+	err := c.SetNamespace(args[0])
+
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(e.writer, "Namespace: %v", args[0])
 
 	return nil
 }

--- a/internal/cli/glide/namespace/set/set.go
+++ b/internal/cli/glide/namespace/set/set.go
@@ -74,7 +74,13 @@ func (e *executor) Execute(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	fmt.Fprintf(e.writer, "Namespace: %v", args[0])
+	namespace, err := c.GetNamespace()
+
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(e.writer, "Active namespace: %s\n", namespace)
 
 	return nil
 }

--- a/internal/cli/glide/namespace/set/set.go
+++ b/internal/cli/glide/namespace/set/set.go
@@ -80,7 +80,7 @@ func (e *executor) Execute(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	fmt.Fprintf(e.writer, "Active namespace: %s\n", namespace)
+	fmt.Fprintf(e.writer, "Active namespace set to: %s\n", namespace)
 
 	return nil
 }

--- a/internal/cli/glide/resource/create/create.go
+++ b/internal/cli/glide/resource/create/create.go
@@ -79,7 +79,7 @@ func (e *executor) Execute(cmd *cobra.Command, args []string) error {
 
 	namespace, err := c.GetNamespace()
 	if err != nil {
-		fmt.Fprintf(e.writer, "Failed to get namespace: %v\n", err)
+		fmt.Fprintf(e.writer, "Failed to get active namespace: %v\n", err)
 		return err
 	}
 

--- a/internal/cli/glide/resource/create/create.go
+++ b/internal/cli/glide/resource/create/create.go
@@ -76,7 +76,14 @@ func (e *executor) Execute(cmd *cobra.Command, args []string) error {
 	resource := &paragliderpb.ResourceDescriptionString{Description: string(e.description)}
 
 	c := client.Client{ControllerAddress: e.cliSettings.ServerAddr}
-	resourceInfo, err := c.CreateResource(e.cliSettings.ActiveNamespace, args[0], args[1], resource)
+
+	namespace, err := c.GetNamespace()
+	if err != nil {
+		fmt.Fprintf(e.writer, "Failed to get namespace: %v\n", err)
+		return err
+	}
+
+	resourceInfo, err := c.CreateResource(namespace, args[0], args[1], resource)
 
 	if err != nil {
 		fmt.Fprintf(e.writer, "Failed to create resource: %v\n", err)

--- a/internal/cli/glide/resource/create/create_test.go
+++ b/internal/cli/glide/resource/create/create_test.go
@@ -43,7 +43,7 @@ func TestResourceCreateExecute(t *testing.T) {
 	serverAddr := server.SetupFakeOrchestratorRESTServer()
 
 	cmd, executor := NewCommand()
-	executor.cliSettings = settings.CLISettings{ServerAddr: serverAddr, ActiveNamespace: fake.Namespace}
+	executor.cliSettings = settings.CLISettings{ServerAddr: serverAddr}
 
 	var output bytes.Buffer
 	executor.writer = &output

--- a/internal/cli/glide/rule/add/add.go
+++ b/internal/cli/glide/rule/add/add.go
@@ -107,7 +107,14 @@ func (e *executor) Execute(cmd *cobra.Command, args []string) error {
 	}
 
 	c := client.Client{ControllerAddress: e.cliSettings.ServerAddr}
-	err := c.AddPermitListRules(e.cliSettings.ActiveNamespace, args[0], args[1], rules)
+
+	namespace, err := c.GetNamespace()
+
+	if err != nil {
+		return err
+	}
+
+	err = c.AddPermitListRules(namespace, args[0], args[1], rules)
 
 	return err
 }

--- a/internal/cli/glide/rule/add/add_test.go
+++ b/internal/cli/glide/rule/add/add_test.go
@@ -52,7 +52,7 @@ func TestRuleAddExecute(t *testing.T) {
 	serverAddr := server.SetupFakeOrchestratorRESTServer()
 
 	cmd, executor := NewCommand()
-	executor.cliSettings = settings.CLISettings{ServerAddr: serverAddr, ActiveNamespace: fake.Namespace}
+	executor.cliSettings = settings.CLISettings{ServerAddr: serverAddr}
 	executor.pingTag = "pingTag"
 	executor.sshTag = "sshTag"
 

--- a/internal/cli/glide/rule/delete/delete.go
+++ b/internal/cli/glide/rule/delete/delete.go
@@ -62,6 +62,13 @@ func (e *executor) Validate(cmd *cobra.Command, args []string) error {
 func (e *executor) Execute(cmd *cobra.Command, args []string) error {
 	// Send the rules to the server
 	c := client.Client{ControllerAddress: e.cliSettings.ServerAddr}
-	err := c.DeletePermitListRules(e.cliSettings.ActiveNamespace, args[0], args[1], e.ruleNames)
+
+	namespace, err := c.GetNamespace()
+
+	if err != nil {
+		return err
+	}
+
+	err = c.DeletePermitListRules(namespace, args[0], args[1], e.ruleNames)
 	return err
 }

--- a/internal/cli/glide/rule/delete/delete_test.go
+++ b/internal/cli/glide/rule/delete/delete_test.go
@@ -46,7 +46,7 @@ func TestRuleDeleteExecute(t *testing.T) {
 	serverAddr := server.SetupFakeOrchestratorRESTServer()
 
 	cmd, executor := NewCommand()
-	executor.cliSettings = settings.CLISettings{ServerAddr: serverAddr, ActiveNamespace: fake.Namespace}
+	executor.cliSettings = settings.CLISettings{ServerAddr: serverAddr}
 	executor.ruleNames = []string{"name1", "name2"}
 
 	args := []string{fake.CloudName, "uri"}

--- a/internal/cli/glide/rule/get/get.go
+++ b/internal/cli/glide/rule/get/get.go
@@ -56,7 +56,14 @@ func (e *executor) Validate(cmd *cobra.Command, args []string) error {
 func (e *executor) Execute(cmd *cobra.Command, args []string) error {
 	// Get the rules from the server
 	c := client.Client{ControllerAddress: e.cliSettings.ServerAddr}
-	permitList, err := c.GetPermitList(e.cliSettings.ActiveNamespace, args[0], args[1])
+
+	namespace, err := c.GetNamespace()
+
+	if err != nil {
+		return err
+	}
+
+	permitList, err := c.GetPermitList(namespace, args[0], args[1])
 	if err != nil {
 		return err
 	}

--- a/internal/cli/glide/rule/get/get_test.go
+++ b/internal/cli/glide/rule/get/get_test.go
@@ -32,7 +32,7 @@ func TestRuleGetExecute(t *testing.T) {
 	serverAddr := server.SetupFakeOrchestratorRESTServer()
 
 	cmd, executor := NewCommand()
-	executor.cliSettings = settings.CLISettings{ServerAddr: serverAddr, ActiveNamespace: fake.Namespace}
+	executor.cliSettings = settings.CLISettings{ServerAddr: serverAddr}
 	var output bytes.Buffer
 	executor.writer = &output
 

--- a/internal/cli/glide/settings/settings.go
+++ b/internal/cli/glide/settings/settings.go
@@ -17,10 +17,9 @@ limitations under the License.
 package settings
 
 var (
-	Global CLISettings = CLISettings{ServerAddr: "http://localhost:8080", ActiveNamespace: "default"}
+	Global CLISettings = CLISettings{ServerAddr: "http://localhost:8080"}
 )
 
 type CLISettings struct {
-	ServerAddr      string
-	ActiveNamespace string
+	ServerAddr string
 }

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -270,6 +270,21 @@ func (c *Client) SetNamespace(namespace string) error {
 	return nil
 }
 
+// Get namespace
+func (c *Client) GetNamespace() (string, error) {
+	result, err := c.sendRequest(orchestrator.GetNamespaceURL, http.MethodGet, nil)
+	if err != nil {
+		return "", err
+	}
+
+	var namespace string
+	err = json.Unmarshal(result, &namespace)
+	if err != nil {
+		return "", err
+	}
+	return namespace, nil
+}
+
 // List all configured namespaces
 func (c *Client) ListNamespaces() (map[string][]config.CloudDeployment, error) {
 	result, err := c.sendRequest(orchestrator.ListNamespacesURL, http.MethodGet, nil)

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -258,6 +258,18 @@ func (c *Client) DeleteTagMembers(tag string, member string) error {
 	return nil
 }
 
+// Set namespace
+func (c *Client) SetNamespace(namespace string) error {
+	path := fmt.Sprintf(orchestrator.GetFormatterString(orchestrator.SetNamespaceURL), namespace)
+
+	_, err := c.sendRequest(path, http.MethodPost, nil)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // List all configured namespaces
 func (c *Client) ListNamespaces() (map[string][]config.CloudDeployment, error) {
 	result, err := c.sendRequest(orchestrator.ListNamespacesURL, http.MethodGet, nil)

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -60,6 +60,7 @@ const (
 	DeleteTagURL             string = "/tags/:tag"
 	DeleteTagMemberURL       string = "/tags/:tag/members/:member"
 	ListNamespacesURL        string = "/namespaces"
+	SetNamespaceURL          string = "/namespaces/:namespace"
 )
 
 type Warning struct {
@@ -1196,6 +1197,16 @@ func (s *ControllerServer) deleteTagMember(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{})
 }
 
+// Set namespace
+func (s *ControllerServer) setNamespace(c *gin.Context) {
+	namespace := c.Param("namespace")
+	s.namespace = namespace
+
+	utils.Log.Printf("setNamespace: %s", namespace)
+
+	c.JSON(http.StatusOK, namespace)
+}
+
 // List all configured namespaces
 func (s *ControllerServer) listNamespaces(c *gin.Context) {
 	c.JSON(http.StatusOK, s.config.Namespaces)
@@ -1324,6 +1335,7 @@ func Setup(cfg config.Config, background bool) {
 	router.DELETE(DeleteTagURL, server.deleteTag)
 	router.DELETE(DeleteTagMemberURL, server.deleteTagMember)
 	router.GET(ListNamespacesURL, server.listNamespaces)
+	router.POST(SetNamespaceURL, server.setNamespace)
 
 	// Run server
 	if background {

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -61,8 +61,7 @@ const (
 	DeleteTagMemberURL       string = "/tags/:tag/members/:member"
 	ListNamespacesURL        string = "/namespaces"
 	SetNamespaceURL          string = "/namespaces/:namespace"
-	// TODO: use better path
-	GetNamespaceURL string = "/namespace"
+	GetNamespaceURL          string = "/namespace"
 )
 
 type Warning struct {
@@ -1204,15 +1203,11 @@ func (s *ControllerServer) setNamespace(c *gin.Context) {
 	namespace := c.Param("namespace")
 	s.namespace = namespace
 
-	utils.Log.Printf("setNamespace: %s", namespace)
-
 	c.JSON(http.StatusOK, namespace)
 }
 
 // Get namespace
 func (s *ControllerServer) getNamespace(c *gin.Context) {
-
-	utils.Log.Printf("getNamespace: %s", s.namespace)
 
 	c.JSON(http.StatusOK, s.namespace)
 }

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -61,6 +61,8 @@ const (
 	DeleteTagMemberURL       string = "/tags/:tag/members/:member"
 	ListNamespacesURL        string = "/namespaces"
 	SetNamespaceURL          string = "/namespaces/:namespace"
+	// TODO: use better path
+	GetNamespaceURL string = "/namespace"
 )
 
 type Warning struct {
@@ -1207,6 +1209,14 @@ func (s *ControllerServer) setNamespace(c *gin.Context) {
 	c.JSON(http.StatusOK, namespace)
 }
 
+// Get namespace
+func (s *ControllerServer) getNamespace(c *gin.Context) {
+
+	utils.Log.Printf("getNamespace: %s", s.namespace)
+
+	c.JSON(http.StatusOK, s.namespace)
+}
+
 // List all configured namespaces
 func (s *ControllerServer) listNamespaces(c *gin.Context) {
 	c.JSON(http.StatusOK, s.config.Namespaces)
@@ -1336,6 +1346,7 @@ func Setup(cfg config.Config, background bool) {
 	router.DELETE(DeleteTagMemberURL, server.deleteTagMember)
 	router.GET(ListNamespacesURL, server.listNamespaces)
 	router.POST(SetNamespaceURL, server.setNamespace)
+	router.GET(GetNamespaceURL, server.getNamespace)
 
 	// Run server
 	if background {


### PR DESCRIPTION
Currently, Paraglider namespaces are not being supported from the CLI (only 'default' can be used).

It seems that `glide namespace set` has no effect since it sets a local variable in the client itself which is stateless.

In this PR, `glide namespace set` updates the active namespace in the controller side and other CLIs query first the namespace from there and use it to create the resource and rule.

It seems to work well in my local environment. I can create resources in multiple namespaces which results in the creation of multiple VPCs.

The PR is not fully completed: few tests and lint fails.

Can you please review it?

Thanks.