### PR TITLE
Moving general functions from pkg/ibm to pkg/utils

### DIFF
--- a/pkg/ibm_plugin/sdk/security_group.go
+++ b/pkg/ibm_plugin/sdk/security_group.go
@@ -420,7 +420,7 @@ func IsRemoteInCIDR(remote, cidr string) (bool, error) {
 		}
 		return netCidr.Contains(netIP), nil
 	}
-	return IsCIDRSubset(remote, cidr)
+	return utils.IsCIDRSubset(remote, cidr)
 }
 
 // GetRemoteType returns IBM specific keyword returned by vpc1 SDK,

--- a/pkg/ibm_plugin/sdk/subnets.go
+++ b/pkg/ibm_plugin/sdk/subnets.go
@@ -134,7 +134,7 @@ func (c *CloudClient) DoSubnetsInVPCOverlapCIDR(vpcID string,
 	}
 
 	for _, subnet := range subnets {
-		doesOverlap, err := DoCIDROverlap(*subnet.Ipv4CIDRBlock, CIDR)
+		doesOverlap, err := utils.DoCIDROverlap(*subnet.Ipv4CIDRBlock, CIDR)
 		if err != nil {
 			return true, err
 		}

--- a/pkg/ibm_plugin/sdk/utils.go
+++ b/pkg/ibm_plugin/sdk/utils.go
@@ -18,8 +18,6 @@ package ibm
 
 import (
 	"fmt"
-	"net"
-	"net/netip"
 	"os"
 	"strings"
 
@@ -91,46 +89,6 @@ func GenerateResourceName(name string) string {
 // IsParagliderResource returns if a given resource (e.g. permit list) belongs to paraglider
 func IsParagliderResource(name string) bool {
 	return strings.HasPrefix(name, ParagliderResourcePrefix)
-}
-
-// DoCIDROverlap returns false if cidr blocks don't share a single ip,
-// i.e. they don't overlap.
-func DoCIDROverlap(cidr1, cidr2 string) (bool, error) {
-	netCIDR1, err := netip.ParsePrefix(cidr1)
-	if err != nil {
-		return true, err
-	}
-	netCIDR2, err := netip.ParsePrefix(cidr2)
-	if err != nil {
-		return true, err
-	}
-	if netCIDR2.Overlaps(netCIDR1) {
-		return true, nil
-	}
-
-	return false, nil
-}
-
-// IsCIDRSubset returns true if cidr1 is a subset (including equal) to cidr2
-func IsCIDRSubset(cidr1, cidr2 string) (bool, error) {
-	firstIP1, netCidr1, err := net.ParseCIDR(cidr1)
-	// ParseCIDR() example from Docs: for CIDR="192.0.2.1/24"
-	// IP=192.0.2.1 and network mask 192.0.2.0/24 are returned
-	if err != nil {
-		return false, err
-	}
-
-	_, netCidr2, err := net.ParseCIDR(cidr2)
-	if err != nil {
-		return false, err
-	}
-	// number of significant bits in the subnet mask
-	maskSize1, _ := netCidr1.Mask.Size()
-	maskSize2, _ := netCidr2.Mask.Size()
-	// cidr1 is a subset of cidr2 if the first user ip of cidr1 within cidr2
-	// and the network mask of cidr1 is no smaller than that of cidr2, as
-	// fewer bits are left for user address space.
-	return netCidr2.Contains(firstIP1) && maskSize1 >= maskSize2, nil
 }
 
 // TODO cleanup k8s clusters

--- a/pkg/multicloud/multicloud_test.go
+++ b/pkg/multicloud/multicloud_test.go
@@ -383,7 +383,7 @@ func TestMulticloudIBMAzure(t *testing.T) {
 	require.NoError(t, err)
 	// removes all of paraglider's deployments on IBM when test ends (if INVISINETS_TEST_PERSIST=1)
 	defer func() {
-		err := ibmSdk.TerminateParagliderDeployments(resourceGroupID, region)
+		err := ibmSdk.TerminateParagliderDeployments(region)
 		require.NoError(t, err)
 	}()
 

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package log
+package utils
 
 import (
 	"fmt"

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -19,6 +19,7 @@ package log
 import (
 	"fmt"
 	"log"
+	"net"
 	"net/netip"
 	"os"
 	"strings"
@@ -172,3 +173,44 @@ func GetNumVpnConnections(cloud1, cloud2 string) int {
 	}
 	return 1
 }
+
+// DoCIDROverlap returns false if cidr blocks don't share a single ip,
+// i.e. they don't overlap.
+func DoCIDROverlap(cidr1, cidr2 string) (bool, error) {
+	netCIDR1, err := netip.ParsePrefix(cidr1)
+	if err != nil {
+		return true, err
+	}
+	netCIDR2, err := netip.ParsePrefix(cidr2)
+	if err != nil {
+		return true, err
+	}
+	if netCIDR2.Overlaps(netCIDR1) {
+		return true, nil
+	}
+
+	return false, nil
+}
+
+// IsCIDRSubset returns true if cidr1 is a subset (including equal) to cidr2
+func IsCIDRSubset(cidr1, cidr2 string) (bool, error) {
+	firstIP1, netCidr1, err := net.ParseCIDR(cidr1)
+	// ParseCIDR() example from Docs: for CIDR="192.0.2.1/24"
+	// IP=192.0.2.1 and network mask 192.0.2.0/24 are returned
+	if err != nil {
+		return false, err
+	}
+
+	_, netCidr2, err := net.ParseCIDR(cidr2)
+	if err != nil {
+		return false, err
+	}
+	// number of significant bits in the subnet mask
+	maskSize1, _ := netCidr1.Mask.Size()
+	maskSize2, _ := netCidr2.Mask.Size()
+	// cidr1 is a subset of cidr2 if the first user ip of cidr1 within cidr2
+	// and the network mask of cidr1 is no smaller than that of cidr2, as
+	// fewer bits are left for user address space.
+	return netCidr2.Contains(firstIP1) && maskSize1 >= maskSize2, nil
+}
+

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -16,7 +16,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package log
+package utils
 
 import (
 	"testing"

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -16,7 +16,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package ibm
+package log
 
 import (
 	"testing"


### PR DESCRIPTION
Moving the CIDR comparison functions from IBMs utils to the general utils folder, so it's available for all the clouds