### PR TITLE
[Azure] Fix create peering

### DIFF
--- a/pkg/azure/plugin.go
+++ b/pkg/azure/plugin.go
@@ -739,17 +739,17 @@ func (s *azurePluginServer) createPeering(ctx context.Context, azureHandler Azur
 			// Create peering
 			err = azureHandler.CreateVnetPeeringOneWay(ctx, resourceVnetName, peeringVnetName, peeringCloudResourceIDInfo.SubscriptionID, peeringCloudResourceIDInfo.ResourceGroupName)
 			if err != nil {
-				return fmt.Errorf("C unable to create vnet peering: %w", err)
+				return fmt.Errorf("unable to create vnet peering: %w", err)
 			}
 			err = peeringCloudAzureHandler.CreateVnetPeeringOneWay(ctx, peeringVnetName, resourceVnetName, resourceIDInfo.SubscriptionID, resourceIDInfo.ResourceGroupName)
 			if err != nil {
-				return fmt.Errorf("B unable to create vnet peering: %w", err)
+				return fmt.Errorf("unable to create vnet peering: %w", err)
 			}
 			break
 		}
 	}
 	if !contained {
-		return fmt.Errorf("A unable to find vnet belonging to permit list rule target")
+		return fmt.Errorf("unable to find vnet belonging to permit list rule target")
 	}
 	return nil
 }

--- a/pkg/azure/resources.go
+++ b/pkg/azure/resources.go
@@ -88,7 +88,7 @@ func GetAndCheckResourceState(ctx context.Context, handler *AzureSDKHandler, res
 		return netInfo, nil
 	}
 
-	// Check the vnet tags for paraglider namespace
+	// Check the vnet tags for paraglider namespace if prefix doesn't match
 	vnet, err := handler.GetVirtualNetwork(ctx, vnetName)
 	if err != nil {
 		return nil, fmt.Errorf("Error in getting vnet %s: %w", vnetName, err)

--- a/pkg/azure/sdk_handler.go
+++ b/pkg/azure/sdk_handler.go
@@ -344,7 +344,7 @@ func (h *AzureSDKHandler) CreateVnetPeeringOneWay(ctx context.Context, vnet1Name
 			UseRemoteGateways: to.Ptr(false),
 		},
 	}
-	utils.Log.Printf("Vnet ID: %s", fmt.Sprintf(virtualNetworkResourceID, vnet2SubscriptionID, vnet2ResourceGroupName, vnet2Name))
+
 	_, err := h.CreateOrUpdateVirtualNetworkPeering(ctx, vnet1Name, getPeeringName(vnet1Name, vnet2Name), vnet1ToVnet2PeeringParameters)
 	if err != nil {
 		return err
@@ -484,8 +484,8 @@ func (h *AzureSDKHandler) GetSecurityGroup(ctx context.Context, nsgName string) 
 	return &nsgResp.SecurityGroup, nil
 }
 
-// GetParagliderVnet returns a valid paraglider vnet. A paraglider vnet is a vnet with a default subnet with the same
-// address space as the vnet and there is only one vnet per location
+// GetParagliderVnet returns a valid paraglider vnet. A paraglider vnet is a vnet created by Paraglider
+// with a default subnet with the same address space as the vnet and there is only one vnet per location
 func (h *AzureSDKHandler) GetParagliderVnet(ctx context.Context, vnetName string, location string, namespace string, orchestratorAddr string) (*armnetwork.VirtualNetwork, error) {
 	// Get the virtual network
 	res, err := h.virtualNetworksClient.Get(ctx, h.resourceGroupName, vnetName, &armnetwork.VirtualNetworksClientGetOptions{Expand: nil})

--- a/pkg/azure/sdk_handler.go
+++ b/pkg/azure/sdk_handler.go
@@ -293,7 +293,7 @@ func (h *AzureSDKHandler) DeleteSecurityRule(ctx context.Context, nsgName string
 // GetAllVnetsAddressSpaces retrieves the address spaces of all virtual networks
 // in the specified namespace that are managed by Paraglider. i.e. Has the namespace tag.
 //
-// Returns a map where the keys are the locations of the virtual networks
+// Returns a map where the keys are the names of the virtual networks
 // and the values are slices of address prefixes associated with each virtual network.
 func (h *AzureSDKHandler) GetAllVnetsAddressSpaces(ctx context.Context, namespace string) (map[string][]string, error) {
 	addressSpaces := make(map[string][]string)
@@ -310,7 +310,7 @@ func (h *AzureSDKHandler) GetAllVnetsAddressSpaces(ctx context.Context, namespac
 				for i, addressPrefix := range v.Properties.AddressSpace.AddressPrefixes {
 					addressPrefixes[i] = *addressPrefix
 				}
-				addressSpaces[*v.Location] = addressPrefixes
+				addressSpaces[*v.Name] = addressPrefixes
 			}
 		}
 	}
@@ -344,6 +344,7 @@ func (h *AzureSDKHandler) CreateVnetPeeringOneWay(ctx context.Context, vnet1Name
 			UseRemoteGateways: to.Ptr(false),
 		},
 	}
