### PR TITLE
[Docs] Add edit button

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -47,4 +47,7 @@ html_theme_options = {
             "class": "",
         },
     ],
+    "source_repository": "https://github.com/paraglider-project/paraglider/",
+    "source_branch": "main",
+    "source_directory": "docs/source",
 }


### PR DESCRIPTION
Resolves #353. The view button will now also link to the file in GitHub rather than a raw dump.

@divega let me know if this is what you were thinking.

<img width="2032" alt="image" src="https://github.com/paraglider-project/paraglider/assets/12043327/fcf6ac34-f24c-4f31-92b0-1e2dc897a91f">
