### PR TITLE
[GCP] Refactor `RunPingConnectivityTest`

### DIFF
--- a/pkg/gcp/firewalls.go
+++ b/pkg/gcp/firewalls.go
@@ -117,7 +117,7 @@ func paragliderRuleToFirewallRule(namespace string, project string, firewallName
 		Description: proto.String(getRuleDescription(rule.Tags)),
 		Direction:   proto.String(firewallDirectionMapParagliderToGCP[rule.Direction]),
 		Name:        proto.String(firewallName),
-		Network:     proto.String(GetVpcUrl(project, namespace)),
+		Network:     proto.String(getVpcUrl(project, namespace)),
 		TargetTags:  []string{networkTag},
 	}
 	if rule.DstPort != -1 {

--- a/pkg/gcp/networks.go
+++ b/pkg/gcp/networks.go
@@ -45,8 +45,8 @@ func getSubnetworkUrl(project string, region string, name string) string {
 	return computeUrlPrefix + fmt.Sprintf("projects/%s/regions/%s/subnetworks/%s", project, region, name)
 }
 
-// GetVpcUrl returns a fully qualified URL for a VPC network
-func GetVpcUrl(project string, namespace string) string {
+// getVpcUrl returns a fully qualified URL for a VPC network
+func getVpcUrl(project string, namespace string) string {
 	return computeUrlPrefix + fmt.Sprintf("projects/%s/global/networks/%s", project, getVpcName(namespace))
 }
 
@@ -70,7 +70,7 @@ func peerVpcNetwork(ctx context.Context, networksClient *compute.NetworksClient,
 	}
 
 	// Add peering
-	peerVpcUrl := GetVpcUrl(peerProject, peerNamespace)
+	peerVpcUrl := getVpcUrl(peerProject, peerNamespace)
 	addPeeringNetworkReq := &computepb.AddPeeringNetworkRequest{
 		Network: getVpcName(currentNamespace),
 		Project: currentProject,

--- a/pkg/gcp/plugin.go
+++ b/pkg/gcp/plugin.go
@@ -401,7 +401,7 @@ func (s *GCPPluginServer) _CreateResource(ctx context.Context, resourceDescripti
 					DestinationRanges: []string{"0.0.0.0/0"},
 					Direction:         proto.String(computepb.Firewall_EGRESS.String()),
 					Name:              proto.String(getDenyAllIngressFirewallName(resourceDescription.Deployment.Namespace)),
-					Network:           proto.String(GetVpcUrl(project, resourceDescription.Deployment.Namespace)),
+					Network:           proto.String(getVpcUrl(project, resourceDescription.Deployment.Namespace)),
 					Priority:          proto.Int32(65534),
 				},
 			}
@@ -460,7 +460,7 @@ func (s *GCPPluginServer) _CreateResource(ctx context.Context, resourceDescripti
 			SubnetworkResource: &computepb.Subnetwork{
 				Name:        proto.String(subnetName),
 				Description: proto.String("Paraglider subnetwork for " + region),
-				Network:     proto.String(GetVpcUrl(project, resourceDescription.Deployment.Namespace)),
+				Network:     proto.String(getVpcUrl(project, resourceDescription.Deployment.Namespace)),
 				IpCidrRange: proto.String(addressSpaces[0]),
 			},
 		}
@@ -633,7 +633,7 @@ func (s *GCPPluginServer) _CreateVpnGateway(ctx context.Context, req *paraglider
 		VpnGatewayResource: &computepb.VpnGateway{
 			Name:        proto.String(getVpnGwName(req.Deployment.Namespace)),
 			Description: proto.String("Paraglider VPN gateway for multicloud connections"),
-			Network:     proto.String(GetVpcUrl(project, req.Deployment.Namespace)),
+			Network:     proto.String(getVpcUrl(project, req.Deployment.Namespace)),
 		},
 	}
 	insertVpnGatewayOp, err := vpnGatewaysClient.Insert(ctx, insertVpnGatewayReq)
@@ -667,7 +667,7 @@ func (s *GCPPluginServer) _CreateVpnGateway(ctx context.Context, req *paraglider
 		RouterResource: &computepb.Router{
 			Name:        proto.String(getRouterName(req.Deployment.Namespace)),
 			Description: proto.String("Paraglider router for multicloud connections"),
-			Network:     proto.String(GetVpcUrl(project, req.Deployment.Namespace)),
+			Network:     proto.String(getVpcUrl(project, req.Deployment.Namespace)),
 			Bgp: &computepb.RouterBgp{
 				Asn: proto.Uint32(asn),
 			},

--- a/pkg/gcp/plugin_integration_test.go
+++ b/pkg/gcp/plugin_integration_test.go
@@ -28,7 +28,6 @@ import (
 
 	compute "cloud.google.com/go/compute/apiv1"
 	computepb "cloud.google.com/go/compute/apiv1/computepb"
-	networkmanagementpb "cloud.google.com/go/networkmanagement/apiv1/networkmanagementpb"
 	fake "github.com/paraglider-project/paraglider/pkg/fake/orchestrator/rpc"
 	"github.com/paraglider-project/paraglider/pkg/orchestrator"
 	"github.com/paraglider-project/paraglider/pkg/orchestrator/config"
@@ -202,21 +201,9 @@ func TestIntegration(t *testing.T) {
 		assert.ElementsMatch(t, rules, getPermitListAfterAddResp.Rules)
 	}
 
-	// Connectivity tests that ping the two VMs
-	vm1Endpoint := &networkmanagementpb.Endpoint{
-		IpAddress: vm1Ip,
-		Network:   GetVpcUrl(projectId, namespace),
-		ProjectId: projectId,
-	}
-	vm2Endpoint := &networkmanagementpb.Endpoint{
-		IpAddress: vm2Ip,
-		Network:   GetVpcUrl(projectId, namespace),
-		ProjectId: projectId,
-	}
-
 	// Run connectivity tests on both directions between vm1 and vm2
-	RunPingConnectivityTest(t, projectId, "1to2", vm1Endpoint, vm2Endpoint)
-	RunPingConnectivityTest(t, projectId, "2to1", vm2Endpoint, vm1Endpoint)
+	RunPingConnectivityTest(t, projectId, "1to2", vm1Ip, namespace, vm2Ip)
+	RunPingConnectivityTest(t, projectId, "2to1", vm2Ip, namespace, vm1Ip)
 
 	// Delete permit lists
 	for i, vmId := range vmUrls {
@@ -349,18 +336,7 @@ func TestCrossNamespace(t *testing.T) {
 		require.NotNil(t, addPermitListRulesResp)
 	}
 
-	// Run connectivity tests
-	vm1Endpoint := &networkmanagementpb.Endpoint{
-		IpAddress: vm1Ip,
-		Network:   GetVpcUrl(project1Id, project1Namespace),
-		ProjectId: project1Id,
-	}
-	vm2Endpoint := &networkmanagementpb.Endpoint{
-		IpAddress: vm2Ip,
-		Network:   GetVpcUrl(project2Id, project2Namespace),
-		ProjectId: project2Id,
-	}
 	// Run connectivity tests on both directions between vm1 and vm2
-	RunPingConnectivityTest(t, project1Id, "vm1-to-vm2", vm1Endpoint, vm2Endpoint)
-	RunPingConnectivityTest(t, project2Id, "vm2-to-vm1", vm2Endpoint, vm1Endpoint)
+	RunPingConnectivityTest(t, project1Id, "vm1-to-vm2", vm1Ip, project1Namespace, vm2Ip)
+	RunPingConnectivityTest(t, project2Id, "vm2-to-vm1", vm2Ip, project2Namespace, vm1Ip)
 }

--- a/pkg/gcp/plugin_test.go
+++ b/pkg/gcp/plugin_test.go
@@ -49,7 +49,7 @@ func TestGetPermitList(t *testing.T) {
 				},
 				Direction:  proto.String(computepb.Firewall_INGRESS.String()),
 				Name:       proto.String("fw-allow-icmp"),
-				Network:    proto.String(GetVpcUrl(fakeProject, fakeNamespace)),
+				Network:    proto.String(getVpcUrl(fakeProject, fakeNamespace)),
 				TargetTags: []string{"0.0.0.0/0"},
 			},
 		},
@@ -108,7 +108,7 @@ func TestAddPermitListRules(t *testing.T) {
 	fakeServerState.instance.NetworkInterfaces = []*computepb.NetworkInterface{
 		{
 			Subnetwork: proto.String(fmt.Sprintf("regions/%s/subnetworks/%s", fakeRegion, "paraglider-"+fakeRegion+"-subnet")),
-			Network:    proto.String(GetVpcUrl(fakeProject, fakeNamespace)),
+			Network:    proto.String(getVpcUrl(fakeProject, fakeNamespace)),
 		},
 	}
 	fakeServer, ctx, fakeClients, fakeGRPCServer := setup(t, fakeServerState)
@@ -221,7 +221,7 @@ func TestAddPermitListRulesExistingRule(t *testing.T) {
 	fakeServerState.instance.NetworkInterfaces = []*computepb.NetworkInterface{
 		{
 			Subnetwork: proto.String(fmt.Sprintf("regions/%s/subnetworks/%s", fakeRegion, "paraglider-"+fakeRegion+"-subnet")),
-			Network:    proto.String(GetVpcUrl(fakeProject, fakeNamespace)),
+			Network:    proto.String(getVpcUrl(fakeProject, fakeNamespace)),
 		},
 	}
 	fakeServer, ctx, fakeClients, fakeGRPCServer := setup(t, fakeServerState)

--- a/pkg/gcp/plugin_test_utils.go
+++ b/pkg/gcp/plugin_test_utils.go
@@ -91,7 +91,7 @@ var (
 		},
 		Direction:    proto.String(computepb.Firewall_INGRESS.String()),
 		Name:         proto.String(getFirewallName(fakeNamespace, fakePermitListRule1.Name, convertInstanceIdToString(fakeInstanceId))),
-		Network:      proto.String(GetVpcUrl(fakeProject, fakeNamespace)),
+		Network:      proto.String(getVpcUrl(fakeProject, fakeNamespace)),
 		SourceRanges: []string{"10.1.2.0/24"},
 		TargetTags:   []string{fakeNetworkTag},
 		Description:  proto.String(getRuleDescription([]string{"tag1", "tag2"})),
@@ -114,7 +114,7 @@ var (
 		DestinationRanges: []string{"10.3.4.0/24"},
 		Direction:         proto.String(computepb.Firewall_EGRESS.String()),
 		Name:              proto.String(getFirewallName(fakeNamespace, fakePermitListRule2.Name, convertInstanceIdToString(fakeInstanceId))),
-		Network:           proto.String(GetVpcUrl(fakeProject, fakeNamespace)),
+		Network:           proto.String(getVpcUrl(fakeProject, fakeNamespace)),
 		TargetTags:        []string{fakeNetworkTag},
 	}
 )
@@ -130,7 +130,7 @@ func getFakeInstance(includeNetwork bool) *computepb.Instance {
 		instance.NetworkInterfaces = []*computepb.NetworkInterface{
 			{
 				NetworkIP:  proto.String("10.1.1.1"),
-				Network:    proto.String(GetVpcUrl(fakeProject, fakeNamespace)),
+				Network:    proto.String(getVpcUrl(fakeProject, fakeNamespace)),
 				Subnetwork: proto.String(fakeSubnetId),
 			},
 		}
@@ -154,7 +154,7 @@ func getFakeCluster(includeNetwork bool) *containerpb.Cluster {
 	}
 	if includeNetwork {
 		cluster.Subnetwork = fakeSubnetName
-		cluster.Network = GetVpcUrl(fakeProject, fakeNamespace)
+		cluster.Network = getVpcUrl(fakeProject, fakeNamespace)
 	}
 	return cluster
 }

--- a/pkg/gcp/plugin_utils.go
+++ b/pkg/gcp/plugin_utils.go
@@ -240,7 +240,7 @@ func RunPingConnectivityTest(t *testing.T, project string, name string, sourceIp
 			Protocol: "ICMP",
 			Source: &networkmanagementpb.Endpoint{
 				IpAddress: sourceIpAddress,
-				Network:   GetVpcUrl(project, sourceNamespace),
+				Network:   getVpcUrl(project, sourceNamespace),
 				ProjectId: project,
 			},
 			Destination: &networkmanagementpb.Endpoint{

--- a/pkg/gcp/plugin_utils.go
+++ b/pkg/gcp/plugin_utils.go
@@ -225,7 +225,7 @@ func GetInstanceId(project string, zone string, instanceName string) (uint64, er
 }
 
 // Runs connectivity test between two endpoints
-func RunPingConnectivityTest(t *testing.T, project string, name string, srcEndpoint *networkmanagementpb.Endpoint, dstEndpoint *networkmanagementpb.Endpoint) {
+func RunPingConnectivityTest(t *testing.T, project string, name string, sourceIpAddress string, sourceNamespace string, destinationIpAddress string) {
 	ctx := context.Background()
 	reachabilityClient, err := networkmanagement.NewReachabilityClient(ctx) // Can't use REST client for some reason (filed as bug within Google internally)
 	if err != nil {
@@ -236,10 +236,17 @@ func RunPingConnectivityTest(t *testing.T, project string, name string, srcEndpo
 		Parent: "projects/" + project + "/locations/global",
 		TestId: connectivityTestId,
 		Resource: &networkmanagementpb.ConnectivityTest{
-			Name:        "projects/" + project + "/locations/global/connectivityTests" + connectivityTestId,
-			Protocol:    "ICMP",
-			Source:      srcEndpoint,
-			Destination: dstEndpoint,
+			Name:     "projects/" + project + "/locations/global/connectivityTests" + connectivityTestId,
+			Protocol: "ICMP",
+			Source: &networkmanagementpb.Endpoint{
+				IpAddress: sourceIpAddress,
+				Network:   GetVpcUrl(project, sourceNamespace),
+				ProjectId: project,
+			},
+			Destination: &networkmanagementpb.Endpoint{
+				IpAddress:   destinationIpAddress,
+				NetworkType: networkmanagementpb.Endpoint_NON_GCP_NETWORK,
+			},
 		},
 	}
 	createConnectivityTestOp, err := reachabilityClient.CreateConnectivityTest(ctx, createConnectivityTestReq)

--- a/pkg/gcp/resources.go
+++ b/pkg/gcp/resources.go
@@ -265,7 +265,7 @@ func (r *gcpInstance) createWithNetwork(ctx context.Context, instance *computepb
 	// Configure network settings to Paraglider VPC and corresponding subnet
 	instance.InstanceResource.NetworkInterfaces = []*computepb.NetworkInterface{
 		{
-			Network:    proto.String(GetVpcUrl(resourceInfo.Project, resourceInfo.Namespace)),
+			Network:    proto.String(getVpcUrl(resourceInfo.Project, resourceInfo.Namespace)),
 			Subnetwork: proto.String(getSubnetworkUrl(resourceInfo.Project, resourceInfo.Region, subnetName)),
 		},
 	}
@@ -421,7 +421,7 @@ func (r *gcpGKE) createWithNetwork(ctx context.Context, cluster *containerpb.Cre
 				Description: proto.String("Paraglider allow cluster egress traffic"),
 				Direction:   proto.String(direction),
 				Name:        proto.String("paraglider-allow-control-plane-" + strings.ToLower(direction) + "-" + resourceInfo.Name),
-				Network:     proto.String(GetVpcUrl(resourceInfo.Project, resourceInfo.Namespace)),
+				Network:     proto.String(getVpcUrl(resourceInfo.Project, resourceInfo.Namespace)),
 				Priority:    proto.Int32(65500),
 				TargetTags:  []string{getClusterNodeTag(resourceInfo.Namespace, getClusterResp.Name, getClusterResp.Id)},
 			},

--- a/pkg/multicloud/multicloud_test.go
+++ b/pkg/multicloud/multicloud_test.go
@@ -24,7 +24,6 @@ import (
 	"strings"
 	"testing"
 
-	"cloud.google.com/go/networkmanagement/apiv1/networkmanagementpb"
 	"github.com/IBM/go-sdk-core/v5/core"
 	"github.com/IBM/vpc-go-sdk/vpcv1"
 	"github.com/google/uuid"
@@ -222,16 +221,7 @@ func TestMulticloud(t *testing.T) {
 	fmt.Println("Added Azure permit list rules")
 
 	// Run GCP connectivity tests (ping from GCP VM to Azure VM)
-	gcpConnectivityTest1GcpVmEndpoint := &networkmanagementpb.Endpoint{
-		IpAddress: gcpVmIpAddress,
-		Network:   gcp.GetVpcUrl(gcpProjectId, "other"),
-		ProjectId: gcpProjectId,
-	}
-	gcpConnectivityTest1AzureVmEndpoint := &networkmanagementpb.Endpoint{
-		IpAddress:   azureVm1IpAddress,
-		NetworkType: networkmanagementpb.Endpoint_NON_GCP_NETWORK,
-	}
-	gcp.RunPingConnectivityTest(t, gcpProjectId, "gcp-azure-1", gcpConnectivityTest1GcpVmEndpoint, gcpConnectivityTest1AzureVmEndpoint)
+	gcp.RunPingConnectivityTest(t, gcpProjectId, "gcp-azure-1", gcpVmIpAddress, "other", azureVm1IpAddress)
 
 	// Run Azure connectivity check (ping from Azure VM to GCP VM)
 	azureConnectivityCheck1, err := azure.RunPingConnectivityCheck(azureVm1ResourceId, gcpVmIpAddress, "default")
@@ -333,16 +323,7 @@ func TestMulticloud(t *testing.T) {
 	fmt.Println("Added Azure permit list rules")
 
 	// Run GCP connectivity tests (ping from GCP VM to Azure VM)
-	gcpConnectivityTest2GcpVmEndpoint := &networkmanagementpb.Endpoint{
-		IpAddress: gcpVmIpAddress,
-		Network:   gcp.GetVpcUrl(gcpProjectId, "other"),
-		ProjectId: gcpProjectId,
-	}
-	gcpConnectivityTest2AzureVmEndpoint := &networkmanagementpb.Endpoint{
-		IpAddress:   azureVm2IpAddress,
-		NetworkType: networkmanagementpb.Endpoint_NON_GCP_NETWORK,
-	}
-	gcp.RunPingConnectivityTest(t, gcpProjectId, "gcp-azure-2", gcpConnectivityTest2GcpVmEndpoint, gcpConnectivityTest2AzureVmEndpoint)
+	gcp.RunPingConnectivityTest(t, gcpProjectId, "gcp-azure-2", gcpVmIpAddress, "other", azureVm2IpAddress)
 
 	// Run Azure connectivity check (ping from Azure VM to GCP VM)
 	azureConnectivityCheck2, err := azure.RunPingConnectivityCheck(azureVm2ResourceId, gcpVmIpAddress, "default")


### PR DESCRIPTION
Changed the arguments of `RunPingConnectivityTest` such that users don't need to pass in `networkmanagement.networkmanagementpb.Endpoint`s. This is an exported function meant to be used in functional tests, so I presumed a new list of arguments with IP addresses and namespaces is better than using a specific GCP API struct.

Also fixes #158. Helps maintain consistency in how we export methods.