### PR TITLE
Fix release trigger on PR Merge

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,6 @@ name: Release Images and Binaries
 
 on:
   push:
-    branches:
-      - main
     tags:
       - 'v**'
 


### PR DESCRIPTION
Currently, a release is triggered upon PR merge. I realized it's because of `branch:main` in push, which doesn't filter out only tag pushes, but applies to all pushes (PR merge) to the main branch. 
I referred to bunch of other projects, which don't have this condition set. Hence, we should be ok with not having `branch:main` condition. 