### PR TITLE
[Infra] Fix rate limit when using arduino/protoc

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -98,6 +98,8 @@ jobs:
         run: python ./.github/scripts/get_release_version.py
       - name: Get protoc
         uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Get protoc-gen-go
         run: |
           GOOS=$(go env GOHOSTOS) GOARCH=$(go env GOHOSTARCH) go install google.golang.org/protobuf/cmd/protoc-gen-go@latest


### PR DESCRIPTION
We've been hitting some rate limits for arduino/setup-protoc step (example: https://github.com/paraglider-project/paraglider/actions/runs/9361388806/job/25768296034?pr=357). Specifying the token will give us access to higher limits.