### PR TITLE
Pre-creation/attachment check at orchestrator level

### DIFF
--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -156,7 +156,7 @@ func parseSubscriberName(sub string) (string, string, string) {
 	return sub, "", ""
 }
 
-func createTagName(namespace string, cloud string, tag string) string {
+func getTagName(namespace string, cloud string, tag string) string {
 	return namespace + "." + cloud + "." + tag
 }
 
@@ -202,7 +202,7 @@ func (s *ControllerServer) getAndValidateResourceURLParams(c *gin.Context, resol
 	}
 
 	if resolveTag {
-		uri, err := s.getTagUri(createTagName(namespace, cloud, tag))
+		uri, err := s.getTagUri(getTagName(namespace, cloud, tag))
 		if err != nil {
 			return nil, "", err
 		}
@@ -1157,7 +1157,7 @@ func (s *ControllerServer) handleCreateOrAttachResource(c *gin.Context) {
 // Check the resource is valid to be created or attached at the orchestrator level
 func (s *ControllerServer) preCreateOrAttach(c *gin.Context, resourceInfo *ResourceInfo) error {
 	// Check if tag already exists
-	tagName := createTagName(resourceInfo.namespace, resourceInfo.cloud, resourceInfo.name)
+	tagName := getTagName(resourceInfo.namespace, resourceInfo.cloud, resourceInfo.name)
 	if tagName == "" {
 		c.AbortWithStatusJSON(400, createErrorResponse("unable to create tag name"))
 		return fmt.Errorf("unable to create tag name")
@@ -1253,7 +1253,7 @@ func (s *ControllerServer) createTag(c *gin.Context, resourceInfo *ResourceInfo,
 	}
 	defer conn.Close()
 
-	tagName := createTagName(resourceInfo.namespace, resourceInfo.cloud, resourceInfo.name)
+	tagName := getTagName(resourceInfo.namespace, resourceInfo.cloud, resourceInfo.name)
 	tagClient := tagservicepb.NewTagServiceClient(conn)
 	_, err = tagClient.SetTag(context.Background(), &tagservicepb.SetTagRequest{Tag: &tagservicepb.TagMapping{Name: tagName, Uri: &uri, Ip: &ip}})
 	if err != nil {


### PR DESCRIPTION
- Checks that a resource tag does not already exist before creating or attaching a resource
- Closes #429 