### PR TITLE
Enable Permit List Rule Operations on Tags

### DIFF
--- a/internal/cli/glide/rule/add/add.go
+++ b/internal/cli/glide/rule/add/add.go
@@ -32,9 +32,9 @@ import (
 func NewCommand() (*cobra.Command, *executor) {
 	executor := &executor{writer: os.Stdout, cliSettings: settings.Global}
 	cmd := &cobra.Command{
-		Use:     "add <cloud> <resource name> [--rulefile <path to rule json file>] [--ping <tag>] [--ssh <tag>]",
-		Short:   "Add a rule to a resource's permit list",
-		Args:    cobra.ExactArgs(2),
+		Use:     "add [<cloud> <resource name> | <tag>] [--rulefile <path to rule json file>] [--ping <tag>] [--ssh <tag>]",
+		Short:   "Add a rule to a resource's permit list or to the permit list of every resource within a tag",
+		Args:    cobra.RangeArgs(1, 2),
 		PreRunE: executor.Validate,
 		RunE:    executor.Execute,
 	}
@@ -107,7 +107,13 @@ func (e *executor) Execute(cmd *cobra.Command, args []string) error {
 	}
 
 	c := client.Client{ControllerAddress: e.cliSettings.ServerAddr}
-	err := c.AddPermitListRules(e.cliSettings.ActiveNamespace, args[0], args[1], rules)
+
+	var err error
+	if len(args) == 1 {
+		err = c.AddPermitListRulesTag(args[0], rules)
+	} else {
+		err = c.AddPermitListRules(e.cliSettings.ActiveNamespace, args[0], args[1], rules)
+	}
 
 	return err
 }

--- a/internal/cli/glide/rule/add/add_test.go
+++ b/internal/cli/glide/rule/add/add_test.go
@@ -73,8 +73,8 @@ func TestRuleAddExecute(t *testing.T) {
 	assert.Nil(t, err)
 
 	// Tag
-	args := []string{"tag"}
-	err := executor.Execute(cmd, args)
+	args = []string{"tag"}
+	err = executor.Execute(cmd, args)
 
 	assert.Nil(t, err)
 }

--- a/internal/cli/glide/rule/add/add_test.go
+++ b/internal/cli/glide/rule/add/add_test.go
@@ -30,7 +30,8 @@ import (
 func TestRuleAddValidate(t *testing.T) {
 	cmd, executor := NewCommand()
 
-	args := []string{fake.CloudName, "uri"}
+	// Resource name
+	args := []string{fake.CloudName, "resourceName"}
 	ruleFile := "not-a-file.json"
 	tag := "tag"
 	err := cmd.Flags().Set("rulefile", ruleFile)
@@ -39,6 +40,15 @@ func TestRuleAddValidate(t *testing.T) {
 	require.Nil(t, err)
 	err = cmd.Flags().Set("ssh", tag)
 	require.Nil(t, err)
+	err = executor.Validate(cmd, args)
+
+	assert.Nil(t, err)
+	assert.Equal(t, executor.ruleFile, ruleFile)
+	assert.Equal(t, executor.pingTag, tag)
+	assert.Equal(t, executor.sshTag, tag)
+
+	// Tag
+	args = []string{tag}
 	err = executor.Validate(cmd, args)
 
 	assert.Nil(t, err)
@@ -56,7 +66,14 @@ func TestRuleAddExecute(t *testing.T) {
 	executor.pingTag = "pingTag"
 	executor.sshTag = "sshTag"
 
+	// Resource name
 	args := []string{fake.CloudName, "uri"}
+	err := executor.Execute(cmd, args)
+
+	assert.Nil(t, err)
+
+	// Tag
+	args := []string{"tag"}
 	err := executor.Execute(cmd, args)
 
 	assert.Nil(t, err)

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -35,6 +35,8 @@ type ParagliderControllerClient interface {
 	AddPermitListRules(namespace string, cloud string, resourceName string, rules []*paragliderpb.PermitListRule) error
 	DeletePermitListRules(namespace string, cloud string, resourceName string, rules []string) error
 	CreateResource(namespace string, cloud string, resourceName string, resource *paragliderpb.ResourceDescriptionString) (map[string]string, error)
+	AddPermitListRulesTag(tag string, rules []*paragliderpb.PermitListRule) error
+	DeletePermitListRulesTag(tag string, rules []string) error
 	GetTag(tag string) (*tagservicepb.TagMapping, error)
 	ResolveTag(tag string) ([]*tagservicepb.TagMapping, error)
 	SetTag(tag string, tagMapping *tagservicepb.TagMapping) error
@@ -161,6 +163,40 @@ func (c *Client) CreateResource(namespace string, cloud string, resourceName str
 	}
 
 	return resourceDict, nil
+}
+
+// Add permit list rules to a tag
+func (c *Client) AddPermitListRulesTag(tag string, rules []*paragliderpb.PermitListRule) error {
+	path := fmt.Sprintf(orchestrator.GetFormatterString(orchestrator.RuleOnTagURL), tag)
+
+	reqBody, err := json.Marshal(rules)
+	if err != nil {
+		return err
+	}
+
+	_, err = c.sendRequest(path, http.MethodPost, bytes.NewBuffer(reqBody))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Remove permit list rules to a tag
+func (c *Client) DeletePermitListRulesTag(tag string, rules []string) error {
+	path := fmt.Sprintf(orchestrator.GetFormatterString(orchestrator.RuleOnTagURL), tag)
+
+	reqBody, err := json.Marshal(rules)
+	if err != nil {
+		return err
+	}
+
+	_, err = c.sendRequest(path, http.MethodDelete, bytes.NewBuffer(reqBody))
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // Get the members of a tag

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -58,6 +58,26 @@ func TestDeletePermitListRules(t *testing.T) {
 	assert.Nil(t, err)
 }
 
+func TestTagAddPermitListRules(t *testing.T) {
+	s := fake.FakeOrchestratorRESTServer{}
+	controllerAddress := s.SetupFakeOrchestratorRESTServer()
+	client := Client{ControllerAddress: controllerAddress}
+
+	err := client.AddPermitListRulesTag("tagName", fake.GetFakePermitListRules())
+
+	assert.Nil(t, err)
+}
+
+func TestTagDeletePermitListRules(t *testing.T) {
+	s := fake.FakeOrchestratorRESTServer{}
+	controllerAddress := s.SetupFakeOrchestratorRESTServer()
+	client := Client{ControllerAddress: controllerAddress}
+
+	err := client.DeletePermitListRulesTag("tagName", fake.GetFakePermitListRuleNames())
+
+	assert.Nil(t, err)
+}
+
 func TestCreateResource(t *testing.T) {
 	s := fake.FakeOrchestratorRESTServer{}
 	controllerAddress := s.SetupFakeOrchestratorRESTServer()

--- a/pkg/fake/orchestrator/rest/fake_orchestrator_rest_server.go
+++ b/pkg/fake/orchestrator/rest/fake_orchestrator_rest_server.go
@@ -243,6 +243,24 @@ func (s *FakeOrchestratorRESTServer) SetupFakeOrchestratorRESTServer() string {
 				return
 			}
 			return
+		// Add Permit List Rules Tag
+		case urlMatches(path, orchestrator.RuleOnTagURL) && r.Method == http.MethodPost:
+			rules := []*paragliderpb.PermitListRule{}
+			err := json.Unmarshal(body, &rules)
+			if err != nil {
+				http.Error(w, fmt.Sprintf("error unmarshalling request body: %s", err), http.StatusBadRequest)
+				return
+			}
+			return
+		// Delete Permit List Rules Tag
+		case urlMatches(path, orchestrator.RuleOnTagURL) && r.Method == http.MethodDelete:
+			rules := []string{}
+			err := json.Unmarshal(body, &rules)
+			if err != nil {
+				http.Error(w, fmt.Sprintf("error unmarshalling request body: %s", err), http.StatusBadRequest)
+				return
+			}
+			return
 		// Tag List
 		case urlMatches(path, orchestrator.ListTagURL):
 			if r.Method == http.MethodGet {

--- a/pkg/fake/tagservice/fake_tag_service.go
+++ b/pkg/fake/tagservice/fake_tag_service.go
@@ -59,7 +59,7 @@ func (s *FakeTagServiceServer) GetTag(c context.Context, req *tagservicepb.GetTa
 }
 
 func (s *FakeTagServiceServer) ResolveTag(c context.Context, req *tagservicepb.ResolveTagRequest) (*tagservicepb.ResolveTagResponse, error) {
-	if strings.HasPrefix(req.TagName, ValidTagName) {
+	if strings.HasPrefix(req.TagName, ValidTagName) || strings.HasSuffix(req.TagName, ValidTagName) {
 		newUri := "uri/" + req.TagName
 		return &tagservicepb.ResolveTagResponse{Tags: []*tagservicepb.TagMapping{{Name: req.TagName, Uri: &newUri, Ip: &ResolvedTagIp}}}, nil
 	}

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -370,8 +370,7 @@ func (s *ControllerServer) permitListRuleAdd(c *gin.Context) {
 	}
 }
 
-// TODO NOW: Create a helper function for this and delete
-// TODO NOW: Document
+// Add permit list rules to all resources within a tag
 func (s *ControllerServer) permitListRuleAddTag(c *gin.Context) {
 	tag := c.Param("tag")
 
@@ -430,6 +429,7 @@ func (s *ControllerServer) permitListRuleAddTag(c *gin.Context) {
 	}
 }
 
+// Delete permit list rules to from resources within a tag
 func (s *ControllerServer) permitListRuleDeleteTag(c *gin.Context) {
 	tag := c.Param("tag")
 

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -417,7 +417,7 @@ func (s *ControllerServer) permitListRuleAddTag(c *gin.Context) {
 				return
 			}
 
-			conn, err := grpc.NewClient(cloudClientAddress, grpc.WithTransportCredentials(insecure.NewCredentials()))
+			conn, err = grpc.NewClient(cloudClientAddress, grpc.WithTransportCredentials(insecure.NewCredentials()))
 			if err != nil {
 				c.AbortWithStatusJSON(400, createErrorResponse(err.Error()))
 				return

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -53,6 +53,7 @@ const (
 	DeletePermitListRulesURL string = "/namespaces/:namespace/clouds/:cloud/resources/:resourceName/deleteRules"
 	CreateResourcePUTURL     string = "/namespaces/:namespace/clouds/:cloud/resources/:resourceName"
 	CreateResourcePOSTURL    string = "/namespaces/:namespace/clouds/:cloud/resources"
+	RuleOnTagURL             string = "/tags/:tag/rules"
 	ListTagURL               string = "/tags"
 	GetTagURL                string = "/tags/:tag"
 	ResolveTagURL            string = "/tags/:tag/resolveMembers"
@@ -150,6 +151,14 @@ func parseSubscriberName(sub string) (string, string, string) {
 
 func createTagName(namespace string, cloud string, tag string) string {
 	return namespace + "." + cloud + "." + tag
+}
+
+func parseTag(tag string) (string, string, string, error) {
+	tokens := strings.Split(tag, ".")
+	if len(tokens) != 3 {
+		return "", "", "", errors.New("invalid tag format")
+	}
+	return tokens[0], tokens[1], tokens[2], nil
 }
 
 // Get the URI of a tag
@@ -358,6 +367,124 @@ func (s *ControllerServer) permitListRuleAdd(c *gin.Context) {
 	if err != nil {
 		c.AbortWithStatusJSON(400, createErrorResponse(err.Error()))
 		return
+	}
+}
+
+// TODO NOW: Create a helper function for this and delete
+// TODO NOW: Document
+func (s *ControllerServer) permitListRuleAddTag(c *gin.Context) {
+	tag := c.Param("tag")
+
+	// Parse permit list rules to add
+	var rule *paragliderpb.PermitListRule
+	if err := c.BindJSON(&rule); err != nil {
+		c.AbortWithStatusJSON(400, createErrorResponse(err.Error()))
+		return
+	}
+
+	// Resolve the tag to URIs
+	conn, err := grpc.NewClient(s.localTagService, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		c.AbortWithStatusJSON(400, createErrorResponse(err.Error()))
+		return
+	}
+	defer conn.Close()
+
+	// Send RPC to resolve tag
+	client := tagservicepb.NewTagServiceClient(conn)
+	resolvedTag, err := client.ResolveTag(context.Background(), &tagservicepb.ResolveTagRequest{TagName: tag})
+	if err != nil {
+		c.AbortWithStatusJSON(400, createErrorResponse(err.Error()))
+		return
+	}
+
+	// Add rule to each URI in the resolved tag
+	for _, mapping := range resolvedTag.Tags {
+		// Get the cloud and namespace from the tag
+		namespace, cloud, _, err := parseTag(mapping.Name)
+		if err != nil {
+			c.AbortWithStatusJSON(400, createErrorResponse(err.Error()))
+			return
+		}
+
+		// Create connection to cloud plugin
+		cloudClient, ok := s.pluginAddresses[cloud]
+		if !ok {
+			c.AbortWithStatusJSON(400, createErrorResponse("invalid cloud name"))
+			return
+		}
+		conn, err := grpc.NewClient(cloudClient, grpc.WithTransportCredentials(insecure.NewCredentials()))
+		if err != nil {
+			c.AbortWithStatusJSON(400, createErrorResponse(err.Error()))
+			return
+		}
+		defer conn.Close()
+
+		// Send RPC to add rule
+		client := paragliderpb.NewCloudPluginClient(conn)
+		_, err = client.AddPermitListRules(context.Background(), &paragliderpb.AddPermitListRulesRequest{Rules: []*paragliderpb.PermitListRule{rule}, Namespace: namespace, Resource: *mapping.Uri})
+		if err != nil {
+			c.AbortWithStatusJSON(400, createErrorResponse(err.Error()))
+			return
+		}
+	}
+}
+
+func (s *ControllerServer) permitListRuleDeleteTag(c *gin.Context) {
+	tag := c.Param("tag")
+
+	// Parse permit list rules to add
+	var rules []string
+	if err := c.BindJSON(&rules); err != nil {
+		c.AbortWithStatusJSON(400, createErrorResponse(err.Error()))
+		return
+	}
+
+	// Resolve the tag to URIs
+	conn, err := grpc.NewClient(s.localTagService, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		c.AbortWithStatusJSON(400, createErrorResponse(err.Error()))
+		return
+	}
+	defer conn.Close()
+
+	// Send RPC to resolve tag
+	client := tagservicepb.NewTagServiceClient(conn)
+	resolvedTag, err := client.ResolveTag(context.Background(), &tagservicepb.ResolveTagRequest{TagName: tag})
+	if err != nil {
+		c.AbortWithStatusJSON(400, createErrorResponse(err.Error()))
+		return
+	}
+
+	// Add rule to each URI in the resolved tag
+	for _, mapping := range resolvedTag.Tags {
+		// Get the cloud and namespace from the tag
+		namespace, cloud, _, err := parseTag(mapping.Name)
+		if err != nil {
+			c.AbortWithStatusJSON(400, createErrorResponse(err.Error()))
+			return
+		}
+
+		// Create connection to cloud plugin
+		cloudClient, ok := s.pluginAddresses[cloud]
+		if !ok {
+			c.AbortWithStatusJSON(400, createErrorResponse("invalid cloud name"))
+			return
+		}
+		conn, err := grpc.NewClient(cloudClient, grpc.WithTransportCredentials(insecure.NewCredentials()))
+		if err != nil {
+			c.AbortWithStatusJSON(400, createErrorResponse(err.Error()))
+			return
+		}
+		defer conn.Close()
+
+		// Send RPC to add rule
+		client := paragliderpb.NewCloudPluginClient(conn)
+		_, err = client.DeletePermitListRules(context.Background(), &paragliderpb.DeletePermitListRulesRequest{RuleNames: rules, Namespace: namespace, Resource: *mapping.Uri})
+		if err != nil {
+			c.AbortWithStatusJSON(400, createErrorResponse(err.Error()))
+			return
+		}
 	}
 }
 
@@ -1317,6 +1444,8 @@ func Setup(cfg config.Config, background bool) {
 	router.DELETE(PermitListRulePUTURL, server.permitListRuleDelete)
 	router.PUT(CreateResourcePUTURL, server.resourceCreate)
 	router.POST(CreateResourcePOSTURL, server.resourceCreate)
+	router.POST(RuleOnTagURL, server.permitListRuleAddTag)
+	router.DELETE(RuleOnTagURL, server.permitListRuleDeleteTag)
 	router.GET(ListTagURL, server.listTags)
 	router.GET(GetTagURL, server.getTag)
 	router.POST(ResolveTagURL, server.resolveTag)

--- a/pkg/orchestrator/orchestrator_test.go
+++ b/pkg/orchestrator/orchestrator_test.go
@@ -369,11 +369,10 @@ func TestPermitListRuleTagAdd(t *testing.T) {
 	faketagservice.SetupFakeTagServer(tagServerPort)
 
 	r := SetUpRouter()
-	r.POST(RuleOnTagURL, orchestratorServer.permitListRuleTagAdd)
+	r.POST(RuleOnTagURL, orchestratorServer.permitListRuleAddTag)
 
 	// Well-formed request
-	name := faketagservice.ValidLastLevelTagName
-	tags := []string{faketagservice.ValidTagName}
+	tags := []string{"1.1.1.1"}
 	rule := &paragliderpb.PermitListRule{
 		Name:      "rulename",
 		Tags:      tags,
@@ -383,7 +382,7 @@ func TestPermitListRuleTagAdd(t *testing.T) {
 		Protocol:  1}
 	jsonValue, _ := json.Marshal(rule)
 
-	url := fmt.Sprintf(GetFormatterString(RuleOnTagURL), defaultNamespace+"."+exampleCloudName+"."+validTagName)
+	url := fmt.Sprintf(GetFormatterString(RuleOnTagURL), defaultNamespace+"."+exampleCloudName+"."+faketagservice.ValidTagName)
 	req, _ := http.NewRequest("POST", url, bytes.NewBuffer(jsonValue))
 	w := httptest.NewRecorder()
 
@@ -413,12 +412,13 @@ func TestPermitListRuleTagDelete(t *testing.T) {
 	faketagservice.SetupFakeTagServer(tagServerPort)
 
 	r := SetUpRouter()
-	r.POST(RuleOnTagURL, orchestratorServer.permitListRuleTagAdd)
+	r.DELETE(RuleOnTagURL, orchestratorServer.permitListRuleDeleteTag)
 
 	// Well-formed request
-	rules = []string{"ruleName"}
+	rules := []string{"ruleName"}
+	jsonValue, _ := json.Marshal(rules)
 
-	url := fmt.Sprintf(GetFormatterString(RuleOnTagURL), defaultNamespace+"."+exampleCloudName+"."+validTagName)
+	url := fmt.Sprintf(GetFormatterString(RuleOnTagURL), defaultNamespace+"."+exampleCloudName+"."+faketagservice.ValidTagName)
 	req, _ := http.NewRequest("DELETE", url, bytes.NewBuffer(jsonValue))
 	w := httptest.NewRecorder()
 

--- a/pkg/orchestrator/orchestrator_test.go
+++ b/pkg/orchestrator/orchestrator_test.go
@@ -357,6 +357,85 @@ func TestPermitListRulePost(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 }
 
+func TestPermitListRuleTagAdd(t *testing.T) {
+	// Setup
+	orchestratorServer := newOrchestratorServer()
+	tagServerPort := getNewPortNumber()
+	cloudPluginPort := getNewPortNumber()
+	orchestratorServer.pluginAddresses[exampleCloudName] = fmt.Sprintf("localhost:%d", cloudPluginPort)
+	orchestratorServer.localTagService = fmt.Sprintf("localhost:%d", tagServerPort)
+
+	fakeplugin.SetupFakePluginServer(cloudPluginPort)
+	faketagservice.SetupFakeTagServer(tagServerPort)
+
+	r := SetUpRouter()
+	r.POST(RuleOnTagURL, orchestratorServer.permitListRuleTagAdd)
+
+	// Well-formed request
+	name := faketagservice.ValidLastLevelTagName
+	tags := []string{faketagservice.ValidTagName}
+	rule := &paragliderpb.PermitListRule{
+		Name:      "rulename",
+		Tags:      tags,
+		Direction: paragliderpb.Direction_INBOUND,
+		SrcPort:   1,
+		DstPort:   2,
+		Protocol:  1}
+	jsonValue, _ := json.Marshal(rule)
+
+	url := fmt.Sprintf(GetFormatterString(RuleOnTagURL), defaultNamespace+"."+exampleCloudName+"."+validTagName)
+	req, _ := http.NewRequest("POST", url, bytes.NewBuffer(jsonValue))
+	w := httptest.NewRecorder()
+
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	// Bad tag name
+	url = fmt.Sprintf(GetFormatterString(RuleOnTagURL), "badtag")
+	req, _ = http.NewRequest("POST", url, bytes.NewBuffer(jsonValue))
+	w = httptest.NewRecorder()
+
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestPermitListRuleTagDelete(t *testing.T) {
+	// Setup
+	orchestratorServer := newOrchestratorServer()
+	tagServerPort := getNewPortNumber()
+	cloudPluginPort := getNewPortNumber()
+	orchestratorServer.pluginAddresses[exampleCloudName] = fmt.Sprintf("localhost:%d", cloudPluginPort)
+	orchestratorServer.localTagService = fmt.Sprintf("localhost:%d", tagServerPort)
+
+	fakeplugin.SetupFakePluginServer(cloudPluginPort)
+	faketagservice.SetupFakeTagServer(tagServerPort)
+
+	r := SetUpRouter()
+	r.POST(RuleOnTagURL, orchestratorServer.permitListRuleTagAdd)
+
+	// Well-formed request
+	rules = []string{"ruleName"}
+
+	url := fmt.Sprintf(GetFormatterString(RuleOnTagURL), defaultNamespace+"."+exampleCloudName+"."+validTagName)
+	req, _ := http.NewRequest("DELETE", url, bytes.NewBuffer(jsonValue))
+	w := httptest.NewRecorder()
+
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	// Bad tag name
+	url = fmt.Sprintf(GetFormatterString(RuleOnTagURL), "badtag")
+	req, _ = http.NewRequest("DELETE", url, bytes.NewBuffer(jsonValue))
+	w = httptest.NewRecorder()
+
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
 func TestPermitListRulesDelete(t *testing.T) {
 	// Setup
 	orchestratorServer := newOrchestratorServer()

--- a/pkg/paragliderpb/paraglider.proto
+++ b/pkg/paragliderpb/paraglider.proto
@@ -25,6 +25,7 @@ service CloudPlugin {
     rpc GetUsedAsns(GetUsedAsnsRequest) returns (GetUsedAsnsResponse) {}
     rpc GetUsedBgpPeeringIpAddresses(GetUsedBgpPeeringIpAddressesRequest) returns (GetUsedBgpPeeringIpAddressesResponse) {}
     rpc CreateResource(CreateResourceRequest) returns (CreateResourceResponse) {}
+    rpc AttachResource(AttachResourceRequest) returns (AttachResourceResponse) {}
     rpc GetPermitList(GetPermitListRequest) returns (GetPermitListResponse) {}
     rpc AddPermitListRules(AddPermitListRulesRequest) returns (AddPermitListRulesResponse) {}
     rpc DeletePermitListRules(DeletePermitListRulesRequest) returns (DeletePermitListRulesResponse) {}
@@ -93,6 +94,18 @@ message CreateResourceRequest {
 }
 
 message CreateResourceResponse {
+    string name = 1;
+    string uri = 2;
+    string ip = 3;
+}
+
+message AttachResourceRequest {
+    ParagliderDeployment deployment = 1;
+    string name = 2;
+    string uri = 3;
+}
+
+message AttachResourceResponse {
     string name = 1;
     string uri = 2;
     string ip = 3;


### PR DESCRIPTION
Enables users to apply rules (or delete rules) on tags. Before, users could only apply a rule on one resource at a time. Now, if a tag maps to many resources, this can be leveraged to apply a rule in one command to many resources.

Resolves #117 