### PR TITLE
Doesn't Allocate Address Space for Non-Google Services

### DIFF
--- a/pkg/gcp/resources.go
+++ b/pkg/gcp/resources.go
@@ -661,7 +661,6 @@ func (r *privateServiceHandler) getResourceInfo(ctx context.Context, resource *p
 
 // Get the subnet requirements for a private service connect attachment
 func (r *privateServiceHandler) getNumberAddressSpacesRequired(description *ServiceAttachmentDescription) int {
-	// return 1 // Only used for GCP services (TODO: Change this to depend on that)
 	if description.Bundle != "" {
 		return 1
 	}

--- a/pkg/gcp/resources.go
+++ b/pkg/gcp/resources.go
@@ -656,12 +656,17 @@ func (r *privateServiceHandler) getResourceInfo(ctx context.Context, resource *p
 		region = globalRegion
 	}
 
-	return &resourceInfo{Region: region, NumAdditionalAddressSpaces: r.getNumberAddressSpacesRequired(), ResourceType: privateServiceConnectTypeName, Name: resource.Name}, nil
+	return &resourceInfo{Region: region, NumAdditionalAddressSpaces: r.getNumberAddressSpacesRequired(description), ResourceType: privateServiceConnectTypeName, Name: resource.Name}, nil
 }
 
 // Get the subnet requirements for a private service connect attachment
-func (r *privateServiceHandler) getNumberAddressSpacesRequired() int {
-	return 1 // Only used for GCP services (TODO: Change this to depend on that)
+func (r *privateServiceHandler) getNumberAddressSpacesRequired(description *ServiceAttachmentDescription) int {
+	// return 1 // Only used for GCP services (TODO: Change this to depend on that)
+	if description.Bundle != "" {
+		return 1
+	}
+
+	return 0
 }
 
 // Get the firewall target type and value for a specific service attachment

--- a/pkg/gcp/resources_test.go
+++ b/pkg/gcp/resources_test.go
@@ -449,6 +449,21 @@ func TestPrivateServiceGetResourceInfo(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Equal(t, fakeRegion, resourceInfo.Region)
+	assert.Equal(t, 0, resourceInfo.NumAdditionalAddressSpaces)
+	assert.Equal(t, privateServiceConnectTypeName, resourceInfo.ResourceType)
+	assert.Equal(t, fakePscName, resourceInfo.Name)
+}
+
+func TestGCPPrivateServiceGetResourceInfo(t *testing.T) {
+	pscHandler := &privateServiceHandler{}
+	resource, _, err := getFakePSCRequest(true)
+	require.NoError(t, err)
+
+	resourceInfo, err := pscHandler.getResourceInfo(context.Background(), resource)
+
+	require.NoError(t, err)
+	assert.Equal(t, "global", resourceInfo.Region)
+	assert.Equal(t, 1, resourceInfo.NumAdditionalAddressSpaces)
 	assert.Equal(t, privateServiceConnectTypeName, resourceInfo.ResourceType)
 	assert.Equal(t, fakePscName, resourceInfo.Name)
 }

--- a/pkg/gcp/resources_test.go
+++ b/pkg/gcp/resources_test.go
@@ -444,7 +444,6 @@ func TestPrivateServiceGetResourceInfo(t *testing.T) {
 	pscHandler := &privateServiceHandler{}
 	resource, _, err := getFakePSCRequest(false)
 	require.NoError(t, err)
-
 	resourceInfo, err := pscHandler.getResourceInfo(context.Background(), resource)
 
 	require.NoError(t, err)
@@ -458,7 +457,6 @@ func TestPrivateServiceGetResourceInfoGoogleService(t *testing.T) {
 	pscHandler := &privateServiceHandler{}
 	resource, _, err := getFakePSCRequest(true)
 	require.NoError(t, err)
-
 	resourceInfo, err := pscHandler.getResourceInfo(context.Background(), resource)
 
 	require.NoError(t, err)

--- a/pkg/gcp/resources_test.go
+++ b/pkg/gcp/resources_test.go
@@ -454,7 +454,7 @@ func TestPrivateServiceGetResourceInfo(t *testing.T) {
 	assert.Equal(t, fakePscName, resourceInfo.Name)
 }
 
-func TestGCPPrivateServiceGetResourceInfo(t *testing.T) {
+func TestPrivateServiceGetResourceInfoGoogleService(t *testing.T) {
 	pscHandler := &privateServiceHandler{}
 	resource, _, err := getFakePSCRequest(true)
 	require.NoError(t, err)

--- a/pkg/gcp/resources_test.go
+++ b/pkg/gcp/resources_test.go
@@ -444,7 +444,6 @@ func TestPrivateServiceGetResourceInfo(t *testing.T) {
 	pscHandler := &privateServiceHandler{}
 	resource, _, err := getFakePSCRequest(false)
 	require.NoError(t, err)
-
 	resourceInfo, err := pscHandler.getResourceInfo(context.Background(), resource)
 
 	require.NoError(t, err)
@@ -458,7 +457,6 @@ func TestPrivateServiceGetResourceInfoGoogleService(t *testing.T) {
 	pscHandler := &privateServiceHandler{}
 	resource, _, err := getFakePSCRequest(true)
 	require.NoError(t, err)
-	
 	resourceInfo, err := pscHandler.getResourceInfo(context.Background(), resource)
 
 	require.NoError(t, err)

--- a/pkg/gcp/resources_test.go
+++ b/pkg/gcp/resources_test.go
@@ -444,6 +444,7 @@ func TestPrivateServiceGetResourceInfo(t *testing.T) {
 	pscHandler := &privateServiceHandler{}
 	resource, _, err := getFakePSCRequest(false)
 	require.NoError(t, err)
+
 	resourceInfo, err := pscHandler.getResourceInfo(context.Background(), resource)
 
 	require.NoError(t, err)
@@ -457,6 +458,7 @@ func TestPrivateServiceGetResourceInfoGoogleService(t *testing.T) {
 	pscHandler := &privateServiceHandler{}
 	resource, _, err := getFakePSCRequest(true)
 	require.NoError(t, err)
+	
 	resourceInfo, err := pscHandler.getResourceInfo(context.Background(), resource)
 
 	require.NoError(t, err)


### PR DESCRIPTION
Returns 0 for non-Google services in `getNumberAddressSpacesRequired()`.