### PR TITLE
[Infra] Add manual trigger for functional tests

### DIFF
--- a/.github/workflows/functional-tests.yaml
+++ b/.github/workflows/functional-tests.yaml
@@ -1,6 +1,12 @@
 name: Functional Tests
 
 on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "Branch to pull the workflow and code file from"
+        required: true
+        default: "main"
   workflow_run:
     workflows: [Functional Tests Approval]
     types:
@@ -35,15 +41,20 @@ jobs:
       pull-requests: write
     steps:
       - name: Download commit SHA artifact
+        if: github.event_name == 'workflow_run'
         uses: dawidd6/action-download-artifact@v6
         with:
           name: commit_sha
           run_id: ${{ github.event.workflow_run.id }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Extract commit SHA
-        id: extract-commit-sha
+        if: github.event_name == 'workflow_run'
         run: |
-          echo "commit_sha=$(cat commit_sha)" >> $GITHUB_OUTPUT
+          echo "CHECKOUT_REF=$(cat commit_sha)" >> $GITHUB_ENV
+      - name: Get checkout ref from input
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          echo "CHECKOUT_REF=${{ github.event.inputs.branch }}" >> $GITHUB_ENV
       - name: Add to check run
         uses: LouisBrunner/checks-action@v2.0.0
         if: always()
@@ -57,7 +68,7 @@ jobs:
       - name: Check out repo
         uses: actions/checkout@v4
         with:
-          ref: ${{ steps.extract-commit-sha.outputs.commit_sha }}
+          ref: ${{ env.CHECKOUT_REF }}
       - name: Set up Go ${{ env.GOVER }}
         uses: actions/setup-go@v5
         with:


### PR DESCRIPTION
This adds a manual trigger so that we can trigger the functional tests manually with the workflow file of a branch for the PR instead of pulling from main. No security concerns as only people with write access to the repo are allowed to manually trigger.

The caveat to this is that the checks shown at the bottom of the PR will still show failures from the auto triggered version. For any PRs that require changes to workflow files (which shouldn't be too many), we'll have to override the checks requirement and just merge as long as the manual triggered run passes tests.