### PR TITLE
Update `GetUsedAddressSpaces` to use Paraglider vnet tags

### DIFF
--- a/pkg/azure/plugin.go
+++ b/pkg/azure/plugin.go
@@ -376,7 +376,7 @@ func (s *azurePluginServer) GetUsedAddressSpaces(ctx context.Context, req *parag
 			return nil, err
 		}
 
-		addressSpaces, err := azureHandler.GetParagaliderVirtualNetworks(ctx, getParagliderNamespacePrefix(deployment.Namespace))
+		addressSpaces, err := azureHandler.GetAllVnetsAddressSpaces(ctx, deployment.Namespace)
 		if err != nil {
 			utils.Log.Printf("An error occured while getting address spaces:%+v", err)
 			return nil, err
@@ -723,7 +723,7 @@ func (s *azurePluginServer) createPeering(ctx context.Context, azureHandler Azur
 	if err != nil {
 		return err
 	}
-	paragliderVnetsMap, err := peeringCloudAzureHandler.GetAllVnetsAddressSpaces(ctx, getParagliderNamespacePrefix(peeringCloudInfo.Namespace))
+	paragliderVnetsMap, err := peeringCloudAzureHandler.GetAllVnetsAddressSpaces(ctx, peeringCloudInfo.Namespace)
 	if err != nil {
 		return fmt.Errorf("unable to create vnets address spaces for peering cloud: %w", err)
 	}

--- a/pkg/azure/plugin.go
+++ b/pkg/azure/plugin.go
@@ -376,7 +376,7 @@ func (s *azurePluginServer) GetUsedAddressSpaces(ctx context.Context, req *parag
 			return nil, err
 		}
 
-		addressSpaces, err := azureHandler.GetAllVnetsAddressSpaces(ctx, getParagliderNamespacePrefix(deployment.Namespace))
+		addressSpaces, err := azureHandler.GetParagaliderVirtualNetworks(ctx, getParagliderNamespacePrefix(deployment.Namespace))
 		if err != nil {
 			utils.Log.Printf("An error occured while getting address spaces:%+v", err)
 			return nil, err

--- a/pkg/azure/plugin_test.go
+++ b/pkg/azure/plugin_test.go
@@ -519,6 +519,9 @@ func TestGetUsedAddressSpaces(t *testing.T) {
 					AddressPrefixes: []*string{to.Ptr(validAddressSpace)},
 				},
 			},
+			Tags: map[string]*string{
+				namespaceTagKey: to.Ptr(namespace),
+			},
 		},
 	}
 	fakeServer, ctx := SetupFakeAzureServer(t, serverState)

--- a/pkg/azure/sdk_handler.go
+++ b/pkg/azure/sdk_handler.go
@@ -290,39 +290,12 @@ func (h *AzureSDKHandler) DeleteSecurityRule(ctx context.Context, nsgName string
 	return nil
 }
 
-// GetParagaliderVirtualNetworks retrieves the address spaces of all virtual networks
-// that are managed by Paraglider
-//
-// Returns a map where the keys are the locations of the virtual networks
-// and the values are slices of address prefixes associated with each virtual network.
-func (h *AzureSDKHandler) GetParagaliderVirtualNetworks(ctx context.Context, prefix string) (map[string][]string, error) {
-	addressSpaces := make(map[string][]string)
-	pager := h.virtualNetworksClient.NewListPager(h.resourceGroupName, nil)
-	for pager.More() {
-		page, err := pager.NextPage(ctx)
-		if err != nil {
-			return nil, err
-		}
-
-		for _, v := range page.Value {
-			if strings.HasPrefix(*v.Name, prefix) || (v.Tags != nil && *v.Tags[namespaceTagKey] == h.paragliderNamespace) {
-				prefixes := make([]string, len(v.Properties.AddressSpace.AddressPrefixes))
-				for i, prefix := range v.Properties.AddressSpace.AddressPrefixes {
-					prefixes[i] = *prefix
-				}
-				addressSpaces[*v.Location] = prefixes
-			}
-		}
-	}
-	return addressSpaces, nil
-}
-
 // GetAllVnetsAddressSpaces retrieves the address spaces of all virtual networks
