### PR TITLE
Refactor: Moving utils from ibm to general

### DIFF
--- a/pkg/azure/utils.go
+++ b/pkg/azure/utils.go
@@ -434,7 +434,7 @@ func DoesVnetOverlapWithParaglider(ctx context.Context, handler *AzureSDKHandler
 	// Check if the Vnet address space overlaps with any of the used address spaces
 	for _, mapping := range response.AddressSpaceMappings {
 		for _, addressSpace := range mapping.AddressSpaces {
-			doesOverlap, err := utils.DoesCIDROverlap(vnetAddress, addressSpace)
+			doesOverlap, err := utils.DoCIDROverlap(vnetAddress, addressSpace)
 			if err != nil {
 				return true, err
 			}

--- a/pkg/ibm/security_group.go
+++ b/pkg/ibm/security_group.go
@@ -419,7 +419,7 @@ func IsRemoteInCIDR(remote, cidr string) (bool, error) {
 		}
 		return netCidr.Contains(netIP), nil
 	}
-	return isCIDRSubset(remote, cidr)
+	return utils.IsCIDRSubset(remote, cidr)
 }
 
 // GetRemoteType returns IBM specific keyword returned by vpc1 SDK,

--- a/pkg/ibm/subnets.go
+++ b/pkg/ibm/subnets.go
@@ -134,7 +134,7 @@ func (c *CloudClient) DoSubnetsInVPCOverlapCIDR(vpcID string,
 	}
 
 	for _, subnet := range subnets {
-		doesOverlap, err := doCIDROverlap(*subnet.Ipv4CIDRBlock, CIDR)
+		doesOverlap, err := utils.DoCIDROverlap(*subnet.Ipv4CIDRBlock, CIDR)
 		if err != nil {
 			return true, err
 		}

--- a/pkg/ibm/utils.go
+++ b/pkg/ibm/utils.go
@@ -22,9 +22,7 @@ import (
 	"fmt"
 	"hash/fnv"
 	"io"
-	"net"
 	"net/http"
-	"net/netip"
 	"os"
 	"reflect"
 	"strings"
@@ -110,46 +108,6 @@ func generateResourceName(name string) string {
 // isParagliderResource returns if a given resource (e.g. permit list) belongs to paraglider
 func isParagliderResource(name string) bool {
 	return strings.HasPrefix(name, paragliderResourcePrefix)
-}
-
-// doCIDROverlap returns false if cidr blocks don't share a single ip,
-// i.e. they don't overlap.
-func doCIDROverlap(cidr1, cidr2 string) (bool, error) {
-	netCIDR1, err := netip.ParsePrefix(cidr1)
-	if err != nil {
-		return true, err
-	}
-	netCIDR2, err := netip.ParsePrefix(cidr2)
-	if err != nil {
-		return true, err
-	}
-	if netCIDR2.Overlaps(netCIDR1) {
-		return true, nil
-	}
-
-	return false, nil
-}
-
-// isCIDRSubset returns true if cidr1 is a subset (including equal) to cidr2
-func isCIDRSubset(cidr1, cidr2 string) (bool, error) {
-	firstIP1, netCidr1, err := net.ParseCIDR(cidr1)
-	// ParseCIDR() example from Docs: for CIDR="192.0.2.1/24"
-	// IP=192.0.2.1 and network mask 192.0.2.0/24 are returned
-	if err != nil {
-		return false, err
-	}
-
-	_, netCidr2, err := net.ParseCIDR(cidr2)
-	if err != nil {
-		return false, err
-	}
-	// number of significant bits in the subnet mask
-	maskSize1, _ := netCidr1.Mask.Size()
-	maskSize2, _ := netCidr2.Mask.Size()
-	// cidr1 is a subset of cidr2 if the first user ip of cidr1 within cidr2
-	// and the network mask of cidr1 is no smaller than that of cidr2, as
-	// fewer bits are left for user address space.
-	return netCidr2.Contains(firstIP1) && maskSize1 >= maskSize2, nil
 }
 
 // TODO cleanup k8s clusters

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -192,7 +192,7 @@ func DoCIDROverlap(cidr1, cidr2 string) (bool, error) {
 	return false, nil
 }
 
-// isCIDRSubset returns true if cidr1 is a subset (including equal) to cidr2
+// IsCIDRSubset returns true if cidr1 is a subset (including equal) to cidr2
 func IsCIDRSubset(cidr1, cidr2 string) (bool, error) {
 	firstIP1, netCidr1, err := net.ParseCIDR(cidr1)
 	// ParseCIDR() example from Docs: for CIDR="192.0.2.1/24"

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -14,11 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package log
+package utils
 
 import (
 	"fmt"
 	"log"
+	"net"
 	"net/netip"
 	"os"
 	"strings"
@@ -175,7 +176,7 @@ func GetNumVpnConnections(cloud1, cloud2 string) int {
 
 // DoCIDROverlap returns false if cidr blocks don't share a single ip,
 // i.e. they don't overlap.
-func DoesCIDROverlap(cidr1, cidr2 string) (bool, error) {
+func DoCIDROverlap(cidr1, cidr2 string) (bool, error) {
 	netCIDR1, err := netip.ParsePrefix(cidr1)
 	if err != nil {
 		return true, err
@@ -189,4 +190,26 @@ func DoesCIDROverlap(cidr1, cidr2 string) (bool, error) {
 	}
 
 	return false, nil
+}
+
+// isCIDRSubset returns true if cidr1 is a subset (including equal) to cidr2
+func IsCIDRSubset(cidr1, cidr2 string) (bool, error) {
+	firstIP1, netCidr1, err := net.ParseCIDR(cidr1)
+	// ParseCIDR() example from Docs: for CIDR="192.0.2.1/24"
+	// IP=192.0.2.1 and network mask 192.0.2.0/24 are returned
+	if err != nil {
+		return false, err
+	}
+
+	_, netCidr2, err := net.ParseCIDR(cidr2)
+	if err != nil {
+		return false, err
+	}
+	// number of significant bits in the subnet mask
+	maskSize1, _ := netCidr1.Mask.Size()
+	maskSize2, _ := netCidr2.Mask.Size()
+	// cidr1 is a subset of cidr2 if the first user ip of cidr1 within cidr2
+	// and the network mask of cidr1 is no smaller than that of cidr2, as
+	// fewer bits are left for user address space.
+	return netCidr2.Contains(firstIP1) && maskSize1 >= maskSize2, nil
 }

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -32,13 +32,13 @@ func TestCIDRSubset(t *testing.T) {
 	cidr1 := "10.10.10.8/29"  // 10.10.10.8 - 10.10.10.151
 	cidr2 := "10.10.10.0/24"  // 10.10.10.0 - 10.10.10.255
 	cidr3 := "192.50.64.0/17" // 192.50.0.0 - 192.50.127.255
-	res1, err := isCIDRSubset(cidr1, cidr2)
+	res1, err := IsCIDRSubset(cidr1, cidr2)
 	require.NoError(t, err)
-	res2, err := isCIDRSubset(cidr2, cidr1)
+	res2, err := IsCIDRSubset(cidr2, cidr1)
 	require.NoError(t, err)
-	res3, err := isCIDRSubset(cidr1, cidr1)
+	res3, err := IsCIDRSubset(cidr1, cidr1)
 	require.NoError(t, err)
-	res4, err := isCIDRSubset(cidr3, cidr1)
+	res4, err := IsCIDRSubset(cidr3, cidr1)
 	require.NoError(t, err)
 	require.True(t, res1)
 	require.False(t, res2)
@@ -52,15 +52,15 @@ func TestCIDROverlap(t *testing.T) {
 	cidr1 := "10.10.10.8/29"  // 10.10.10.8 - 10.10.10.151
 	cidr2 := "10.10.10.0/24"  // 10.10.10.0 - 10.10.10.255
 	cidr3 := "192.50.64.0/17" // 192.50.0.0 - 192.50.127.255
-	res1, err := doCIDROverlap(cidr1, cidr2)
+	res1, err := DoCIDROverlap(cidr1, cidr2)
 	require.NoError(t, err)
-	res2, err := doCIDROverlap(cidr2, cidr1)
+	res2, err := DoCIDROverlap(cidr2, cidr1)
 	require.NoError(t, err)
-	res3, err := doCIDROverlap(cidr1, cidr1)
+	res3, err := DoCIDROverlap(cidr1, cidr1)
 	require.NoError(t, err)
-	res4, err := doCIDROverlap(cidr1, cidr3)
+	res4, err := DoCIDROverlap(cidr1, cidr3)
 	require.NoError(t, err)
-	res5, err := doCIDROverlap(cidr2, cidr3)
+	res5, err := DoCIDROverlap(cidr2, cidr3)
 	require.NoError(t, err)
 	require.True(t, res1)
 	require.True(t, res2)

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -16,7 +16,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package ibm
+package utils
 
 import (
 	"testing"


### PR DESCRIPTION
Moving the CIDR comparison functions from IBMs utils to the general utils folder, so it's available for all the clouds