### PR TITLE
[Infra] Use package ecosystem name in dependabot group name

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,7 @@ updates:
     schedule:
       interval: "monthly"
     groups:
-      all:
+      gomod-all:
         patterns:
           - "*"
         update-types:
@@ -21,7 +21,7 @@ updates:
     schedule:
       interval: "monthly"
     groups:
-      all:
+      devcontainers-all:
         patterns:
           - "*"
         update-types:
@@ -32,7 +32,7 @@ updates:
     schedule:
       interval: "monthly"
     groups:
-      all:
+      pip-all:
         patterns:
           - "*"
         update-types:
@@ -43,7 +43,7 @@ updates:
     schedule:
       interval: "monthly"
     groups:
-      all:
+      github-actions-all:
         patterns:
           - "*"
         update-types:


### PR DESCRIPTION
Better PR names for dependabot PRs when using groups

Before
```
Bump the all group across 1 directory with 9 updates
```

After
```
Bump the gomod-all group across 1 directory with 9 updates
```