### PR TITLE
Allocate Flexible address spaces

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -47,6 +47,8 @@ require (
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/kr/pretty v0.3.1 // indirect
 	github.com/rogpeppe/go-internal v1.10.0 // indirect
+	github.com/seancfoley/bintree v1.3.1 // indirect
+	github.com/seancfoley/ipaddress-go v1.6.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 	gopkg.in/go-playground/validator.v9 v9.31.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -302,6 +302,10 @@ github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/f
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
 github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/seancfoley/bintree v1.3.1 h1:cqmmQK7Jm4aw8gna0bP+huu5leVOgHGSJBEpUx3EXGI=
+github.com/seancfoley/bintree v1.3.1/go.mod h1:hIUabL8OFYyFVTQ6azeajbopogQc2l5C/hiXMcemWNU=
+github.com/seancfoley/ipaddress-go v1.6.0 h1:9z7yGmOnV4P2ML/dlR/kCJiv5tp8iHOOetJvxJh/R5w=
+github.com/seancfoley/ipaddress-go v1.6.0/go.mod h1:TQRZgv+9jdvzHmKoPGBMxyiaVmoI0rYpfEk8Q/sL/Iw=
 github.com/sirupsen/logrus v1.4.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=

--- a/internal/cli/glided/startup/startup.go
+++ b/internal/cli/glided/startup/startup.go
@@ -55,6 +55,7 @@ type executor struct {
 	ibmPort          int
 	orchestratorAddr string
 	clearKeys        bool
+	addressSpace     []string
 }
 
 func (e *executor) Validate(cmd *cobra.Command, args []string) error {

--- a/pkg/azure/plugin.go
+++ b/pkg/azure/plugin.go
@@ -29,7 +29,6 @@ import (
 	utils "github.com/paraglider-project/paraglider/pkg/utils"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
-	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/emptypb"
 )
 
@@ -311,7 +310,8 @@ func (s *azurePluginServer) CreateResource(ctx context.Context, resourceDesc *pa
 		}
 		defer conn.Close()
 		client := paragliderpb.NewControllerClient(conn)
-		response, err := client.FindUnusedAddressSpaces(context.Background(), &paragliderpb.FindUnusedAddressSpacesRequest{Num: proto.Int32(int32(resourceDescInfo.NumAdditionalAddressSpaces))})
+		reqAddressSpaces := make([]int32, resourceDescInfo.NumAdditionalAddressSpaces)
+		response, err := client.FindUnusedAddressSpaces(context.Background(), &paragliderpb.FindUnusedAddressSpacesRequest{Sizes: reqAddressSpaces})
 		if err != nil {
 			utils.Log.Printf("Failed to find unused address spaces: %v", err)
 			return nil, err

--- a/pkg/fake/orchestrator/rpc/fake_orchestrator_rpc_server.go
+++ b/pkg/fake/orchestrator/rpc/fake_orchestrator_rpc_server.go
@@ -40,8 +40,8 @@ type FakeOrchestratorRPCServer struct {
 
 func (f *FakeOrchestratorRPCServer) FindUnusedAddressSpaces(ctx context.Context, req *paragliderpb.FindUnusedAddressSpacesRequest) (*paragliderpb.FindUnusedAddressSpacesResponse, error) {
 	numAddresses := 1
-	if req.Num != nil {
-		numAddresses = int(*req.Num)
+	if req.Sizes != nil {
+		numAddresses = len(req.Sizes)
 	}
 	addresses := make([]string, numAddresses)
 	for i := 0; i < numAddresses; i++ {

--- a/pkg/gcp/plugin.go
+++ b/pkg/gcp/plugin.go
@@ -441,7 +441,9 @@ func (s *GCPPluginServer) _CreateResource(ctx context.Context, resourceDescripti
 			numAddressSpacesNeeded += 1
 		}
 
-		response, err := client.FindUnusedAddressSpaces(context.Background(), &paragliderpb.FindUnusedAddressSpacesRequest{Num: &numAddressSpacesNeeded})
+		reqAddressSpaces := make([]int32, numAddressSpacesNeeded)
+
+		response, err := client.FindUnusedAddressSpaces(context.Background(), &paragliderpb.FindUnusedAddressSpacesRequest{Sizes: reqAddressSpaces})
 
 		if err != nil {
 			return nil, fmt.Errorf("unable to find unused address space: %w", err)

--- a/pkg/ibm_plugin/server/plugin.go
+++ b/pkg/ibm_plugin/server/plugin.go
@@ -147,7 +147,7 @@ func (s *IBMPluginServer) CreateResource(c context.Context, resourceDesc *paragl
 		}
 		defer conn.Close()
 		client := paragliderpb.NewControllerClient(conn)
-		resp, err := client.FindUnusedAddressSpaces(context.Background(), &paragliderpb.FindUnusedAddressSpacesRequest{})
+		resp, err := client.FindUnusedAddressSpaces(context.Background(), &paragliderpb.FindUnusedAddressSpacesRequest{Sizes: []int32{0}})
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/orchestrator/config/config.go
+++ b/pkg/orchestrator/config/config.go
@@ -48,5 +48,6 @@ type Config struct {
 	} `yaml:"kvStore"`
 
 	Namespaces   map[string][]CloudDeployment `yaml:"namespaces"`
+	AddressSpace []string                     `yaml:"addressSpace"`
 	CloudPlugins []CloudPlugin                `yaml:"cloudPlugins"`
 }

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -602,6 +602,7 @@ func (s *ControllerServer) FindUnusedAddressSpaces(c context.Context, req *parag
 			if reqSize < block.GetCount().Int64() {
 				aBlock = allocBlock(block, reqSize)
 				if aBlock == nil {
+					// Allocation failed, move on to next available block
 					continue
 				}
 				respAddressSpaces[i] = aBlock.String()

--- a/pkg/orchestrator/orchestrator_test.go
+++ b/pkg/orchestrator/orchestrator_test.go
@@ -63,6 +63,7 @@ func newOrchestratorServer() *ControllerServer {
 		pluginAddresses:           make(map[string]string),
 		usedBgpPeeringIpAddresses: make(map[string][]string),
 		namespace:                 defaultNamespace,
+		config:                    config.Config{AddressSpace: []string{defaultAddressSpace}},
 	}
 	return s
 }
@@ -614,7 +615,6 @@ func TestUpdateUsedAddressSpacesMap(t *testing.T) {
 
 func TestFindUnusedAddressSpaces(t *testing.T) {
 	orchestratorServer := newOrchestratorServer()
-
 	// No entries in address space map
 	resp, err := orchestratorServer.FindUnusedAddressSpaces(context.Background(), &paragliderpb.FindUnusedAddressSpacesRequest{})
 	require.Nil(t, err)
@@ -649,24 +649,24 @@ func TestFindUnusedAddressSpaces(t *testing.T) {
 	require.Nil(t, err)
 	assert.Equal(t, resp.AddressSpaces[0], "10.2.0.0/16")
 
+	// Multiple spaces
+	orchestratorServer.usedAddressSpaces = []*paragliderpb.AddressSpaceMapping{}
+	resp, err = orchestratorServer.FindUnusedAddressSpaces(context.Background(), &paragliderpb.FindUnusedAddressSpacesRequest{Sizes: []int32{200, 1000, 2}})
+	require.Nil(t, err)
+	assert.Equal(t, resp.AddressSpaces[0], "10.0.0.0/24")
+	assert.Equal(t, resp.AddressSpaces[1], "10.1.0.0/22")
+	assert.Equal(t, resp.AddressSpaces[2], "10.1.4.0/30")
+
 	// Out of addresses
 	orchestratorServer.usedAddressSpaces = []*paragliderpb.AddressSpaceMapping{
 		{
-			AddressSpaces: []string{"10.255.0.0/16"},
+			AddressSpaces: []string{"10.0.0.0/10", "10.64.0.0/10", "10.128.0.0/10", "10.192.0.0/10"},
 			Cloud:         exampleCloudName,
 			Namespace:     defaultNamespace,
 		},
 	}
 	_, err = orchestratorServer.FindUnusedAddressSpaces(context.Background(), &paragliderpb.FindUnusedAddressSpacesRequest{})
-
 	require.NotNil(t, err)
-
-	// Multiple spaces
-	orchestratorServer.usedAddressSpaces = []*paragliderpb.AddressSpaceMapping{}
-	resp, err = orchestratorServer.FindUnusedAddressSpaces(context.Background(), &paragliderpb.FindUnusedAddressSpacesRequest{Num: proto.Int32(2)})
-	require.Nil(t, err)
-	assert.Equal(t, resp.AddressSpaces[0], "10.0.0.0/16")
-	assert.Equal(t, resp.AddressSpaces[1], "10.1.0.0/16")
 }
 
 func TestGetUsedAsns(t *testing.T) {

--- a/pkg/paragliderpb/paraglider.proto
+++ b/pkg/paragliderpb/paraglider.proto
@@ -187,7 +187,7 @@ message GetUsedBgpPeeringIpAddressesResponse {
 }
 
 message FindUnusedAddressSpacesRequest {
-    optional int32 num = 2;
+    repeated int32 sizes = 1;
 }
 
 message FindUnusedAddressSpacesResponse {


### PR DESCRIPTION
Fixes https://github.com/paraglider-project/paraglider/issues/81 

Overview: 
1) Plugins instead of requested n address spaces, would now request an array of n address space sizes.
2) The Orchestrator tries to allocat n address spaces according to the sizes . Added a Mutex so that two requests don't get served at the same time (avoid allocation of same address space to both clients).
2) Additionally,  made allocatable address space a configuration parameter. Hence users can specify address spaces to be allocated.