### PR TITLE
[Infra] Ignore more paths to reduce extraneous builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,14 +7,22 @@ on:
     tags:
       - v*
     paths-ignore:
+      - '.devcontainer/**'
+      - '.githooks/**'
       - 'docs/**'
+      - '**.md'
+      - '**.rst'
   pull_request:
     branches:
       - main
       - features/*
       - release/*
     paths-ignore:
+      - '.devcontainer/**'
+      - '.githooks/**'
       - 'docs/**'
+      - '**.md'
+      - '**.rst'
 
 concurrency:
   # Cancel the previously triggered build for only PR build.

--- a/.github/workflows/functional-tests-approval.yaml
+++ b/.github/workflows/functional-tests-approval.yaml
@@ -8,14 +8,22 @@ on:
     tags:
       - v*
     paths-ignore:
+      - '.devcontainer/**'
+      - '.githooks/**'
       - 'docs/**'
+      - '**.md'
+      - '**.rst'
   pull_request:
     branches:
       - main
       - features/*
       - release/*
     paths-ignore:
+      - '.devcontainer/**'
+      - '.githooks/**'
       - 'docs/**'
+      - '**.md'
+      - '**.rst'
 
 jobs:
   functional-tests-approval:


### PR DESCRIPTION
I updated our workflows to not run "Build and Test" and "Functional Test Approvals" for PRs that only change some files. The current reasoning behind each (listed under `paths-ignore` in the diff) is as follows.

- `.devcontainer/`: Not used in any of the build process, though this may change with #187
- `.githooks/`: same as above
- `docs/`: same as above (and already existed before this PR)
- `**.md`: excludes files such as README, CONTRIBUTING, CODE-OF-CONDUCT
- `**.rst`: not sure if this isn't covered anywhere that `docs/` doesn't cover since we don't use RST outside of docs but just as a safe measure

Resolves #259. @smcclure20 let me know your thoughts.