### PR TITLE
Allow rules for GetPermitList

### DIFF
--- a/pkg/azure/plugin.go
+++ b/pkg/azure/plugin.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"net"
 	"os"
-	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v4"
@@ -90,7 +89,7 @@ func (s *azurePluginServer) GetPermitList(ctx context.Context, req *paragliderpb
 
 	// get the NSG rules
 	for _, rule := range nsg.Properties.SecurityRules {
-		if !strings.HasPrefix(*rule.Name, denyAllNsgRulePrefix) && strings.HasPrefix(*rule.Name, paragliderPrefix) {
+		if *rule.Properties.Access == allowRule {
 			plRule, err := azureHandler.GetPermitListRuleFromNSGRule(rule)
 			if err != nil {
 				utils.Log.Printf("An error occured while getting Paraglider rule from NSG rule: %+v", err)


### PR DESCRIPTION
- `GetPermitList` checks if a rule is an allow rule before converting to Permit List
- However, it did this by checking if the prefix of the name is "paraglider...".
- For attached resources, the name of the rule may not conform to paraglider naming requirement