### PR TITLE
[GCP] Fix integration test bugs for display name and Debian 10

### DIFF
--- a/docs/source/developers/plugin-interface.rst
+++ b/docs/source/developers/plugin-interface.rst
@@ -48,9 +48,9 @@ An example of a resource description for an Azure VM is as follows:
                     },
                     "storageProfile": {
                         "imageReference": {
-                            "offer": "debian-10",
-                            "publisher": "Debian",
-                            "sku": "10",
+                            "offer": "0001-com-ubuntu-minimal-jammy",
+                            "publisher": "canonical",
+                            "sku": "minimal-22_04-lts-gen2",
                             "version": "latest"
                         }
                     }

--- a/docs/source/overview/api.rst
+++ b/docs/source/overview/api.rst
@@ -117,9 +117,9 @@ Note that a tag is automatically created for the resource with the name ``<names
                                         },
                                         \"storageProfile\": {
                                             \"imageReference\": {
-                                                \"offer\": \"debian-10\",
-                                                \"publisher\": \"Debian\",
-                                                \"sku\": \"10\",
+                                                \"offer\": \"0001-com-ubuntu-minimal-jammy\",
+                                                \"publisher\": \"canonical\",
+                                                \"sku\": \"minimal-22_04-lts-gen2\",
                                                 \"version\": \"latest\"
                                             }
                                         }
@@ -158,9 +158,9 @@ Note that a tag is automatically created for the resource with the name ``<names
                                         },
                                         \"storageProfile\": {
                                             \"imageReference\": {
-                                                \"offer\": \"debian-10\",
-                                                \"publisher\": \"Debian\",
-                                                \"sku\": \"10\",
+                                                \"offer\": \"0001-com-ubuntu-minimal-jammy\",
+                                                \"publisher\": \"canonical\",
+                                                \"sku\": \"minimal-22_04-lts-gen2\",
                                                 \"version\": \"latest\"
                                             }
                                         }

--- a/docs/source/overview/quickstart.rst
+++ b/docs/source/overview/quickstart.rst
@@ -259,7 +259,7 @@ To create VMs in clouds, Paraglider requires a JSON file that describes the VM. 
                             "boot": true,
                             "initialize_params": {
                                 "disk_size_gb": 10,
-                                    "source_image": "projects/debian-cloud/global/images/family/debian-10"
+                                    "source_image": "projects/debian-cloud/global/images/family/debian-11"
                                 },
                             "type": "PERSISTENT"
                         }],

--- a/docs/source/overview/quickstart.rst
+++ b/docs/source/overview/quickstart.rst
@@ -259,7 +259,7 @@ To create VMs in clouds, Paraglider requires a JSON file that describes the VM. 
                             "boot": true,
                             "initialize_params": {
                                 "disk_size_gb": 10,
-                                    "source_image": "projects/debian-cloud/global/images/family/debian-11"
+                                    "source_image": "projects/ubuntu-os-cloud/global/images/family/ubuntu-2204-lts"
                                 },
                             "type": "PERSISTENT"
                         }],

