### PR TITLE
[Infra] Fix description of input for functional test manual trigger

### DIFF
--- a/.github/workflows/functional-tests.yaml
+++ b/.github/workflows/functional-tests.yaml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       branch:
-        description: "Branch to pull the workflow and code file from"
+        description: "Branch to checkout the code from"
         required: true
         default: "main"
   workflow_run:


### PR DESCRIPTION
Turns out there already exists a separate dropdown to select which branch's workflow file to use.

<img width="2032" alt="image" src="https://github.com/user-attachments/assets/78dc176d-cb99-459a-9d45-098a2cfb32bf">
