### PR TITLE
[Docs] Improve Discord badge for better accessibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Paraglider
 
+![Discord](https://img.shields.io/discord/1116864463832891502?logo=discord&logoColor=white&logoSize=20&label=Discord&labelColor=7289DA&color=17cf48&link=https%3A%2F%2Fdiscord.gg%2FKrZGbfZ7wm)
+
+
 Paraglider is a cross-cloud control plane for configuring networking. 
 
 ![Paraglider Logo](logo.png)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 ![Discord](https://img.shields.io/discord/1116864463832891502?logo=discord&logoColor=white&logoSize=20&label=Discord&labelColor=7289DA&color=17cf48&link=https%3A%2F%2Fdiscord.gg%2FKrZGbfZ7wm)
 
-
 Paraglider is a cross-cloud control plane for configuring networking. 
 
 ![Paraglider Logo](logo.png)

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -4,11 +4,14 @@ Welcome to Paraglider!
 .. raw:: html
 
    <br />
-   <a href="https://discord.gg/KrZGbfZ7wm"><img src="https://dcbadge.vercel.app/api/server/KrZGbfZ7wm?compact=true&?compact=true" /></a>
    <a class="github-button" href="https://github.com/paraglider-project/paraglider" data-size="large" data-show-count="true" aria-label="Star paraglider-project/paraglider on GitHub">Star</a>
-
    <!-- Place this tag in your head or just before your close body tag. -->
    <script async defer src="https://buttons.github.io/buttons.js"></script>
+
+.. image:: https://img.shields.io/discord/1116864463832891502?logo=discord&logoColor=white&logoSize=auto&label=Discord&labelColor=7289DA&color=17cf48&link=https%3A%2F%2Fdiscord.gg%2FKrZGbfZ7wm
+   :alt: Discord
+   :target: https://discord.gg/KrZGbfZ7wm
+   :height: 28
 
 Paraglider is a cross-cloud control plane for configuring cloud networks. 
 


### PR DESCRIPTION
Added a Discord badge to our README for better accessibility and changed the one on the website so that the text "Discord" is searchable via cmd-f. @divega do you think this is sufficient enough for #375?

<img width="2032" alt="image" src="https://github.com/paraglider-project/paraglider/assets/12043327/38d52248-9cea-4529-9f9f-8b14f87a92b2">
<img width="2032" alt="Screenshot 2024-07-11 at 15 20 50" src="https://github.com/user-attachments/assets/46bd829b-e273-4f1a-8398-1804f4ec0bca">