+	utils.Log.Printf("Vnet ID: %s", fmt.Sprintf(virtualNetworkResourceID, vnet2SubscriptionID, vnet2ResourceGroupName, vnet2Name))
 	_, err := h.CreateOrUpdateVirtualNetworkPeering(ctx, vnet1Name, getPeeringName(vnet1Name, vnet2Name), vnet1ToVnet2PeeringParameters)
 	if err != nil {
 		return err
@@ -483,7 +484,7 @@ func (h *AzureSDKHandler) GetSecurityGroup(ctx context.Context, nsgName string) 
 	return &nsgResp.SecurityGroup, nil
 }
 
-// GetParagliderVnet returns a valid paraglider vnet, a paraglider vnet is a vnet with a default subnet with the same
+// GetParagliderVnet returns a valid paraglider vnet. A paraglider vnet is a vnet with a default subnet with the same
 // address space as the vnet and there is only one vnet per location
 func (h *AzureSDKHandler) GetParagliderVnet(ctx context.Context, vnetName string, location string, namespace string, orchestratorAddr string) (*armnetwork.VirtualNetwork, error) {
 	// Get the virtual network
@@ -730,8 +731,8 @@ func (h *AzureSDKHandler) CreateAKSCluster(ctx context.Context, parameters armco
 	return &resp.ManagedCluster, nil
 }
 
-// GetVNet returns the virtual network with the given name
-func (h *AzureSDKHandler) GetVNet(ctx context.Context, vnetName string) (*armnetwork.VirtualNetwork, error) {
+// GetVnet returns the virtual network with the given name
+func (h *AzureSDKHandler) GetVnet(ctx context.Context, vnetName string) (*armnetwork.VirtualNetwork, error) {
 	vnet, err := h.virtualNetworksClient.Get(ctx, h.resourceGroupName, vnetName, nil)
 	if err != nil {
 		return nil, err

--- a/pkg/azure/sdk_handler_test.go
+++ b/pkg/azure/sdk_handler_test.go
@@ -52,7 +52,7 @@ func TestGetAllVnetsAddressSpaces(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, addresses)
 		require.Len(t, addresses, 1)
-		assert.Equal(t, addresses[testLocation], []string{validAddressSpace})
+		assert.Equal(t, addresses[validParagliderVnetName], []string{validAddressSpace})
 	})
 
 	t.Run("GetAllVnetsAddressSpaces: Failure - No Vnet", func(t *testing.T) {
@@ -534,7 +534,7 @@ func TestGetVnet(t *testing.T) {
 
 	// Test case: Success
 	t.Run("GetVnet: Success", func(t *testing.T) {
-		vnet, err := handler.GetVNet(ctx, validParagliderVnetName)
+		vnet, err := handler.GetVnet(ctx, validParagliderVnetName)
 
 		require.NoError(t, err)
 		require.NotNil(t, vnet)
@@ -543,7 +543,7 @@ func TestGetVnet(t *testing.T) {
 	// Test case: Failure
 	t.Run("GetVnet: Failure", func(t *testing.T) {
 		fakeServerState.vnet = nil
-		vnet, err := handler.GetVNet(ctx, validParagliderVnetName)
+		vnet, err := handler.GetVnet(ctx, validParagliderVnetName)
 
 		require.Error(t, err)
 		require.Nil(t, vnet)


### PR DESCRIPTION
- Create peering assumed the resource vnet name by prefixing the location with the paraglider prefix
- Updating to ensure that external vnets are supported
- Contributes to #170 