-// that have a name starting with the specified prefix.
+// in the specified namespace that are managed by Paraglider. i.e. Has the namespace tag.
 //
 // Returns a map where the keys are the locations of the virtual networks
 // and the values are slices of address prefixes associated with each virtual network.
-func (h *AzureSDKHandler) GetAllVnetsAddressSpaces(ctx context.Context, prefix string) (map[string][]string, error) {
+func (h *AzureSDKHandler) GetAllVnetsAddressSpaces(ctx context.Context, namespace string) (map[string][]string, error) {
 	addressSpaces := make(map[string][]string)
 	pager := h.virtualNetworksClient.NewListPager(h.resourceGroupName, nil)
 	for pager.More() {
@@ -330,13 +303,14 @@ func (h *AzureSDKHandler) GetAllVnetsAddressSpaces(ctx context.Context, prefix s
 		if err != nil {
 			return nil, err
 		}
+
 		for _, v := range page.Value {
-			if strings.HasPrefix(*v.Name, prefix) {
-				prefixes := make([]string, len(v.Properties.AddressSpace.AddressPrefixes))
-				for i, prefix := range v.Properties.AddressSpace.AddressPrefixes {
-					prefixes[i] = *prefix
+			if v.Tags != nil && *v.Tags[namespaceTagKey] == namespace {
+				addressPrefixes := make([]string, len(v.Properties.AddressSpace.AddressPrefixes))
+				for i, addressPrefix := range v.Properties.AddressSpace.AddressPrefixes {
+					addressPrefixes[i] = *addressPrefix
 				}
-				addressSpaces[*v.Location] = prefixes
+				addressSpaces[*v.Location] = addressPrefixes
 			}
 		}
 	}

--- a/pkg/azure/sdk_handler_test.go
+++ b/pkg/azure/sdk_handler_test.go
@@ -34,7 +34,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestGetVnetsWithMatchingPrefixAddressSpaces(t *testing.T) {
+func TestGetAllVnetsAddressSpaces(t *testing.T) {
 	// Set up the fake Azure server
 	fakeServerState := &fakeServerState{
 		subId:  subID,
@@ -48,7 +48,7 @@ func TestGetVnetsWithMatchingPrefixAddressSpaces(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("GetAllVnetsAddressSpaces: Success", func(t *testing.T) {
-		addresses, err := handler.GetAllVnetsAddressSpaces(ctx, paragliderPrefix)
+		addresses, err := handler.GetAllVnetsAddressSpaces(ctx, namespace)
 		require.NoError(t, err)
 		require.NotNil(t, addresses)
 		require.Len(t, addresses, 1)
@@ -57,13 +57,13 @@ func TestGetVnetsWithMatchingPrefixAddressSpaces(t *testing.T) {
 
 	t.Run("GetAllVnetsAddressSpaces: Failure - No Vnet", func(t *testing.T) {
 		fakeServerState.vnet = nil
-		addresses, err := handler.GetAllVnetsAddressSpaces(ctx, paragliderPrefix)
+		addresses, err := handler.GetAllVnetsAddressSpaces(ctx, namespace)
 		require.Error(t, err)
 		require.Nil(t, addresses)
 	})
 
-	t.Run("GetAllVnetsAddressSpaces: Failure - wrong name", func(t *testing.T) {
-		addresses, err := handler.GetAllVnetsAddressSpaces(ctx, "otherprefix")
+	t.Run("GetAllVnetsAddressSpaces: Failure - wrong namespace", func(t *testing.T) {
+		addresses, err := handler.GetAllVnetsAddressSpaces(ctx, "wrongNamespace")
 		require.Error(t, err)
 		require.Nil(t, addresses)
 	})

--- a/pkg/azure/test_utils.go
+++ b/pkg/azure/test_utils.go
@@ -480,6 +480,9 @@ func getFakeParagliderVirtualNetwork() *armnetwork.VirtualNetwork {
 				},
 			},
 		},
+		Tags: map[string]*string{
+			namespaceTagKey: to.Ptr(namespace),
+		},
 	}
 }
 


### PR DESCRIPTION
- Currently, `GetUsedAddressSpaces` checks the vnet name prefix to determine if the vnet is managed by Paraglider. 
- Since we're supporting external vnet attachments, this PR updates the function to use the namespace tags attached to every Paraglider managed vnet, instead of just the name
- Fixes #404 