--- a/pkg/gcp/plugin_utils.go
+++ b/pkg/gcp/plugin_utils.go
@@ -177,7 +177,7 @@ func GetTestVmParameters(project string, zone string, name string) *computepb.In
 				{
 					InitializeParams: &computepb.AttachedDiskInitializeParams{
 						DiskSizeGb:  proto.Int64(10),
-						SourceImage: proto.String("projects/debian-cloud/global/images/family/debian-10"),
+						SourceImage: proto.String("projects/debian-cloud/global/images/family/debian-11"),
 					},
 					AutoDelete: proto.Bool(true),
 					Boot:       proto.Bool(true),

--- a/pkg/gcp/plugin_utils.go
+++ b/pkg/gcp/plugin_utils.go
@@ -177,7 +177,7 @@ func GetTestVmParameters(project string, zone string, name string) *computepb.In
 				{
 					InitializeParams: &computepb.AttachedDiskInitializeParams{
 						DiskSizeGb:  proto.Int64(10),
-						SourceImage: proto.String("projects/debian-cloud/global/images/family/debian-11"),
+						SourceImage: proto.String("projects/ubuntu-os-cloud/global/images/family/ubuntu-2204-lts"),
 					},
 					AutoDelete: proto.Bool(true),
 					Boot:       proto.Bool(true),

--- a/pkg/gcp/plugin_utils.go
+++ b/pkg/gcp/plugin_utils.go
@@ -82,7 +82,7 @@ func SetupGcpTesting(testName string) string {
 		projectId = generateProjectId(testName)
 		if os.Getenv("GH_RUN_NUMBER") != "" {
 			// Use run number in project display name since it's more human readable
-			projectDisplayName = fmt.Sprintf("paraglider-gh-%s-%s", os.Getenv("GH_RUN_NUMBER"), testName)
+			projectDisplayName = fmt.Sprintf("glide-gh-%s-%s", os.Getenv("GH_RUN_NUMBER"), testName)
 		} else {
 			projectDisplayName = projectId
 		}
@@ -95,7 +95,7 @@ func SetupGcpTesting(testName string) string {
 		createProjectReq := &resourcemanagerpb.CreateProjectRequest{
 			Project: &resourcemanagerpb.Project{
 				ProjectId:   projectId,
-				DisplayName: projectDisplayName[:30],
+				DisplayName: projectDisplayName,
 				Parent:      os.Getenv("PARAGLIDER_GCP_PROJECT_PARENT"),
 			},
 		}

--- a/pkg/gcp/plugin_utils.go
+++ b/pkg/gcp/plugin_utils.go
@@ -95,7 +95,7 @@ func SetupGcpTesting(testName string) string {
 		createProjectReq := &resourcemanagerpb.CreateProjectRequest{
 			Project: &resourcemanagerpb.Project{
 				ProjectId:   projectId,
-				DisplayName: projectDisplayName,
+				DisplayName: projectDisplayName[:30],
 				Parent:      os.Getenv("PARAGLIDER_GCP_PROJECT_PARENT"),
 			},
 		}

--- a/tools/examples/vm-configs/azure-vm-eastus.json
+++ b/tools/examples/vm-configs/azure-vm-eastus.json
@@ -11,9 +11,9 @@
         },
         "storageProfile": {
             "imageReference": {
-                "offer": "debian-10",
-                "publisher": "Debian",
-                "sku": "10",
+                "offer": "0001-com-ubuntu-minimal-jammy",
+                "publisher": "canonical",
+                "sku": "minimal-22_04-lts-gen2",
                 "version": "latest"
             }
         }

--- a/tools/examples/vm-configs/azure-vm-westus.json
+++ b/tools/examples/vm-configs/azure-vm-westus.json
@@ -11,9 +11,9 @@
         },
         "storageProfile": {
             "imageReference": {
-                "offer": "debian-10",
-                "publisher": "Debian",
-                "sku": "10",
+                "offer": "0001-com-ubuntu-minimal-jammy",
+                "publisher": "canonical",
+                "sku": "minimal-22_04-lts-gen2",
                 "version": "latest"
             }
         }

--- a/tools/examples/vm-configs/gcp-vm.json
+++ b/tools/examples/vm-configs/gcp-vm.json
@@ -5,7 +5,7 @@
             "boot": true,
             "initialize_params": {
                 "disk_size_gb": 10,
-                    "source_image": "projects/debian-cloud/global/images/family/debian-11"
+                    "source_image": "projects/ubuntu-os-cloud/global/images/family/ubuntu-2204-lts"
                 },
             "type": "PERSISTENT"
         }],

--- a/tools/examples/vm-configs/gcp-vm.json
+++ b/tools/examples/vm-configs/gcp-vm.json
@@ -5,7 +5,7 @@
             "boot": true,
             "initialize_params": {
                 "disk_size_gb": 10,
-                    "source_image": "projects/debian-cloud/global/images/family/debian-10"
+                    "source_image": "projects/debian-cloud/global/images/family/debian-11"
                 },
             "type": "PERSISTENT"
         }],


### PR DESCRIPTION
**Display name**
Our GitHub run numbers have become reached 4 digits, leading to display names that end up being > 30 characters (GCP imposed limit). For now, I truncated the prefix from "paraglider" to "glide". That should provide enough leeway for a while.

**Debian 10**
GCP integration test is failing due to [Debian 10 reaching its end of life](https://www.debian.org/News/2024/20240615). This doesn't affect Azure tests because those use Ubuntu 22.04.

I updated everything (i.e., GCP tests, GCP docs, and Azure docs) to use Ubuntu 22.04. Azure tests require Ubuntu 22.04 due to the network watcher extension, so I figured it's best if we make it clean and make everything use Ubuntu 22.04. I believe IBM already uses it as well.