### PR TITLE
[Azure][GCP] Change all test/example OS images to Ubuntu

### DIFF
--- a/docs/source/developers/plugin-interface.rst
+++ b/docs/source/developers/plugin-interface.rst
@@ -48,9 +48,9 @@ An example of a resource description for an Azure VM is as follows:
                     },
                     "storageProfile": {
                         "imageReference": {
-                            "offer": "debian-10",
-                            "publisher": "Debian",
-                            "sku": "10",
+                            "offer": "0001-com-ubuntu-minimal-jammy",
+                            "publisher": "canonical",
+                            "sku": "minimal-22_04-lts-gen2",
                             "version": "latest"
                         }
                     }

--- a/docs/source/overview/api.rst
+++ b/docs/source/overview/api.rst
@@ -117,9 +117,9 @@ Note that a tag is automatically created for the resource with the name ``<names
                                         },
                                         \"storageProfile\": {
                                             \"imageReference\": {
-                                                \"offer\": \"debian-10\",
-                                                \"publisher\": \"Debian\",
-                                                \"sku\": \"10\",
+                                                \"offer\": \"0001-com-ubuntu-minimal-jammy\",
+                                                \"publisher\": \"canonical\",
+                                                \"sku\": \"minimal-22_04-lts-gen2\",
                                                 \"version\": \"latest\"
                                             }
                                         }
@@ -158,9 +158,9 @@ Note that a tag is automatically created for the resource with the name ``<names
                                         },
                                         \"storageProfile\": {
                                             \"imageReference\": {
-                                                \"offer\": \"debian-10\",
-                                                \"publisher\": \"Debian\",
-                                                \"sku\": \"10\",
+                                                \"offer\": \"0001-com-ubuntu-minimal-jammy\",
+                                                \"publisher\": \"canonical\",
+                                                \"sku\": \"minimal-22_04-lts-gen2\",
                                                 \"version\": \"latest\"
                                             }
                                         }

--- a/docs/source/overview/quickstart.rst
+++ b/docs/source/overview/quickstart.rst
@@ -259,7 +259,7 @@ To create VMs in clouds, Paraglider requires a JSON file that describes the VM. 
                             "boot": true,
                             "initialize_params": {
                                 "disk_size_gb": 10,
-                                    "source_image": "projects/debian-cloud/global/images/family/debian-10"
+                                    "source_image": "projects/debian-cloud/global/images/family/debian-11"
                                 },
                             "type": "PERSISTENT"
                         }],

--- a/docs/source/overview/quickstart.rst
+++ b/docs/source/overview/quickstart.rst
@@ -259,7 +259,7 @@ To create VMs in clouds, Paraglider requires a JSON file that describes the VM. 
                             "boot": true,
                             "initialize_params": {
                                 "disk_size_gb": 10,
-                                    "source_image": "projects/debian-cloud/global/images/family/debian-11"
+                                    "source_image": "projects/ubuntu-os-cloud/global/images/family/ubuntu-2204-lts"
                                 },
                             "type": "PERSISTENT"
                         }],

--- a/pkg/gcp/plugin_utils.go
+++ b/pkg/gcp/plugin_utils.go
@@ -177,7 +177,7 @@ func GetTestVmParameters(project string, zone string, name string) *computepb.In
 				{
 					InitializeParams: &computepb.AttachedDiskInitializeParams{
 						DiskSizeGb:  proto.Int64(10),
-						SourceImage: proto.String("projects/debian-cloud/global/images/family/debian-10"),
+						SourceImage: proto.String("projects/debian-cloud/global/images/family/debian-11"),
 					},
 					AutoDelete: proto.Bool(true),
 					Boot:       proto.Bool(true),

--- a/pkg/gcp/plugin_utils.go
+++ b/pkg/gcp/plugin_utils.go
@@ -177,7 +177,7 @@ func GetTestVmParameters(project string, zone string, name string) *computepb.In
 				{
 					InitializeParams: &computepb.AttachedDiskInitializeParams{
 						DiskSizeGb:  proto.Int64(10),
-						SourceImage: proto.String("projects/debian-cloud/global/images/family/debian-11"),
+						SourceImage: proto.String("projects/ubuntu-os-cloud/global/images/family/ubuntu-2204-lts"),
 					},
 					AutoDelete: proto.Bool(true),
 					Boot:       proto.Bool(true),

--- a/tools/examples/vm-configs/azure-vm-eastus.json
+++ b/tools/examples/vm-configs/azure-vm-eastus.json
@@ -11,9 +11,9 @@
         },
         "storageProfile": {
             "imageReference": {
-                "offer": "debian-10",
-                "publisher": "Debian",
-                "sku": "10",
+                "offer": "0001-com-ubuntu-minimal-jammy",
+                "publisher": "canonical",
+                "sku": "minimal-22_04-lts-gen2",
                 "version": "latest"
             }
         }

--- a/tools/examples/vm-configs/azure-vm-westus.json
+++ b/tools/examples/vm-configs/azure-vm-westus.json
@@ -11,9 +11,9 @@
         },
         "storageProfile": {
             "imageReference": {
-                "offer": "debian-10",
-                "publisher": "Debian",
-                "sku": "10",
+                "offer": "0001-com-ubuntu-minimal-jammy",
+                "publisher": "canonical",
+                "sku": "minimal-22_04-lts-gen2",
                 "version": "latest"
             }
         }

--- a/tools/examples/vm-configs/gcp-vm.json
+++ b/tools/examples/vm-configs/gcp-vm.json
@@ -5,7 +5,7 @@
             "boot": true,
             "initialize_params": {
                 "disk_size_gb": 10,
-                    "source_image": "projects/debian-cloud/global/images/family/debian-11"
+                    "source_image": "projects/ubuntu-os-cloud/global/images/family/ubuntu-2204-lts"
                 },
             "type": "PERSISTENT"
         }],

--- a/tools/examples/vm-configs/gcp-vm.json
+++ b/tools/examples/vm-configs/gcp-vm.json
@@ -5,7 +5,7 @@
             "boot": true,
             "initialize_params": {
                 "disk_size_gb": 10,
-                    "source_image": "projects/debian-cloud/global/images/family/debian-10"
+                    "source_image": "projects/debian-cloud/global/images/family/debian-11"
                 },
             "type": "PERSISTENT"
         }],


### PR DESCRIPTION
GCP integration test is [failing](https://github.com/paraglider-project/paraglider/actions/runs/9749067130) for #401 merge due to [Debian 10 reaching its end of life](https://www.debian.org/News/2024/20240615). This doesn't affect Azure tests because those use Ubuntu 22.04.

I updated everything (i.e., GCP tests, GCP docs, and Azure docs) to use Ubuntu 22.04. Azure tests require Ubuntu 22.04 due to the network watcher extension, so I figured it's best if we make it clean and make everything use Ubuntu 22.04. I believe IBM already uses it as well.