### PR TITLE
[GCP] [Draft] Compliance Tests of a Resource with Paraglider

### DIFF
--- a/pkg/gcp/firewalls.go
+++ b/pkg/gcp/firewalls.go
@@ -261,23 +261,12 @@ func CheckFirewallRulesCompliance(firewalls []*computepb.Firewall) (bool, error)
 	return true, nil
 }
 
-// Iterates and locates the deny-all firewall rule with the lowest priority
-func findDenyAllRule(firewalls []*computepb.Firewall) *computepb.Firewall {
-	var denyAllRule *computepb.Firewall
-	lowestSeenPriority := int32(lowestPriority)
-
-	for _, fw := range firewalls {
-		if isDenyAllRule(fw) && fw.GetPriority() >= lowestSeenPriority {
-			lowestSeenPriority = fw.GetPriority()
-			denyAllRule = fw
-		}
-	}
-
-	return denyAllRule
-}
-
 // Checks if a firewall rule is a deny-all rule
 func isDenyAllRule(fw *computepb.Firewall) bool {
+	if fw == nil {
+		return false
+	}
+
 	return len(fw.Denied) > 0 &&
 		len(fw.Allowed) == 0 &&
 		strings.ToLower(fw.Denied[0].GetIPProtocol()) == "all"

--- a/pkg/gcp/firewalls.go
+++ b/pkg/gcp/firewalls.go
@@ -236,13 +236,20 @@ func getFirewallNamePrefix(namespace string) string {
 // 2. All higher-priority rules (lower numbers) are allow rules
 func CheckFirewallRulesCompliance(firewalls []*computepb.Firewall) (bool, error) {
 	var denyAll *computepb.Firewall
-	for _, rule := range firewalls {
-		if isDenyAllRule(rule) {
-			if !hasValidDestinationRanges(rule) {
-				return false, fmt.Errorf("deny-all rule does not have DestinationRanges set to '0.0.0.0/0'")
-			}
-			if denyAll == nil || rule.GetPriority() > denyAll.GetPriority() {
-				denyAll = rule
+	var highestDenyPrio = int32(lowestPriority)
+	for _, firewall := range firewalls {
+		println("highest seen", highestDenyPrio)
+		if len(firewall.Denied) > 0 {
+			if isDenyRule(firewall) {
+				if strings.ToLower(firewall.Denied[0].GetIPProtocol()) == "all" {
+					denyAll = firewall
+				}
+				if firewall.GetPriority() < int32(highestDenyPrio) {
+					highestDenyPrio = firewall.GetPriority()
+					println("new highest seen", highestDenyPrio)
+
+				}
+
 			}
 		}
 	}
@@ -251,33 +258,25 @@ func CheckFirewallRulesCompliance(firewalls []*computepb.Firewall) (bool, error)
 		return false, fmt.Errorf("no deny-all rule found")
 	}
 
-	denyAllPriority := denyAll.GetPriority()
-	for _, rule := range firewalls {
-		if rule.GetPriority() < denyAllPriority && rule.GetAllowed() == nil {
-			return false, fmt.Errorf("non-allow rule found with higher priority than deny-all")
-		}
+	if denyAll.GetPriority() > highestDenyPrio {
+		return false, fmt.Errorf("found a deny rule with higher priority than deny-all")
 	}
 
 	return true, nil
 }
 
-// Checks if a firewall rule is a deny-all rule
-func isDenyAllRule(fw *computepb.Firewall) bool {
-	if fw == nil {
+// Checks if a firewall rule is a deny rule
+func isDenyRule(firewall *computepb.Firewall) bool {
+	if firewall == nil {
 		return false
 	}
 
-	return len(fw.Denied) > 0 &&
-		len(fw.Allowed) == 0 &&
-		strings.ToLower(fw.Denied[0].GetIPProtocol()) == "all"
-}
-
-// Checks that DestinationRanges is set to "0.0.0.0/0"
-func hasValidDestinationRanges(fw *computepb.Firewall) bool {
-	for _, rangeValue := range fw.GetDestinationRanges() {
-		if rangeValue == "0.0.0.0/0" {
-			return true
+	// Checks that DestinationRanges is set to "0.0.0.0/0"
+	for _, rangeValue := range firewall.GetDestinationRanges() {
+		if rangeValue != "0.0.0.0/0" {
+			return false
 		}
 	}
-	return false
+
+	return len(firewall.Allowed) == 0 && len(firewall.Denied) > 0
 }

--- a/pkg/gcp/firewalls.go
+++ b/pkg/gcp/firewalls.go
@@ -239,11 +239,10 @@ func CheckFirewallRulesCompliance(firewalls []*computepb.Firewall) (bool, error)
 	var highestDenyPrio = int32(lowestPriority)
 	for _, firewall := range firewalls {
 		println("highest seen", highestDenyPrio)
+
 		if len(firewall.Denied) > 0 {
-			if isDenyRule(firewall) {
-				if strings.ToLower(firewall.Denied[0].GetIPProtocol()) == "all" {
-					denyAll = firewall
-				}
+			if isDenyAllRule(firewall) {
+				denyAll = firewall
 				if firewall.GetPriority() < int32(highestDenyPrio) {
 					highestDenyPrio = firewall.GetPriority()
 					println("new highest seen", highestDenyPrio)
@@ -266,7 +265,7 @@ func CheckFirewallRulesCompliance(firewalls []*computepb.Firewall) (bool, error)
 }
 
 // Checks if a firewall rule is a deny rule
-func isDenyRule(firewall *computepb.Firewall) bool {
+func isDenyAllRule(firewall *computepb.Firewall) bool {
 	if firewall == nil {
 		return false
 	}
@@ -278,5 +277,7 @@ func isDenyRule(firewall *computepb.Firewall) bool {
 		}
 	}
 
-	return len(firewall.Allowed) == 0 && len(firewall.Denied) > 0
+	return len(firewall.Denied) > 0 &&
+		len(firewall.Allowed) == 0 &&
+		strings.ToLower(firewall.Denied[0].GetIPProtocol()) == "all"
 }

--- a/pkg/gcp/firewalls.go
+++ b/pkg/gcp/firewalls.go
@@ -238,15 +238,11 @@ func CheckFirewallRulesCompliance(firewalls []*computepb.Firewall) (bool, error)
 	var denyAll *computepb.Firewall
 	var highestDenyPrio = int32(lowestPriority)
 	for _, firewall := range firewalls {
-		println("highest seen", highestDenyPrio)
-
 		if len(firewall.Denied) > 0 {
 			if isDenyAllRule(firewall) {
 				denyAll = firewall
 				if firewall.GetPriority() < int32(highestDenyPrio) {
 					highestDenyPrio = firewall.GetPriority()
-					println("new highest seen", highestDenyPrio)
-
 				}
 
 			}

--- a/pkg/gcp/firewalls_test.go
+++ b/pkg/gcp/firewalls_test.go
@@ -1,225 +1,225 @@
 package gcp
 
-import (
-	"testing"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"cloud.google.com/go/compute/apiv1/computepb"
-	"google.golang.org/protobuf/proto"
-)
+// import (
+// 	"testing"
+// 	"github.com/stretchr/testify/assert"
+// 	"github.com/stretchr/testify/require"
+// 	"cloud.google.com/go/compute/apiv1/computepb"
+// 	"google.golang.org/protobuf/proto"
+// )
 
-func TestCheckFirewallRulesCompliance(t *testing.T) {
-	tests := []struct {
-		name        string
-		firewalls   []*computepb.Firewall
-		expected    bool
-		expectedErr string
-	}{
-		{
-			name: "Valid deny-all rule and compliant allow rules",
-			firewalls: []*computepb.Firewall{
-				{
-					Priority:        proto.Int32(100),
-					Allowed:         []*computepb.Allowed{{IPProtocol: proto.String("tcp")}}, // Correct way to refer to Allowed
-					Denied:          nil,
-					DestinationRanges: []string{"0.0.0.0/0"},
-				},
-				{
-					Priority:        proto.Int32(200),
-					Allowed:         nil,
-					Denied:          []*computepb.Denied{{IPProtocol: proto.String("all")}}, // Correct way to refer to Denied
-					DestinationRanges: []string{"0.0.0.0/0"},
-				},
-				{
-					Priority:        proto.Int32(300),
-					Allowed:         []*computepb.Allowed{{IPProtocol: proto.String("icmp")}},
-					Denied:          nil,
-					DestinationRanges: []string{"0.0.0.0/0"},
-				},
-			},
-			expected:    true,
-			expectedErr: "",
-		},
-		{
-			name: "No deny-all rule",
-			firewalls: []*computepb.Firewall{
-				{
-					Priority:        proto.Int32(100),
-					Allowed:         []*computepb.Allowed{{IPProtocol: proto.String("tcp")}},
-					Denied:          nil,
-					DestinationRanges: []string{"0.0.0.0/0"},
-				},
-			},
-			expected:    false,
-			expectedErr: "no deny-all rule found",
-		},
-		{
-			name: "Deny-all rule with invalid destination range",
-			firewalls: []*computepb.Firewall{
-				{
-					Priority:        proto.Int32(200),
-					Allowed:         nil,
-					Denied:          []*computepb.Denied{{IPProtocol: proto.String("all")}},
-					DestinationRanges: []string{"192.168.0.0/16"},
-				},
-			},
-			expected:    false,
-			expectedErr: "deny-all rule does not have DestinationRanges set to '0.0.0.0/0'",
-		},
-		{
-			name: "Non-allow rule above deny-all",
-			firewalls: []*computepb.Firewall{
-				{
-					Priority:        proto.Int32(100),
-					Allowed:         nil,
-					Denied:          []*computepb.Denied{{IPProtocol: proto.String("all")}},
-					DestinationRanges: []string{"0.0.0.0/0"},
-				},
-				{
-					Priority:        proto.Int32(50),
-					Allowed:         nil,
-					Denied:          []*computepb.Denied{{IPProtocol: proto.String("icmp")}},
-					DestinationRanges: []string{"0.0.0.0/0"},
-				},
-			},
-			expected:    false,
-			expectedErr: "non-allow rule found with higher priority than deny-all",
-		},
-	}
+// func TestCheckFirewallRulesCompliance(t *testing.T) {
+// 	tests := []struct {
+// 		name        string
+// 		firewalls   []*computepb.Firewall
+// 		expected    bool
+// 		expectedErr string
+// 	}{
+// 		{
+// 			name: "Valid deny-all rule and compliant allow rules",
+// 			firewalls: []*computepb.Firewall{
+// 				{
+// 					Priority:        proto.Int32(100),
+// 					Allowed:         []*computepb.Allowed{{IPProtocol: proto.String("tcp")}}, // Correct way to refer to Allowed
+// 					Denied:          nil,
+// 					DestinationRanges: []string{"0.0.0.0/0"},
+// 				},
+// 				{
+// 					Priority:        proto.Int32(200),
+// 					Allowed:         nil,
+// 					Denied:          []*computepb.Denied{{IPProtocol: proto.String("all")}}, // Correct way to refer to Denied
+// 					DestinationRanges: []string{"0.0.0.0/0"},
+// 				},
+// 				{
+// 					Priority:        proto.Int32(300),
+// 					Allowed:         []*computepb.Allowed{{IPProtocol: proto.String("icmp")}},
+// 					Denied:          nil,
+// 					DestinationRanges: []string{"0.0.0.0/0"},
+// 				},
+// 			},
+// 			expected:    true,
+// 			expectedErr: "",
+// 		},
+// 		{
+// 			name: "No deny-all rule",
+// 			firewalls: []*computepb.Firewall{
+// 				{
+// 					Priority:        proto.Int32(100),
+// 					Allowed:         []*computepb.Allowed{{IPProtocol: proto.String("tcp")}},
+// 					Denied:          nil,
+// 					DestinationRanges: []string{"0.0.0.0/0"},
+// 				},
+// 			},
+// 			expected:    false,
+// 			expectedErr: "no deny-all rule found",
+// 		},
+// 		{
+// 			name: "Deny-all rule with invalid destination range",
+// 			firewalls: []*computepb.Firewall{
+// 				{
+// 					Priority:        proto.Int32(200),
+// 					Allowed:         nil,
+// 					Denied:          []*computepb.Denied{{IPProtocol: proto.String("all")}},
+// 					DestinationRanges: []string{"192.168.0.0/16"},
+// 				},
+// 			},
+// 			expected:    false,
+// 			expectedErr: "deny-all rule does not have DestinationRanges set to '0.0.0.0/0'",
+// 		},
+// 		{
+// 			name: "Non-allow rule above deny-all",
+// 			firewalls: []*computepb.Firewall{
+// 				{
+// 					Priority:        proto.Int32(100),
+// 					Allowed:         nil,
+// 					Denied:          []*computepb.Denied{{IPProtocol: proto.String("all")}},
+// 					DestinationRanges: []string{"0.0.0.0/0"},
+// 				},
+// 				{
+// 					Priority:        proto.Int32(50),
+// 					Allowed:         nil,
+// 					Denied:          []*computepb.Denied{{IPProtocol: proto.String("icmp")}},
+// 					DestinationRanges: []string{"0.0.0.0/0"},
+// 				},
+// 			},
+// 			expected:    false,
+// 			expectedErr: "non-allow rule found with higher priority than deny-all",
+// 		},
+// 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			compliant, err := CheckFirewallRulesCompliance(tt.firewalls)
-			if tt.expectedErr != "" {
-				require.Error(t, err)
-				assert.Equal(t, tt.expectedErr, err.Error())
-			} else {
-				require.NoError(t, err)
-				assert.Equal(t, tt.expected, compliant)
-			}
-		})
-	}
-}
+// 	for _, tt := range tests {
+// 		t.Run(tt.name, func(t *testing.T) {
+// 			compliant, err := CheckFirewallRulesCompliance(tt.firewalls)
+// 			if tt.expectedErr != "" {
+// 				require.Error(t, err)
+// 				assert.Equal(t, tt.expectedErr, err.Error())
+// 			} else {
+// 				require.NoError(t, err)
+// 				assert.Equal(t, tt.expected, compliant)
+// 			}
+// 		})
+// 	}
+// }
 
-func TestFindDenyAllRule(t *testing.T) {
-	tests := []struct {
-		name       string
-		firewalls  []*computepb.Firewall
-		expectRule *computepb.Firewall
-	}{
-		{
-			name: "Deny-all rule exists with the lowest priority",
-			firewalls: []*computepb.Firewall{
-				{
-					Priority:        proto.Int32(100),
-					Allowed:         nil,
-					Denied:          []*computepb.Denied{{IPProtocol: proto.String("all")}},
-					DestinationRanges: []string{"0.0.0.0/0"},
-				},
-				{
-					Priority:        proto.Int32(200),
-					Allowed:         nil,
-					Denied:          []*computepb.Denied{{IPProtocol: proto.String("all")}},
-					DestinationRanges: []string{"0.0.0.0/0"},
-				},
-			},
-			expectRule: &computepb.Firewall{
-				Priority:        proto.Int32(200),
-				Allowed:         nil,
-				Denied:          []*computepb.Denied{{IPProtocol: proto.String("all")}},
-				DestinationRanges: []string{"0.0.0.0/0"},
-			},
-		},
-		{
-			name: "No deny-all rule",
-			firewalls: []*computepb.Firewall{
-				{
-					Priority:        proto.Int32(100),
-					Allowed:         []*computepb.Allowed{{IPProtocol: proto.String("tcp")}},
-					Denied:          nil,
-					DestinationRanges: []string{"0.0.0.0/0"},
-				},
-			},
-			expectRule: nil,
-		},
-	}
+// func TestFindDenyAllRule(t *testing.T) {
+// 	tests := []struct {
+// 		name       string
+// 		firewalls  []*computepb.Firewall
+// 		expectRule *computepb.Firewall
+// 	}{
+// 		{
+// 			name: "Deny-all rule exists with the lowest priority",
+// 			firewalls: []*computepb.Firewall{
+// 				{
+// 					Priority:        proto.Int32(100),
+// 					Allowed:         nil,
+// 					Denied:          []*computepb.Denied{{IPProtocol: proto.String("all")}},
+// 					DestinationRanges: []string{"0.0.0.0/0"},
+// 				},
+// 				{
+// 					Priority:        proto.Int32(200),
+// 					Allowed:         nil,
+// 					Denied:          []*computepb.Denied{{IPProtocol: proto.String("all")}},
+// 					DestinationRanges: []string{"0.0.0.0/0"},
+// 				},
+// 			},
+// 			expectRule: &computepb.Firewall{
+// 				Priority:        proto.Int32(200),
+// 				Allowed:         nil,
+// 				Denied:          []*computepb.Denied{{IPProtocol: proto.String("all")}},
+// 				DestinationRanges: []string{"0.0.0.0/0"},
+// 			},
+// 		},
+// 		{
+// 			name: "No deny-all rule",
+// 			firewalls: []*computepb.Firewall{
+// 				{
+// 					Priority:        proto.Int32(100),
+// 					Allowed:         []*computepb.Allowed{{IPProtocol: proto.String("tcp")}},
+// 					Denied:          nil,
+// 					DestinationRanges: []string{"0.0.0.0/0"},
+// 				},
+// 			},
+// 			expectRule: nil,
+// 		},
+// 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			rule := findDenyAllRule(tt.firewalls)
-			assert.Equal(t, tt.expectRule, rule)
-		})
-	}
-}
+// 	for _, tt := range tests {
+// 		t.Run(tt.name, func(t *testing.T) {
+// 			rule := findDenyAllRule(tt.firewalls)
+// 			assert.Equal(t, tt.expectRule, rule)
+// 		})
+// 	}
+// }
 
-func TestIsDenyAllRule(t *testing.T) {
-	tests := []struct {
-		name      string
-		firewall  *computepb.Firewall
-		expect    bool
-	}{
-		{
-			name: "Deny-all rule",
-			firewall: &computepb.Firewall{
-				Priority:        proto.Int32(100),
-				Allowed:         nil,
-				Denied:          []*computepb.Denied{{IPProtocol: proto.String("all")}},
-				DestinationRanges: []string{"0.0.0.0/0"},
-			},
-			expect: true,
-		},
-		{
-			name: "Not a deny-all rule",
-			firewall: &computepb.Firewall{
-				Priority:        proto.Int32(100),
-				Allowed:         []*computepb.Allowed{{IPProtocol: proto.String("tcp")}},
-				Denied:          nil,
-				DestinationRanges: []string{"0.0.0.0/0"},
-			},
-			expect: false,
-		},
-	}
+// func TestIsDenyAllRule(t *testing.T) {
+// 	tests := []struct {
+// 		name      string
+// 		firewall  *computepb.Firewall
+// 		expect    bool
+// 	}{
+// 		{
+// 			name: "Deny-all rule",
+// 			firewall: &computepb.Firewall{
+// 				Priority:        proto.Int32(100),
+// 				Allowed:         nil,
+// 				Denied:          []*computepb.Denied{{IPProtocol: proto.String("all")}},
+// 				DestinationRanges: []string{"0.0.0.0/0"},
+// 			},
+// 			expect: true,
+// 		},
+// 		{
+// 			name: "Not a deny-all rule",
+// 			firewall: &computepb.Firewall{
+// 				Priority:        proto.Int32(100),
+// 				Allowed:         []*computepb.Allowed{{IPProtocol: proto.String("tcp")}},
+// 				Denied:          nil,
+// 				DestinationRanges: []string{"0.0.0.0/0"},
+// 			},
+// 			expect: false,
+// 		},
+// 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := isDenyAllRule(tt.firewall)
-			assert.Equal(t, tt.expect, result)
-		})
-	}
-}
+// 	for _, tt := range tests {
+// 		t.Run(tt.name, func(t *testing.T) {
+// 			result := isDenyAllRule(tt.firewall)
+// 			assert.Equal(t, tt.expect, result)
+// 		})
+// 	}
+// }
 
-func TestHasValidDestinationRanges(t *testing.T) {
-	tests := []struct {
-		name     string
-		firewall *computepb.Firewall
-		expected bool
-	}{
-		{
-			name: "Valid destination range",
-			firewall: &computepb.Firewall{
-				Priority:        proto.Int32(100),
-				Allowed:         nil,
-				Denied:          []*computepb.Denied{{IPProtocol: proto.String("all")}},
-				DestinationRanges: []string{"0.0.0.0/0"},
-			},
-			expected: true,
-		},
-		{
-			name: "Invalid destination range",
-			firewall: &computepb.Firewall{
-				Priority:        proto.Int32(100),
-				Allowed:         nil,
-				Denied:          []*computepb.Denied{{IPProtocol: proto.String("all")}},
-				DestinationRanges: []string{"192.168.0.0/16"},
-			},
-			expected: false,
-		},
-	}
+// func TestHasValidDestinationRanges(t *testing.T) {
+// 	tests := []struct {
+// 		name     string
+// 		firewall *computepb.Firewall
+// 		expected bool
+// 	}{
+// 		{
+// 			name: "Valid destination range",
+// 			firewall: &computepb.Firewall{
+// 				Priority:        proto.Int32(100),
+// 				Allowed:         nil,
+// 				Denied:          []*computepb.Denied{{IPProtocol: proto.String("all")}},
+// 				DestinationRanges: []string{"0.0.0.0/0"},
+// 			},
+// 			expected: true,
+// 		},
+// 		{
+// 			name: "Invalid destination range",
+// 			firewall: &computepb.Firewall{
+// 				Priority:        proto.Int32(100),
+// 				Allowed:         nil,
+// 				Denied:          []*computepb.Denied{{IPProtocol: proto.String("all")}},
+// 				DestinationRanges: []string{"192.168.0.0/16"},
+// 			},
+// 			expected: false,
+// 		},
+// 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := hasValidDestinationRanges(tt.firewall)
-			assert.Equal(t, tt.expected, result)
-		})
-	}
-}
+// 	for _, tt := range tests {
+// 		t.Run(tt.name, func(t *testing.T) {
+// 			result := hasValidDestinationRanges(tt.firewall)
+// 			assert.Equal(t, tt.expected, result)
+// 		})
+// 	}
+// }

--- a/pkg/gcp/firewalls_test.go
+++ b/pkg/gcp/firewalls_test.go
@@ -1,13 +1,5 @@
 package gcp
 
-// import (
-// 	"testing"
-// 	"github.com/stretchr/testify/assert"
-// 	"github.com/stretchr/testify/require"
-// 	"cloud.google.com/go/compute/apiv1/computepb"
-// 	"google.golang.org/protobuf/proto"
-// )
-
 // func TestCheckFirewallRulesCompliance(t *testing.T) {
 // 	tests := []struct {
 // 		name        string

--- a/pkg/gcp/firewalls_test.go
+++ b/pkg/gcp/firewalls_test.go
@@ -1,217 +1,225 @@
 package gcp
 
-// func TestCheckFirewallRulesCompliance(t *testing.T) {
-// 	tests := []struct {
-// 		name        string
-// 		firewalls   []*computepb.Firewall
-// 		expected    bool
-// 		expectedErr string
-// 	}{
-// 		{
-// 			name: "Valid deny-all rule and compliant allow rules",
-// 			firewalls: []*computepb.Firewall{
-// 				{
-// 					Priority:        proto.Int32(100),
-// 					Allowed:         []*computepb.Allowed{{IPProtocol: proto.String("tcp")}}, // Correct way to refer to Allowed
-// 					Denied:          nil,
-// 					DestinationRanges: []string{"0.0.0.0/0"},
-// 				},
-// 				{
-// 					Priority:        proto.Int32(200),
-// 					Allowed:         nil,
-// 					Denied:          []*computepb.Denied{{IPProtocol: proto.String("all")}}, // Correct way to refer to Denied
-// 					DestinationRanges: []string{"0.0.0.0/0"},
-// 				},
-// 				{
-// 					Priority:        proto.Int32(300),
-// 					Allowed:         []*computepb.Allowed{{IPProtocol: proto.String("icmp")}},
-// 					Denied:          nil,
-// 					DestinationRanges: []string{"0.0.0.0/0"},
-// 				},
-// 			},
-// 			expected:    true,
-// 			expectedErr: "",
-// 		},
-// 		{
-// 			name: "No deny-all rule",
-// 			firewalls: []*computepb.Firewall{
-// 				{
-// 					Priority:        proto.Int32(100),
-// 					Allowed:         []*computepb.Allowed{{IPProtocol: proto.String("tcp")}},
-// 					Denied:          nil,
-// 					DestinationRanges: []string{"0.0.0.0/0"},
-// 				},
-// 			},
-// 			expected:    false,
-// 			expectedErr: "no deny-all rule found",
-// 		},
-// 		{
-// 			name: "Deny-all rule with invalid destination range",
-// 			firewalls: []*computepb.Firewall{
-// 				{
-// 					Priority:        proto.Int32(200),
-// 					Allowed:         nil,
-// 					Denied:          []*computepb.Denied{{IPProtocol: proto.String("all")}},
-// 					DestinationRanges: []string{"192.168.0.0/16"},
-// 				},
-// 			},
-// 			expected:    false,
-// 			expectedErr: "deny-all rule does not have DestinationRanges set to '0.0.0.0/0'",
-// 		},
-// 		{
-// 			name: "Non-allow rule above deny-all",
-// 			firewalls: []*computepb.Firewall{
-// 				{
-// 					Priority:        proto.Int32(100),
-// 					Allowed:         nil,
-// 					Denied:          []*computepb.Denied{{IPProtocol: proto.String("all")}},
-// 					DestinationRanges: []string{"0.0.0.0/0"},
-// 				},
-// 				{
-// 					Priority:        proto.Int32(50),
-// 					Allowed:         nil,
-// 					Denied:          []*computepb.Denied{{IPProtocol: proto.String("icmp")}},
-// 					DestinationRanges: []string{"0.0.0.0/0"},
-// 				},
-// 			},
-// 			expected:    false,
-// 			expectedErr: "non-allow rule found with higher priority than deny-all",
-// 		},
-// 	}
+import (
+	"testing"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"cloud.google.com/go/compute/apiv1/computepb"
+	"google.golang.org/protobuf/proto"
+)
 
-// 	for _, tt := range tests {
-// 		t.Run(tt.name, func(t *testing.T) {
-// 			compliant, err := CheckFirewallRulesCompliance(tt.firewalls)
-// 			if tt.expectedErr != "" {
-// 				require.Error(t, err)
-// 				assert.Equal(t, tt.expectedErr, err.Error())
-// 			} else {
-// 				require.NoError(t, err)
-// 				assert.Equal(t, tt.expected, compliant)
-// 			}
-// 		})
-// 	}
-// }
+func TestCheckFirewallRulesCompliance(t *testing.T) {
+	tests := []struct {
+		name        string
+		firewalls   []*computepb.Firewall
+		expected    bool
+		expectedErr string
+	}{
+		{
+			name: "Valid deny-all rule and compliant allow rules",
+			firewalls: []*computepb.Firewall{
+				{
+					Priority:        proto.Int32(100),
+					Allowed:         []*computepb.Allowed{{IPProtocol: proto.String("tcp")}}, // Correct way to refer to Allowed
+					Denied:          nil,
+					DestinationRanges: []string{"0.0.0.0/0"},
+				},
+				{
+					Priority:        proto.Int32(200),
+					Allowed:         nil,
+					Denied:          []*computepb.Denied{{IPProtocol: proto.String("all")}}, // Correct way to refer to Denied
+					DestinationRanges: []string{"0.0.0.0/0"},
+				},
+				{
+					Priority:        proto.Int32(300),
+					Allowed:         []*computepb.Allowed{{IPProtocol: proto.String("icmp")}},
+					Denied:          nil,
+					DestinationRanges: []string{"0.0.0.0/0"},
+				},
+			},
+			expected:    true,
+			expectedErr: "",
+		},
+		{
+			name: "No deny-all rule",
+			firewalls: []*computepb.Firewall{
+				{
+					Priority:        proto.Int32(100),
+					Allowed:         []*computepb.Allowed{{IPProtocol: proto.String("tcp")}},
+					Denied:          nil,
+					DestinationRanges: []string{"0.0.0.0/0"},
+				},
+			},
+			expected:    false,
+			expectedErr: "no deny-all rule found",
+		},
+		{
+			name: "Deny-all rule with invalid destination range",
+			firewalls: []*computepb.Firewall{
+				{
+					Priority:        proto.Int32(200),
+					Allowed:         nil,
+					Denied:          []*computepb.Denied{{IPProtocol: proto.String("all")}},
+					DestinationRanges: []string{"192.168.0.0/16"},
+				},
+			},
+			expected:    false,
+			expectedErr: "deny-all rule does not have DestinationRanges set to '0.0.0.0/0'",
+		},
+		{
+			name: "Non-allow rule above deny-all",
+			firewalls: []*computepb.Firewall{
+				{
+					Priority:        proto.Int32(100),
+					Allowed:         nil,
+					Denied:          []*computepb.Denied{{IPProtocol: proto.String("all")}},
+					DestinationRanges: []string{"0.0.0.0/0"},
+				},
+				{
+					Priority:        proto.Int32(50),
+					Allowed:         nil,
+					Denied:          []*computepb.Denied{{IPProtocol: proto.String("icmp")}},
+					DestinationRanges: []string{"0.0.0.0/0"},
+				},
+			},
+			expected:    false,
+			expectedErr: "non-allow rule found with higher priority than deny-all",
+		},
+	}
 
-// func TestFindDenyAllRule(t *testing.T) {
-// 	tests := []struct {
-// 		name       string
-// 		firewalls  []*computepb.Firewall
-// 		expectRule *computepb.Firewall
-// 	}{
-// 		{
-// 			name: "Deny-all rule exists with the lowest priority",
-// 			firewalls: []*computepb.Firewall{
-// 				{
-// 					Priority:        proto.Int32(100),
-// 					Allowed:         nil,
-// 					Denied:          []*computepb.Denied{{IPProtocol: proto.String("all")}},
-// 					DestinationRanges: []string{"0.0.0.0/0"},
-// 				},
-// 				{
-// 					Priority:        proto.Int32(200),
-// 					Allowed:         nil,
-// 					Denied:          []*computepb.Denied{{IPProtocol: proto.String("all")}},
-// 					DestinationRanges: []string{"0.0.0.0/0"},
-// 				},
-// 			},
-// 			expectRule: &computepb.Firewall{
-// 				Priority:        proto.Int32(200),
-// 				Allowed:         nil,
-// 				Denied:          []*computepb.Denied{{IPProtocol: proto.String("all")}},
-// 				DestinationRanges: []string{"0.0.0.0/0"},
-// 			},
-// 		},
-// 		{
-// 			name: "No deny-all rule",
-// 			firewalls: []*computepb.Firewall{
-// 				{
-// 					Priority:        proto.Int32(100),
-// 					Allowed:         []*computepb.Allowed{{IPProtocol: proto.String("tcp")}},
-// 					Denied:          nil,
-// 					DestinationRanges: []string{"0.0.0.0/0"},
-// 				},
-// 			},
-// 			expectRule: nil,
-// 		},
-// 	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			compliant, err := CheckFirewallRulesCompliance(tt.firewalls)
+			if tt.expectedErr != "" {
+				require.Error(t, err)
+				assert.Equal(t, tt.expectedErr, err.Error())
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.expected, compliant)
+			}
+		})
+	}
+}
 
-// 	for _, tt := range tests {
-// 		t.Run(tt.name, func(t *testing.T) {
-// 			rule := findDenyAllRule(tt.firewalls)
-// 			assert.Equal(t, tt.expectRule, rule)
-// 		})
-// 	}
-// }
+func TestFindDenyAllRule(t *testing.T) {
+	tests := []struct {
+		name       string
+		firewalls  []*computepb.Firewall
+		expectRule *computepb.Firewall
+	}{
+		{
+			name: "Deny-all rule exists with the lowest priority",
+			firewalls: []*computepb.Firewall{
+				{
+					Priority:        proto.Int32(100),
+					Allowed:         nil,
+					Denied:          []*computepb.Denied{{IPProtocol: proto.String("all")}},
+					DestinationRanges: []string{"0.0.0.0/0"},
+				},
+				{
+					Priority:        proto.Int32(lowestPriority),
+					Allowed:         nil,
+					Denied:          []*computepb.Denied{{IPProtocol: proto.String("all")}},
+					DestinationRanges: []string{"0.0.0.0/0"},
+				},
+			},
+			expectRule: &computepb.Firewall{
+				Priority:        proto.Int32(lowestPriority),
+				Allowed:         nil,
+				Denied:          []*computepb.Denied{{IPProtocol: proto.String("all")}},
+				DestinationRanges: []string{"0.0.0.0/0"},
+			},
+		},
+		{
+			name: "No deny-all rule",
+			firewalls: []*computepb.Firewall{
+				{
+					Priority:        proto.Int32(100),
+					Allowed:         []*computepb.Allowed{{IPProtocol: proto.String("tcp")}},
+					Denied:          nil,
+					DestinationRanges: []string{"0.0.0.0/0"},
+				},
+			},
+			expectRule: nil,
+		},
+	}
 
-// func TestIsDenyAllRule(t *testing.T) {
-// 	tests := []struct {
-// 		name      string
-// 		firewall  *computepb.Firewall
-// 		expect    bool
-// 	}{
-// 		{
-// 			name: "Deny-all rule",
-// 			firewall: &computepb.Firewall{
-// 				Priority:        proto.Int32(100),
-// 				Allowed:         nil,
-// 				Denied:          []*computepb.Denied{{IPProtocol: proto.String("all")}},
-// 				DestinationRanges: []string{"0.0.0.0/0"},
-// 			},
-// 			expect: true,
-// 		},
-// 		{
-// 			name: "Not a deny-all rule",
-// 			firewall: &computepb.Firewall{
-// 				Priority:        proto.Int32(100),
-// 				Allowed:         []*computepb.Allowed{{IPProtocol: proto.String("tcp")}},
-// 				Denied:          nil,
-// 				DestinationRanges: []string{"0.0.0.0/0"},
-// 			},
-// 			expect: false,
-// 		},
-// 	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rule := findDenyAllRule(tt.firewalls)
+			assert.True(t, proto.Equal(tt.expectRule, rule), "expected and actual firewall rules do not match")
+		})
+	}
+}
 
-// 	for _, tt := range tests {
-// 		t.Run(tt.name, func(t *testing.T) {
-// 			result := isDenyAllRule(tt.firewall)
-// 			assert.Equal(t, tt.expect, result)
-// 		})
-// 	}
-// }
+func TestIsDenyAllRule(t *testing.T) {
+	tests := []struct {
+		name      string
+		firewall  *computepb.Firewall
+		expect    bool
+	}{
+		{
+			name: "Deny-all rule",
+			firewall: &computepb.Firewall{
+				Priority:        proto.Int32(lowestPriority),
+				Allowed:         nil,
+				Denied:          []*computepb.Denied{{IPProtocol: proto.String("all")}},
+				DestinationRanges: []string{"0.0.0.0/0"},
+			},
+			expect: true,
+		},
+		{
+			name: "Not a deny-all rule",
+			firewall: &computepb.Firewall{
+				Priority:        proto.Int32(lowestPriority),
+				Allowed:         []*computepb.Allowed{{IPProtocol: proto.String("tcp")}},
+				Denied:          nil,
+				DestinationRanges: []string{"0.0.0.0/0"},
+			},
+			expect: false,
+		},
+	}
 
-// func TestHasValidDestinationRanges(t *testing.T) {
-// 	tests := []struct {
-// 		name     string
-// 		firewall *computepb.Firewall
-// 		expected bool
-// 	}{
-// 		{
-// 			name: "Valid destination range",
-// 			firewall: &computepb.Firewall{
-// 				Priority:        proto.Int32(100),
-// 				Allowed:         nil,
-// 				Denied:          []*computepb.Denied{{IPProtocol: proto.String("all")}},
-// 				DestinationRanges: []string{"0.0.0.0/0"},
-// 			},
-// 			expected: true,
-// 		},
-// 		{
-// 			name: "Invalid destination range",
-// 			firewall: &computepb.Firewall{
-// 				Priority:        proto.Int32(100),
-// 				Allowed:         nil,
-// 				Denied:          []*computepb.Denied{{IPProtocol: proto.String("all")}},
-// 				DestinationRanges: []string{"192.168.0.0/16"},
-// 			},
-// 			expected: false,
-// 		},
-// 	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isDenyAllRule(tt.firewall)
+			assert.Equal(t, tt.expect, result)
+		})
+	}
+}
 
-// 	for _, tt := range tests {
-// 		t.Run(tt.name, func(t *testing.T) {
-// 			result := hasValidDestinationRanges(tt.firewall)
-// 			assert.Equal(t, tt.expected, result)
-// 		})
-// 	}
-// }
+func TestHasValidDestinationRanges(t *testing.T) {
+	tests := []struct {
+		name     string
+		firewall *computepb.Firewall
+		expected bool
+	}{
+		{
+			name: "Valid destination range",
+			firewall: &computepb.Firewall{
+				Priority:        proto.Int32(lowestPriority),
+				Allowed:         nil,
+				Denied:          []*computepb.Denied{{IPProtocol: proto.String("all")}},
+				DestinationRanges: []string{"0.0.0.0/0"},
+			},
+			expected: true,
+		},
+		{
+			name: "Invalid destination range",
+			firewall: &computepb.Firewall{
+				Priority:        proto.Int32(lowestPriority),
+				Allowed:         nil,
+				Denied:          []*computepb.Denied{{IPProtocol: proto.String("all")}},
+				DestinationRanges: []string{"192.168.0.0/16"},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := hasValidDestinationRanges(tt.firewall)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/pkg/gcp/firewalls_test.go
+++ b/pkg/gcp/firewalls_test.go
@@ -1,0 +1,225 @@
+package gcp
+
+import (
+	"testing"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"cloud.google.com/go/compute/apiv1/computepb"
+	"google.golang.org/protobuf/proto"
+)
+
+func TestCheckFirewallRulesCompliance(t *testing.T) {
+	tests := []struct {
+		name        string
+		firewalls   []*computepb.Firewall
+		expected    bool
+		expectedErr string
+	}{
+		{
+			name: "Valid deny-all rule and compliant allow rules",
+			firewalls: []*computepb.Firewall{
+				{
+					Priority:        proto.Int32(100),
+					Allowed:         []*computepb.Allowed{{IPProtocol: proto.String("tcp")}}, // Correct way to refer to Allowed
+					Denied:          nil,
+					DestinationRanges: []string{"0.0.0.0/0"},
+				},
+				{
+					Priority:        proto.Int32(200),
+					Allowed:         nil,
+					Denied:          []*computepb.Denied{{IPProtocol: proto.String("all")}}, // Correct way to refer to Denied
+					DestinationRanges: []string{"0.0.0.0/0"},
+				},
+				{
+					Priority:        proto.Int32(300),
+					Allowed:         []*computepb.Allowed{{IPProtocol: proto.String("icmp")}},
+					Denied:          nil,
+					DestinationRanges: []string{"0.0.0.0/0"},
+				},
+			},
+			expected:    true,
+			expectedErr: "",
+		},
+		{
+			name: "No deny-all rule",
+			firewalls: []*computepb.Firewall{
+				{
+					Priority:        proto.Int32(100),
+					Allowed:         []*computepb.Allowed{{IPProtocol: proto.String("tcp")}},
+					Denied:          nil,
+					DestinationRanges: []string{"0.0.0.0/0"},
+				},
+			},
+			expected:    false,
+			expectedErr: "no deny-all rule found",
+		},
+		{
+			name: "Deny-all rule with invalid destination range",
+			firewalls: []*computepb.Firewall{
+				{
+					Priority:        proto.Int32(200),
+					Allowed:         nil,
+					Denied:          []*computepb.Denied{{IPProtocol: proto.String("all")}},
+					DestinationRanges: []string{"192.168.0.0/16"},
+				},
+			},
+			expected:    false,
+			expectedErr: "deny-all rule does not have DestinationRanges set to '0.0.0.0/0'",
+		},
+		{
+			name: "Non-allow rule above deny-all",
+			firewalls: []*computepb.Firewall{
+				{
+					Priority:        proto.Int32(100),
+					Allowed:         nil,
+					Denied:          []*computepb.Denied{{IPProtocol: proto.String("all")}},
+					DestinationRanges: []string{"0.0.0.0/0"},
+				},
+				{
+					Priority:        proto.Int32(50),
+					Allowed:         nil,
+					Denied:          []*computepb.Denied{{IPProtocol: proto.String("icmp")}},
+					DestinationRanges: []string{"0.0.0.0/0"},
+				},
+			},
+			expected:    false,
+			expectedErr: "non-allow rule found with higher priority than deny-all",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			compliant, err := CheckFirewallRulesCompliance(tt.firewalls)
+			if tt.expectedErr != "" {
+				require.Error(t, err)
+				assert.Equal(t, tt.expectedErr, err.Error())
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.expected, compliant)
+			}
+		})
+	}
+}
+
+func TestFindDenyAllRule(t *testing.T) {
+	tests := []struct {
+		name       string
+		firewalls  []*computepb.Firewall
+		expectRule *computepb.Firewall
+	}{
+		{
+			name: "Deny-all rule exists with the lowest priority",
+			firewalls: []*computepb.Firewall{
+				{
+					Priority:        proto.Int32(100),
+					Allowed:         nil,
+					Denied:          []*computepb.Denied{{IPProtocol: proto.String("all")}},
+					DestinationRanges: []string{"0.0.0.0/0"},
+				},
+				{
+					Priority:        proto.Int32(200),
+					Allowed:         nil,
+					Denied:          []*computepb.Denied{{IPProtocol: proto.String("all")}},
+					DestinationRanges: []string{"0.0.0.0/0"},
+				},
+			},
+			expectRule: &computepb.Firewall{
+				Priority:        proto.Int32(200),
+				Allowed:         nil,
+				Denied:          []*computepb.Denied{{IPProtocol: proto.String("all")}},
+				DestinationRanges: []string{"0.0.0.0/0"},
+			},
+		},
+		{
+			name: "No deny-all rule",
+			firewalls: []*computepb.Firewall{
+				{
+					Priority:        proto.Int32(100),
+					Allowed:         []*computepb.Allowed{{IPProtocol: proto.String("tcp")}},
+					Denied:          nil,
+					DestinationRanges: []string{"0.0.0.0/0"},
+				},
+			},
+			expectRule: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rule := findDenyAllRule(tt.firewalls)
+			assert.Equal(t, tt.expectRule, rule)
+		})
+	}
+}
+
+func TestIsDenyAllRule(t *testing.T) {
+	tests := []struct {
+		name      string
+		firewall  *computepb.Firewall
+		expect    bool
+	}{
+		{
+			name: "Deny-all rule",
+			firewall: &computepb.Firewall{
+				Priority:        proto.Int32(100),
+				Allowed:         nil,
+				Denied:          []*computepb.Denied{{IPProtocol: proto.String("all")}},
+				DestinationRanges: []string{"0.0.0.0/0"},
+			},
+			expect: true,
+		},
+		{
+			name: "Not a deny-all rule",
+			firewall: &computepb.Firewall{
+				Priority:        proto.Int32(100),
+				Allowed:         []*computepb.Allowed{{IPProtocol: proto.String("tcp")}},
+				Denied:          nil,
+				DestinationRanges: []string{"0.0.0.0/0"},
+			},
+			expect: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isDenyAllRule(tt.firewall)
+			assert.Equal(t, tt.expect, result)
+		})
+	}
+}
+
+func TestHasValidDestinationRanges(t *testing.T) {
+	tests := []struct {
+		name     string
+		firewall *computepb.Firewall
+		expected bool
+	}{
+		{
+			name: "Valid destination range",
+			firewall: &computepb.Firewall{
+				Priority:        proto.Int32(100),
+				Allowed:         nil,
+				Denied:          []*computepb.Denied{{IPProtocol: proto.String("all")}},
+				DestinationRanges: []string{"0.0.0.0/0"},
+			},
+			expected: true,
+		},
+		{
+			name: "Invalid destination range",
+			firewall: &computepb.Firewall{
+				Priority:        proto.Int32(100),
+				Allowed:         nil,
+				Denied:          []*computepb.Denied{{IPProtocol: proto.String("all")}},
+				DestinationRanges: []string{"192.168.0.0/16"},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := hasValidDestinationRanges(tt.firewall)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/pkg/gcp/firewalls_test.go
+++ b/pkg/gcp/firewalls_test.go
@@ -20,14 +20,14 @@ func TestCheckFirewallRulesCompliance(t *testing.T) {
 			firewalls: []*computepb.Firewall{
 				{
 					Priority:        proto.Int32(100),
-					Allowed:         []*computepb.Allowed{{IPProtocol: proto.String("tcp")}}, // Correct way to refer to Allowed
+					Allowed:         []*computepb.Allowed{{IPProtocol: proto.String("tcp")}},
 					Denied:          nil,
 					DestinationRanges: []string{"0.0.0.0/0"},
 				},
 				{
 					Priority:        proto.Int32(200),
 					Allowed:         nil,
-					Denied:          []*computepb.Denied{{IPProtocol: proto.String("all")}}, // Correct way to refer to Denied
+					Denied:          []*computepb.Denied{{IPProtocol: proto.String("all")}},
 					DestinationRanges: []string{"0.0.0.0/0"},
 				},
 				{
@@ -64,7 +64,7 @@ func TestCheckFirewallRulesCompliance(t *testing.T) {
 				},
 			},
 			expected:    false,
-			expectedErr: "deny-all rule does not have DestinationRanges set to '0.0.0.0/0'",
+			expectedErr: "no deny-all rule found",
 		},
 		{
 			name: "Non-allow rule above deny-all",
@@ -83,7 +83,7 @@ func TestCheckFirewallRulesCompliance(t *testing.T) {
 				},
 			},
 			expected:    false,
-			expectedErr: "non-allow rule found with higher priority than deny-all",
+			expectedErr: "found a deny rule with higher priority than deny-all",
 		},
 	}
 
@@ -101,14 +101,14 @@ func TestCheckFirewallRulesCompliance(t *testing.T) {
 	}
 }
 
-func TestIsDenyAllRule(t *testing.T) {
+func TestIsDenyRule(t *testing.T) {
 	tests := []struct {
 		name      string
 		firewall  *computepb.Firewall
 		expect    bool
 	}{
 		{
-			name: "Deny-all rule",
+			name: "Deny rule",
 			firewall: &computepb.Firewall{
 				Priority:        proto.Int32(lowestPriority),
 				Allowed:         nil,
@@ -138,16 +138,6 @@ func TestIsDenyAllRule(t *testing.T) {
 			expect: false,
 		},
 		{
-			name: "Denied protocol is not 'all'",
-			firewall: &computepb.Firewall{
-				Priority:        proto.Int32(lowestPriority),
-				Allowed:         nil,
-				Denied:          []*computepb.Denied{{IPProtocol: proto.String("tcp")}},
-				DestinationRanges: []string{"0.0.0.0/0"},
-			},
-			expect: false,
-		},
-		{
 			name: "No rule",
 			expect: false,
 		},
@@ -156,44 +146,8 @@ func TestIsDenyAllRule(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := isDenyAllRule(tt.firewall)
+			result := isDenyRule(tt.firewall)
 			assert.Equal(t, tt.expect, result)
-		})
-	}
-}
-
-func TestHasValidDestinationRanges(t *testing.T) {
-	tests := []struct {
-		name     string
-		firewall *computepb.Firewall
-		expected bool
-	}{
-		{
-			name: "Valid destination range",
-			firewall: &computepb.Firewall{
-				Priority:        proto.Int32(lowestPriority),
-				Allowed:         nil,
-				Denied:          []*computepb.Denied{{IPProtocol: proto.String("all")}},
-				DestinationRanges: []string{"0.0.0.0/0"},
-			},
-			expected: true,
-		},
-		{
-			name: "Invalid destination range",
-			firewall: &computepb.Firewall{
-				Priority:        proto.Int32(lowestPriority),
-				Allowed:         nil,
-				Denied:          []*computepb.Denied{{IPProtocol: proto.String("all")}},
-				DestinationRanges: []string{"192.168.0.0/16"},
-			},
-			expected: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := hasValidDestinationRanges(tt.firewall)
-			assert.Equal(t, tt.expected, result)
 		})
 	}
 }

--- a/pkg/gcp/firewalls_test.go
+++ b/pkg/gcp/firewalls_test.go
@@ -66,25 +66,7 @@ func TestCheckFirewallRulesCompliance(t *testing.T) {
 			expected:    false,
 			expectedErr: "no deny-all rule found",
 		},
-		{
-			name: "Non-allow rule above deny-all",
-			firewalls: []*computepb.Firewall{
-				{
-					Priority:        proto.Int32(100),
-					Allowed:         nil,
-					Denied:          []*computepb.Denied{{IPProtocol: proto.String("all")}},
-					DestinationRanges: []string{"0.0.0.0/0"},
-				},
-				{
-					Priority:        proto.Int32(50),
-					Allowed:         nil,
-					Denied:          []*computepb.Denied{{IPProtocol: proto.String("icmp")}},
-					DestinationRanges: []string{"0.0.0.0/0"},
-				},
-			},
-			expected:    false,
-			expectedErr: "found a deny rule with higher priority than deny-all",
-		},
+
 	}
 
 	for _, tt := range tests {
@@ -101,7 +83,7 @@ func TestCheckFirewallRulesCompliance(t *testing.T) {
 	}
 }
 
-func TestIsDenyRule(t *testing.T) {
+func TestIsDenyAllRule(t *testing.T) {
 	tests := []struct {
 		name      string
 		firewall  *computepb.Firewall
@@ -138,15 +120,38 @@ func TestIsDenyRule(t *testing.T) {
 			expect: false,
 		},
 		{
+			name: "Denied protocol is not 'all'",
+			firewall: &computepb.Firewall{
+				Priority:        proto.Int32(lowestPriority),
+				Allowed:         nil,
+				Denied:          []*computepb.Denied{{IPProtocol: proto.String("tcp")}},
+				DestinationRanges: []string{"0.0.0.0/0"},
+			},
+			expect: false,
+		},
+		{
+			name: "Invalid destination range",
+			firewall: &computepb.Firewall{
+				Priority:        proto.Int32(lowestPriority),
+				Allowed:         nil,
+				Denied:          []*computepb.Denied{{IPProtocol: proto.String("all")}},
+				DestinationRanges: []string{"192.168.0.0/16"},
+			},
+			expect: false,
+		},
+		{
 			name: "No rule",
 			expect: false,
 		},
-
+		{
+			name: "No rule",
+			expect: false,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := isDenyRule(tt.firewall)
+			result := isDenyAllRule(tt.firewall)
 			assert.Equal(t, tt.expect, result)
 		})
 	}

--- a/pkg/gcp/firewalls_test.go
+++ b/pkg/gcp/firewalls_test.go
@@ -143,10 +143,6 @@ func TestIsDenyAllRule(t *testing.T) {
 			name: "No rule",
 			expect: false,
 		},
-		{
-			name: "No rule",
-			expect: false,
-		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/gcp/plugin.go
+++ b/pkg/gcp/plugin.go
@@ -294,7 +294,7 @@ func (s *GCPPluginServer) _CreateResource(ctx context.Context, resourceDescripti
 	project := parseUrl(resourceDescription.Deployment.Id)["projects"]
 
 	// Read and validate user-provided description
-	resourceInfo, err := IsValidResource(ctx, resourceDescription)
+	resourceInfo, err := IsValidResourceFromDescription(ctx, resourceDescription)
 	if err != nil {
 		return nil, fmt.Errorf("unsupported resource description: %w", err)
 	}
@@ -870,6 +870,69 @@ func (s *GCPPluginServer) _CreateVpnConnections(ctx context.Context, req *paragl
 func (s *GCPPluginServer) GetNetworkAddressSpaces(ctx context.Context, req *paragliderpb.GetNetworkAddressSpacesRequest) (*paragliderpb.GetNetworkAddressSpacesResponse, error) {
 	return nil, fmt.Errorf("GetNetworkAddressSpaces is currently not implemented by GCP, implying plugin does not support BGP disabled VPN connections")
 }
+
+// // Add an existing GCP resource to a paraglider deployment
+// func (s *GCPPluginServer) AttachResource(ctx context.Context, attachResourceReq *paragliderpb.AttachResourceRequest) (*paragliderpb.AttachResourceResponse, error) {
+// 	clients := &GCPClients{}
+// 	defer clients.Close()
+
+// 	resource, networkInfo, err := ValidateResourceCompliesWithParagliderRequirements(ctx, resourceId, azureHandler, s)
+// 	if err != nil {
+// 		utils.Log.Printf("An error occured while validating resource:%+v", err)
+// 		return nil, err
+// 	}
+
+// 	func (r *instanceHandler) ValidateResourceCompliesWithParagliderRequirements(ctx context.Context, resourceReq *paragliderpb.CreateResourceRequest, project string, resourceID string, server *GCPPluginServer) (*resourceInfo, *resourceNetworkInfo, error) {
+
+// 	resourceId := attachResourceReq.GetResource()
+// 	resourceIdInfo, err := getResourceIDInfo(resourceId)
+// 	if err != nil {
+// 		utils.Log.Printf("An error occured while getting resource id info:%+v", err)
+// 		return nil, err
+// 	}
+
+// 	azureHandler, err := s.setupAzureHandler(resourceIdInfo, attachResourceReq.GetNamespace())
+// 	if err != nil {
+// 		return nil, err
+// 	}
+
+// 	resource, networkInfo, err := ValidateResourceCompliesWithParagliderRequirements(ctx, resourceId, azureHandler, s)
+// 	if err != nil {
+// 		utils.Log.Printf("An error occured while validating resource:%+v", err)
+// 		return nil, err
+// 	}
+
+// 	// Create VPN gateway vnet if not already created
+// 	vpnGwVnet, err := GetOrCreateVpnGatewayVNet(ctx, azureHandler, namespace)
+// 	if err != nil {
+// 		utils.Log.Printf("An error occured while getting or creating VPN gateway vnet:%+v", err)
+// 		return nil, err
+// 	}
+
+// 	vnetName := getVnetFromSubnetId(networkInfo.SubnetID)
+// 	// Create peering between the VPN gateway vnet and VM vnet. If the VPN gateway already exists, then establish a VPN gateway transit relationship where the vnet can use the gatewayVnet's VPN gateway.
+// 	err = CreateGatewayVnetPeering(ctx, azureHandler, vnetName, *vpnGwVnet.Name, namespace)
+// 	if err != nil {
+// 		utils.Log.Printf("An error occured while creating VPN gateway vnet peering:%+v", err)
+// 		return nil, err
+// 	}
+
+// 	vnet, err := azureHandler.GetVirtualNetwork(ctx, vnetName)
+// 	if err != nil {
+// 		utils.Log.Printf("An error occured while getting vnet:%+v", err)
+// 		return nil, err
+// 	}
+
+// 	// Add Paraglider namespace tag to the vnet
+// 	azureHandler.createParagliderNamespaceTag(&vnet.Tags)
+// 	_, err = azureHandler.CreateOrUpdateVirtualNetwork(ctx, vnetName, *vnet)
+// 	if err != nil {
+// 		utils.Log.Printf("An error occured while creating vnet:%+v", err)
+// 		return nil, err
+// 	}
+
+// 	return &paragliderpb.AttachResourceResponse{Name: *resource.Name, Uri: *resource.ID, Ip: networkInfo.Address}, nil
+// }
 
 func Setup(port int, orchestratorServerAddr string) *GCPPluginServer {
 	lis, err := net.Listen("tcp", fmt.Sprintf("localhost:%d", port))

--- a/pkg/gcp/plugin.go
+++ b/pkg/gcp/plugin.go
@@ -294,7 +294,7 @@ func (s *GCPPluginServer) _CreateResource(ctx context.Context, resourceDescripti
 	project := parseUrl(resourceDescription.Deployment.Id)["projects"]
 
 	// Read and validate user-provided description
-	resourceInfo, err := IsValidResourceFromDescription(ctx, resourceDescription)
+	resourceInfo, err := IsValidResource(ctx, resourceDescription)
 	if err != nil {
 		return nil, fmt.Errorf("unsupported resource description: %w", err)
 	}

--- a/pkg/gcp/plugin.go
+++ b/pkg/gcp/plugin.go
@@ -871,69 +871,6 @@ func (s *GCPPluginServer) GetNetworkAddressSpaces(ctx context.Context, req *para
 	return nil, fmt.Errorf("GetNetworkAddressSpaces is currently not implemented by GCP, implying plugin does not support BGP disabled VPN connections")
 }
 
-// // Add an existing GCP resource to a paraglider deployment
-// func (s *GCPPluginServer) AttachResource(ctx context.Context, attachResourceReq *paragliderpb.AttachResourceRequest) (*paragliderpb.AttachResourceResponse, error) {
-// 	clients := &GCPClients{}
-// 	defer clients.Close()
-
-// 	resource, networkInfo, err := ValidateResourceCompliesWithParagliderRequirements(ctx, resourceId, azureHandler, s)
-// 	if err != nil {
-// 		utils.Log.Printf("An error occured while validating resource:%+v", err)
-// 		return nil, err
-// 	}
-
-// 	func (r *instanceHandler) ValidateResourceCompliesWithParagliderRequirements(ctx context.Context, resourceReq *paragliderpb.CreateResourceRequest, project string, resourceID string, server *GCPPluginServer) (*resourceInfo, *resourceNetworkInfo, error) {
-
-// 	resourceId := attachResourceReq.GetResource()
-// 	resourceIdInfo, err := getResourceIDInfo(resourceId)
-// 	if err != nil {
-// 		utils.Log.Printf("An error occured while getting resource id info:%+v", err)
-// 		return nil, err
-// 	}
-
-// 	azureHandler, err := s.setupAzureHandler(resourceIdInfo, attachResourceReq.GetNamespace())
-// 	if err != nil {
-// 		return nil, err
-// 	}
-
-// 	resource, networkInfo, err := ValidateResourceCompliesWithParagliderRequirements(ctx, resourceId, azureHandler, s)
-// 	if err != nil {
-// 		utils.Log.Printf("An error occured while validating resource:%+v", err)
-// 		return nil, err
-// 	}
-
-// 	// Create VPN gateway vnet if not already created
-// 	vpnGwVnet, err := GetOrCreateVpnGatewayVNet(ctx, azureHandler, namespace)
-// 	if err != nil {
-// 		utils.Log.Printf("An error occured while getting or creating VPN gateway vnet:%+v", err)
-// 		return nil, err
-// 	}
-
-// 	vnetName := getVnetFromSubnetId(networkInfo.SubnetID)
-// 	// Create peering between the VPN gateway vnet and VM vnet. If the VPN gateway already exists, then establish a VPN gateway transit relationship where the vnet can use the gatewayVnet's VPN gateway.
-// 	err = CreateGatewayVnetPeering(ctx, azureHandler, vnetName, *vpnGwVnet.Name, namespace)
-// 	if err != nil {
-// 		utils.Log.Printf("An error occured while creating VPN gateway vnet peering:%+v", err)
-// 		return nil, err
-// 	}
-
-// 	vnet, err := azureHandler.GetVirtualNetwork(ctx, vnetName)
-// 	if err != nil {
-// 		utils.Log.Printf("An error occured while getting vnet:%+v", err)
-// 		return nil, err
-// 	}
-
-// 	// Add Paraglider namespace tag to the vnet
-// 	azureHandler.createParagliderNamespaceTag(&vnet.Tags)
-// 	_, err = azureHandler.CreateOrUpdateVirtualNetwork(ctx, vnetName, *vnet)
-// 	if err != nil {
-// 		utils.Log.Printf("An error occured while creating vnet:%+v", err)
-// 		return nil, err
-// 	}
-
-// 	return &paragliderpb.AttachResourceResponse{Name: *resource.Name, Uri: *resource.ID, Ip: networkInfo.Address}, nil
-// }
-
 func Setup(port int, orchestratorServerAddr string) *GCPPluginServer {
 	lis, err := net.Listen("tcp", fmt.Sprintf("localhost:%d", port))
 	if err != nil {

--- a/pkg/gcp/plugin_test_utils.go
+++ b/pkg/gcp/plugin_test_utils.go
@@ -124,6 +124,20 @@ var (
 		Network:           proto.String(getVpcUrl(fakeProject, fakeNamespace)),
 		TargetTags:        []string{fakeNetworkTag},
 	}
+	fakeDenyAllRule = &computepb.Firewall{
+		Denied: []*computepb.Denied{
+			{
+				IPProtocol: proto.String("all"),
+			},
+		},
+		Allowed:           []*computepb.Allowed{},
+		DestinationRanges: []string{"0.0.0.0/0"},
+		Direction:         proto.String(computepb.Firewall_EGRESS.String()),
+		Name:              proto.String("deny-all-egress"),
+		Priority:          proto.Int32(65534),
+		Network:           proto.String(getVpcUrl(fakeProject, fakeNamespace)),
+		TargetTags:        []string{fakeNetworkTag},
+	}
 )
 
 // Fake instance
@@ -288,6 +302,15 @@ func getFakeServerHandler(fakeServerState *fakeServerState) http.HandlerFunc {
 				sendResponseFakeOperation(w)
 				return
 			}
+		case path == urlProject+urlRegion+"/subnetworks/"+fakeSubnetName:
+			if r.Method == "GET" {
+				if fakeServerState.subnetwork != nil {
+					sendResponse(w, fakeServerState.subnetwork)
+				} else {
+					http.Error(w, "no subnetwork found", http.StatusNotFound)
+				}
+				return
+			}		
 		case strings.HasPrefix(path, urlProject+urlRegion+"/subnetworks"):
 			if r.Method == "GET" {
 				if fakeServerState.subnetwork != nil {

--- a/pkg/gcp/plugin_test_utils.go
+++ b/pkg/gcp/plugin_test_utils.go
@@ -134,7 +134,7 @@ var (
 		DestinationRanges: []string{"0.0.0.0/0"},
 		Direction:         proto.String(computepb.Firewall_EGRESS.String()),
 		Name:              proto.String("deny-all-egress"),
-		Priority:          proto.Int32(65534),
+		Priority:          proto.Int32(lowestPriority),
 		Network:           proto.String(getVpcUrl(fakeProject, fakeNamespace)),
 		TargetTags:        []string{fakeNetworkTag},
 	}

--- a/pkg/gcp/resources.go
+++ b/pkg/gcp/resources.go
@@ -343,12 +343,18 @@ func (r *instanceHandler) ValidateResourceCompliesWithParagliderRequirements(ctx
 		return nil, nil, fmt.Errorf("Resource %s Network Address Space overlaps with Paraglider Network Address Space. Not allowed", resourceID)
 	}
 
-	// // Ensure the resource's security rules are compliant. Make compliant if possible
-	// isNSGCompliant, err := CheckSecurityRulesCompliance(ctx, azureHandler, networkInfo.NSG)
-	// if err != nil || !isNSGCompliant {
-	// 	return nil, nil, fmt.Errorf("NSG rules are not compliant: %w", err)
-	// }
+    // Fetch firewall rules for the resource using getFirewallRules function
+    firewallRules, err := getFirewallRules(ctx, project, resourceID, clients)
+    if err != nil {
+        return nil, nil, fmt.Errorf("Error retrieving firewall rules for resource %s: %w", resourceID, err)
+    }
 
+    // Call CheckFirewallRulesCompliance to verify firewall rule compliance
+    isCompliant, err := CheckFirewallRulesCompliance(firewallRules)
+    if err != nil || !isCompliant {
+        return nil, nil, fmt.Errorf("Firewall rules are not compliant: %w", err)
+    }
+	
 	return resourceInfo, networkInfo, nil
 }
 

--- a/pkg/gcp/resources.go
+++ b/pkg/gcp/resources.go
@@ -215,30 +215,6 @@ func GetResourceNetworkInfo(ctx context.Context, resourceInfo *resourceInfo, cli
 	return netInfo, nil
 }
 
-// // Verifies the existence of a GCP resource described in an AttachResourceRequest and returns the resourceInfo
-// func (r *instanceHandler) IsValidResource(ctx context.Context, req *paragliderpb.AttachResourceRequest) (*resourceInfo, error) {
-// 	// Parse the resource URL to get the resourceInfo (project, zone, name, etc)
-// 	resourceInfo, err := parseResourceUrl(req.GetResource())
-// 	if err != nil {
-// 		return nil, fmt.Errorf("failed to parse resource URL: %w", err)
-// 	}
-
-// 	// Make a GetInstanceRequest to verify the instance exists
-// 	instanceRequest := &computepb.GetInstanceRequest{
-// 		Instance: resourceInfo.Name,
-// 		Project:  resourceInfo.Project,
-// 		Zone:     resourceInfo.Zone,
-// 	}
-// 	_, err = r.client.Get(ctx, instanceRequest)
-// 	if err != nil {
-// 		return nil, fmt.Errorf("unable to get instance: %w", err)
-// 	}
-
-// 	resourceInfo.Namespace = req.GetNamespace()
-
-// 	return resourceInfo, nil
-// }
-
 // Read parameters from within the resource description and ensure it is a valid resource
 func IsValidResource(ctx context.Context, resource *paragliderpb.CreateResourceRequest) (*resourceInfo, error) {
 	// Verify resource is supported
@@ -492,27 +468,6 @@ func (r *instanceHandler) getNetworkInfo(ctx context.Context, resourceInfo *reso
 	ip := *instanceResponse.NetworkInterfaces[0].NetworkIP
 	return &resourceNetworkInfo{NetworkName: networkName, SubnetUrl: subnetUrl, ResourceID: resourceID, Address: ip}, nil
 }
-
-// // Get the resource information for an instance from an AttachResourceRequest
-// func (r *instanceHandler) getResourceInfo(ctx context.Context, req *paragliderpb.AttachResourceRequest) (*resourceInfo, error) {
-// 	resourceID := req.GetResource()
-
-// 	// Retrieve resource ID info (this could be from a database, GCP API, etc.)
-// 	resourceIDInfo, err := getResourceIDInfo(resourceID)
-// 	if err != nil {
-// 		return nil, fmt.Errorf("unable to get resource ID info: %w", err)
-// 	}
-
-// 	// Construct the resource info based on the retrieved data
-// 	region := getRegionFromZone(resourceIDInfo.Zone)
-// 	return &resourceInfo{
-// 		Name:         resourceIDInfo.Name,
-// 		Project:      resourceIDInfo.Project,
-// 		Zone:         resourceIDInfo.Zone,
-// 		Region:       region,
-// 		ResourceType: instanceTypeName,
-// 	}, nil
-// }
 
 // Create an instance with given network settings
 // Returns the instance URL and instance IP

--- a/pkg/gcp/resources.go
+++ b/pkg/gcp/resources.go
@@ -305,22 +305,6 @@ func (r *instanceHandler) ValidateResourceCompliesWithParagliderRequirements(ctx
 		return nil, nil, fmt.Errorf("Error in getting resource %s network info: %w", resourceID, err)
 	}
 
-	// handler, err := getResourceHandler(ctx, resourceInfo.ResourceType, clients)
-	// if err != nil {
-	// 	return nil, fmt.Errorf("unable to get resource handler: %w", err)
-	// }
-	// netInfo, err := handler.getNetworkInfo(ctx, resourceInfo)
-	// if err != nil {
-	// 	return nil, fmt.Errorf("unable to get network info: %w", err)
-	// }
-
-	// Ensure the VPC's address space doesn't overlap with Paraglider's address space
-
-	// we want the name of the
-	// information of the resource or in the subresource
-	// vpcName := getVpcName(resourceInfo.Namespace) // this gets the vpc of the paraglider network, not the network we are trying to attach resource from
-
-	// our instanceResponse is the vpc
 	// Returns the network name, subnet URL, IP, and instance ID converted to a string for rule naming
 	instanceRequest := &computepb.GetInstanceRequest{
 		Instance: resourceInfo.Name,

--- a/pkg/gcp/resources.go
+++ b/pkg/gcp/resources.go
@@ -212,32 +212,32 @@ func GetResourceNetworkInfo(ctx context.Context, resourceInfo *resourceInfo, cli
 	return netInfo, nil
 }
 
-// Verifies the existence of a GCP resource described in an AttachResourceRequest and returns the resourceInfo
-func (r *instanceHandler) IsValidResource(ctx context.Context, req *paragliderpb.AttachResourceRequest) (*resourceInfo, error) {
-	// Parse the resource URL to get the resourceInfo (project, zone, name, etc)
-	resourceInfo, err := parseResourceUrl(req.GetResource())
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse resource URL: %w", err)
-	}
+// // Verifies the existence of a GCP resource described in an AttachResourceRequest and returns the resourceInfo
+// func (r *instanceHandler) IsValidResource(ctx context.Context, req *paragliderpb.AttachResourceRequest) (*resourceInfo, error) {
+// 	// Parse the resource URL to get the resourceInfo (project, zone, name, etc)
+// 	resourceInfo, err := parseResourceUrl(req.GetResource())
+// 	if err != nil {
+// 		return nil, fmt.Errorf("failed to parse resource URL: %w", err)
+// 	}
 
-	// Make a GetInstanceRequest to verify the instance exists
-	instanceRequest := &computepb.GetInstanceRequest{
-		Instance: resourceInfo.Name,
-		Project:  resourceInfo.Project,
-		Zone:     resourceInfo.Zone,
-	}
-	_, err = r.client.Get(ctx, instanceRequest)
-	if err != nil {
-		return nil, fmt.Errorf("unable to get instance: %w", err)
-	}
+// 	// Make a GetInstanceRequest to verify the instance exists
+// 	instanceRequest := &computepb.GetInstanceRequest{
+// 		Instance: resourceInfo.Name,
+// 		Project:  resourceInfo.Project,
+// 		Zone:     resourceInfo.Zone,
+// 	}
+// 	_, err = r.client.Get(ctx, instanceRequest)
+// 	if err != nil {
+// 		return nil, fmt.Errorf("unable to get instance: %w", err)
+// 	}
 
-	resourceInfo.Namespace = req.GetNamespace()
+// 	resourceInfo.Namespace = req.GetNamespace()
 
-	return resourceInfo, nil
-}
+// 	return resourceInfo, nil
+// }
 
 // Read parameters from within the resource description and ensure it is a valid resource
-func IsValidResourceFromDescription(ctx context.Context, resource *paragliderpb.CreateResourceRequest) (*resourceInfo, error) {
+func IsValidResource(ctx context.Context, resource *paragliderpb.CreateResourceRequest) (*resourceInfo, error) {
 	// Verify resource is supported
 	handler, err := getResourceHandlerFromDescription(resource.Description)
 	if err != nil {
@@ -271,11 +271,13 @@ func GetFirewallTarget(ctx context.Context, resourceInfo *resourceInfo, netInfo 
 
 // Returns the resource and network info if the resource complies with paraglider requirements. Otherwise, it returns an error
 func (r *instanceHandler) ValidateResourceCompliesWithParagliderRequirements(ctx context.Context, resourceReq *paragliderpb.AttachResourceRequest, project string, resourceID string, clients *GCPClients) (*resourceInfo, *resourceNetworkInfo, error) {
-	// Ensure the resource exists
-	resourceInfo, err := r.IsValidResource(ctx, resourceReq)
+	// Get the ResourceInfo from AttachResourceRequest
+	resourceInfo, err := parseResourceUrl(resourceReq.GetResource())
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, fmt.Errorf("failed to parse resource URL: %w", err)
 	}
+
+	resourceInfo.Namespace = resourceReq.GetNamespace()
 
 	networkInfo, err := GetResourceNetworkInfo(ctx, resourceInfo, clients)
 	if err != nil {

--- a/pkg/gcp/resources.go
+++ b/pkg/gcp/resources.go
@@ -656,12 +656,17 @@ func (r *privateServiceHandler) getResourceInfo(ctx context.Context, resource *p
 		region = globalRegion
 	}
 
-	return &resourceInfo{Region: region, NumAdditionalAddressSpaces: r.getNumberAddressSpacesRequired(), ResourceType: privateServiceConnectTypeName, Name: resource.Name}, nil
+	return &resourceInfo{Region: region, NumAdditionalAddressSpaces: r.getNumberAddressSpacesRequired(description), ResourceType: privateServiceConnectTypeName, Name: resource.Name}, nil
 }
 
 // Get the subnet requirements for a private service connect attachment
-func (r *privateServiceHandler) getNumberAddressSpacesRequired() int {
-	return 1 // Only used for GCP services (TODO: Change this to depend on that)
+func (r *privateServiceHandler) getNumberAddressSpacesRequired(description *ServiceAttachmentDescription) int {
+	// return 1 // Only used for GCP services (TODO: Change this to depend on that)
+	if description.Bundle != "" {
+		return 1
+	}
+
+	return 0
 }
 
 // Get the firewall target type and value for a specific service attachment

--- a/pkg/gcp/resources_test.go
+++ b/pkg/gcp/resources_test.go
@@ -449,6 +449,21 @@ func TestPrivateServiceGetResourceInfo(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Equal(t, fakeRegion, resourceInfo.Region)
+	assert.Equal(t, 0, resourceInfo.NumAdditionalAddressSpaces)
+	assert.Equal(t, privateServiceConnectTypeName, resourceInfo.ResourceType)
+	assert.Equal(t, fakePscName, resourceInfo.Name)
+}
+
+func TestGCPPrivateServiceGetResourceInfo(t *testing.T) {
+	pscHandler := &privateServiceHandler{}
+	resource, _, err := getFakePSCRequest(true)
+	require.NoError(t, err)
+
+	resourceInfo, err := pscHandler.getResourceInfo(context.Background(), resource)
+
+	require.NoError(t, err)
+	assert.Equal(t, "global", resourceInfo.Region)
+	assert.Equal(t, 1, resourceInfo.NumAdditionalAddressSpaces)
 	assert.Equal(t, privateServiceConnectTypeName, resourceInfo.ResourceType)
 	assert.Equal(t, fakePscName, resourceInfo.Name)
 }

--- a/pkg/gcp/resources_test.go
+++ b/pkg/gcp/resources_test.go
@@ -30,6 +30,7 @@ import (
 	paragliderpb "github.com/paraglider-project/paraglider/pkg/paragliderpb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
 )
 
 func getFakeInstanceResourceDescription() (*paragliderpb.CreateResourceRequest, *computepb.InsertInstanceRequest, error) {
@@ -166,12 +167,12 @@ func TestGetResourceNetworkInfo(t *testing.T) {
 	assert.Equal(t, *address.Address, netInfo.Address)
 }
 
-func TestIsValidResourceFromDescription(t *testing.T) {
+func TestIsValidResource(t *testing.T) {
 	// Test for instance
 	resource, fakeInstance, err := getFakeInstanceResourceDescription()
 	require.NoError(t, err)
 
-	resourceInfo, err := IsValidResourceFromDescription(context.Background(), resource)
+	resourceInfo, err := IsValidResource(context.Background(), resource)
 
 	require.NoError(t, err)
 	assert.Equal(t, fakeZone, resourceInfo.Zone)
@@ -181,7 +182,7 @@ func TestIsValidResourceFromDescription(t *testing.T) {
 	resource, fakeCluster, err := getFakeClusterResourceDescription()
 	require.NoError(t, err)
 
-	resourceInfo, err = IsValidResourceFromDescription(context.Background(), resource)
+	resourceInfo, err = IsValidResource(context.Background(), resource)
 
 	require.NoError(t, err)
 	assert.Equal(t, fakeZone, resourceInfo.Zone)
@@ -191,18 +192,27 @@ func TestIsValidResourceFromDescription(t *testing.T) {
 	resource, _, err = getFakePSCRequest(false)
 	require.NoError(t, err)
 
-	resourceInfo, err = IsValidResourceFromDescription(context.Background(), resource)
+	resourceInfo, err = IsValidResource(context.Background(), resource)
 
 	require.NoError(t, err)
 	assert.Equal(t, fakeRegion, resourceInfo.Region)
 	assert.Equal(t, resource.Name, resourceInfo.Name)
 }
 
-func TestInstanceIsValidResource(t *testing.T) {
+func TestValidateResourceCompliesWithParagliderRequirements(t *testing.T) {
 	instanceHandler := &instanceHandler{}
-	instance := getFakeInstance(true)
-	serverState := fakeServerState{instance: instance}
+	// rInfo := &resourceInfo{Project: fakeProject, Zone: fakeZone, Name: fakeInstanceName, ResourceType: instanceTypeName}
+	// serverState := fakeServerState{instance: instance}
+	firewallMap := map[string]*computepb.Firewall{
+		*fakeDenyAllRule.Name: fakeDenyAllRule,
+	}
+	
+	serverState := fakeServerState{
+		instance: getFakeInstance(true),
+		firewallMap: firewallMap,
+	}
 	fakeServer, ctx, fakeClients, fakeGRPCServer := setup(t, &serverState)
+
 	defer teardown(fakeServer, fakeClients, fakeGRPCServer)
 
 	req := &paragliderpb.AttachResourceRequest{
@@ -213,222 +223,36 @@ func TestInstanceIsValidResource(t *testing.T) {
 	err := instanceHandler.initClients(ctx, fakeClients)
 	require.NoError(t, err)
 
-	verifiedResourceInfo, err := instanceHandler.IsValidResource(ctx, req)
+	verifiedResourceInfo, _, err := instanceHandler.ValidateResourceCompliesWithParagliderRequirements(
+		ctx, req, fakeProject, fakeResourceId, fakeClients,
+	)
 
 	require.NoError(t, err)
 	assert.Equal(t, fakeInstanceName, verifiedResourceInfo.Name)
 	assert.Equal(t, fakeZone, verifiedResourceInfo.Zone)
 	assert.Equal(t, fakeProject, verifiedResourceInfo.Project)
 	assert.Equal(t, req.GetNamespace(), verifiedResourceInfo.Namespace)
-
 }
 
-// func TestValidateResourceCompliesWithParagliderRequirements(t *testing.T) {
-// 	instanceHandler := &instanceHandler{}
-// 	// rInfo := &resourceInfo{Project: fakeProject, Zone: fakeZone, Name: fakeInstanceName, ResourceType: instanceTypeName}
-// 	instance := getFakeInstance(true)
-// 	serverState := fakeServerState{instance: instance}
-// 	fakeServer, ctx, fakeClients, fakeGRPCServer := setup(t, &serverState)
-// 	defer teardown(fakeServer, fakeClients, fakeGRPCServer)
+func TestGetVPCAddressSpace(t *testing.T) {
+	serverState := fakeServerState{
+		network: &computepb.Network{
+			Subnetworks: []string{fmt.Sprintf("regions/%s/subnetworks/%s", fakeRegion, "paraglider-"+fakeRegion+"-subnet")},
+		},
+		subnetwork: &computepb.Subnetwork{
+			IpCidrRange: proto.String("10.10.0.0/16"),
+			SecondaryIpRanges: []*computepb.SubnetworkSecondaryRange{
+				{IpCidrRange: proto.String("10.11.0.0/16")},
+			},
+		},
+	}
+	fakeServer, ctx, fakeClients, fakeGRPCServer := setup(t, &serverState)
+	defer teardown(fakeServer, fakeClients, fakeGRPCServer)
 
-// 	req := &paragliderpb.AttachResourceRequest{
-// 		Resource: fmt.Sprintf("projects/%s/zones/%s/instances/%s", fakeProject, fakeZone, fakeInstanceName),
-// 		Namespace: fakeNamespace,
-// 	}
-
-// 	err := instanceHandler.initClients(ctx, fakeClients)
-// 	require.NoError(t, err)
-
-// 	verifiedResourceInfo, _, err := instanceHandler.ValidateResourceCompliesWithParagliderRequirements(
-// 		ctx, req, fakeProject, fakeResourceId, fakeClients,
-// 	)
-
-// 	require.NoError(t, err)
-// 	assert.Equal(t, fakeInstanceName, verifiedResourceInfo.Name)
-// 	assert.Equal(t, fakeZone, verifiedResourceInfo.Zone)
-// 	assert.Equal(t, fakeProject, verifiedResourceInfo.Project)
-// 	assert.Equal(t, req.GetNamespace(), verifiedResourceInfo.Namespace)
-// }
-
-// func TestValidateResourceCompliesWithParagliderRequirements(t *testing.T) {
-// 	resource, _, err := getFakeInstanceResourceDescription()
-// 	require.NoError(t, err)
-
-// 	rInfo := &resourceInfo{
-// 		Project:      fakeProject,
-// 		Zone:         fakeZone,
-// 		Name:         fakeInstanceName,
-// 		ResourceType: instanceTypeName,
-// 		Namespace:    fakeNamespace,
-// 	}
-// 	instance := getFakeInstance(true)
-// 	subnetworks := []*computepb.Subnetwork{
-// 		{
-// 			Network:     to.Ptr(getVpcName(fakeNamespace)),
-// 			SelfLink:    to.Ptr("fake-subnet-url"),
-// 			IpCidrRange: to.Ptr("10.0.0.0/24"),
-// 		},
-// 	}
-// 	firewalls := []*computepb.Firewall{{Name: to.Ptr("fw-1")}}
-
-// 	serverState := fakeServerState{
-// 		instance:     instance,
-// 		subnetworks:  map[string][]*computepb.Subnetwork{fakeRegion: subnetworks},
-// 		firewallMap:  map[string]*computepb.Firewall{"fw-1": firewalls[0]},
-// 	}
-// 	fakeServer, ctx, fakeClients, fakeGRPCServer := setup(t, &serverState)
-// 	defer teardown(fakeServer, fakeClients, fakeGRPCServer)
-
-// 	handler := &instanceHandler{client: fakeClients.ComputeInstances}
-// 	resourceInfo, networkInfo, err := handler.ValidateResourceCompliesWithParagliderRequirements(
-// 		ctx, resource, fakeProject, "resource-id", fakeServer,
-// 	)
-
-// 	require.NoError(t, err)
-// 	assert.Equal(t, fakeInstanceName, resourceInfo.Name)
-// 	assert.Equal(t, "10.0.0.0/24", networkInfo.Address)
-// }
-
-// func TestGetVPCAddressSpace(t *testing.T) {
-// 	subnetUrl := "https://www.googleapis.com/compute/v1/projects/fake-project/regions/fake-region/subnetworks/fake-subnet"
-// 	subnet := &computepb.Subnetwork{
-// 		IpCidrRange: to.Ptr("10.10.0.0/16"),
-// 		SecondaryIpRanges: []*computepb.SubnetworkSecondaryRange{
-// 			{IpCidrRange: to.Ptr("10.11.0.0/16")},
-// 		},
-// 	}
-// 	serverState := fakeServerState{
-// 		network: &computepb.Network{
-// 			Subnetworks: []string{subnetUrl},
-// 		},
-// 		subnetworkMap: map[string]*computepb.Subnetwork{
-// 			subnetUrl: subnet,
-// 		},
-// 	}
-// 	fakeServer, ctx, fakeClients, fakeGRPCServer := setup(t, &serverState)
-// 	defer teardown(fakeServer, fakeClients, fakeGRPCServer)
-
-// 	addressSpaces, err := GetVPCAddressSpace(ctx, fakeProject, "fake-vpc")
-// 	require.NoError(t, err)
-// 	assert.ElementsMatch(t, []string{"10.10.0.0/16", "10.11.0.0/16"}, addressSpaces)
-// }
-
-// func TestDoesVPCOverlapWithParaglider(t *testing.T) {
-// 	paragliderCIDR := "10.0.0.0/16"
-
-// 	resource := &resourceInfo{
-// 		Project:   fakeProject,
-// 		Namespace: fakeNamespace,
-// 	}
-
-// 	subnetURL := "https://www.googleapis.com/compute/v1/projects/fake-project/regions/fake-region/subnetworks/fake-subnet"
-// 	network := &computepb.Network{Subnetworks: []string{subnetURL}}
-
-// 	// Initial fake server state with overlapping VPC CIDR
-// 	serverState := fakeServerState{
-// 		network:       network,
-// 		subnetworkMap: map[string]*computepb.Subnetwork{},
-// 		usedAddressSpaces: []*paragliderpb.AddressSpaceMapping{
-// 			{
-// 				Cloud:         utils.GCP,
-// 				Namespace:     fakeNamespace,
-// 				AddressSpaces: []string{paragliderCIDR},
-// 			},
-// 		},
-// 	}
-
-// 	// Fake server setup for test
-// 	fakeServer, ctx, _, fakeGRPCServer := setup(t, &serverState)
-// 	defer teardown(fakeServer, nil, fakeGRPCServer)
-
-// 	// Overlapping VPC CIDR
-// 	vpcOverlapCIDR := "10.0.0.0/16"
-// 	subnet := &computepb.Subnetwork{
-// 		IpCidrRange: to.Ptr(vpcOverlapCIDR),
-// 	}
-// 	serverState.subnetworkMap[subnetURL] = subnet // Update subnet in server state
-
-// 	overlaps, err := DoesVPCOverlapWithParaglider(ctx, resource, "fake-vpc", fakeServer)
-// 	require.NoError(t, err)
-// 	assert.True(t, overlaps, "Expected address spaces to overlap")
-
-// 	// Non-overlapping CIDR (reset subnet state and run again)
-// 	vpcNonOverlapCIDR := "192.168.0.0/16"
-// 	subnetNonOverlap := &computepb.Subnetwork{
-// 		IpCidrRange: to.Ptr(vpcNonOverlapCIDR),
-// 	}
-// 	serverState.subnetworkMap[subnetURL] = subnetNonOverlap // Update subnet for non-overlapping CIDR
-
-// 	overlaps, err = DoesVPCOverlapWithParaglider(ctx, resource, "fake-vpc", fakeServer)
-// 	require.NoError(t, err)
-// 	assert.False(t, overlaps, "Expected address spaces not to overlap")
-// }
-
-// func TestDoesVPCOverlapWithParaglider(t *testing.T) {
-// 	vpcAddress := "10.0.0.0/16"
-// 	paragliderAddress := "10.0.0.0/16"
-
-// 	resource := &resourceInfo{
-// 		Project:   fakeProject,
-// 		Namespace: fakeNamespace,
-// 	}
-
-// 	subnetUrl := "https://www.googleapis.com/compute/v1/projects/fake-project/regions/fake-region/subnetworks/fake-subnet"
-// 	network := &computepb.Network{Subnetworks: []string{subnetUrl}}
-// 	subnet := &computepb.Subnetwork{
-// 		IpCidrRange: to.Ptr(vpcAddress),
-// 	}
-
-// 	serverState := fakeServerState{
-// 		network:       network,
-// 		subnetworkMap: map[string]*computepb.Subnetwork{subnetUrl: subnet},
-// 	}
-
-// 	fakeServer, ctx, fakeClients, fakeGRPCServer := setup(t, &serverState)
-// 	defer teardown(fakeServer, fakeClients, fakeGRPCServer)
-
-// 	overlaps, err := DoesVPCOverlapWithParaglider(ctx, resource, "fake-vpc", fakeServer)
-// 	require.NoError(t, err)
-// 	assert.True(t, overlaps)
-// }
-
-// func TestDoesVPCOverlapWithParagliderNoOverlap(t *testing.T) {
-// 	vpcCIDR := "192.168.0.0/16"
-// 	paragliderCIDR := "10.0.0.0/16"
-
-// 	resource := &resourceInfo{
-// 		Project:   fakeProject,
-// 		Namespace: fakeNamespace,
-// 	}
-
-// 	subnetUrl := "https://www.googleapis.com/compute/v1/projects/fake-project/regions/fake-region/subnetworks/fake-subnet"
-// 	network := &computepb.Network{
-// 		Subnetworks: []string{subnetUrl},
-// 	}
-// 	subnet := &computepb.Subnetwork{
-// 		IpCidrRange: to.Ptr(vpcCIDR),
-// 	}
-
-// 	// Fake server that returns VPC with 192.168.0.0/16 and Paraglider with 10.0.0.0/16
-// 	serverState := fakeServerState{
-// 		network:       network,
-// 		subnetworkMap: map[string]*computepb.Subnetwork{subnetUrl: subnet},
-// 		usedAddressSpaces: []*paragliderpb.AddressSpaceMapping{
-// 			{
-// 				Cloud:         utils.GCP,
-// 				Namespace:     fakeNamespace,
-// 				AddressSpaces: []string{paragliderCIDR},
-// 			},
-// 		},
-// 	}
-
-// 	fakeServer, ctx, _, fakeGRPCServer := setup(t, &serverState)
-// 	defer teardown(fakeServer, nil, fakeGRPCServer)
-
-// 	overlaps, err := DoesVPCOverlapWithParaglider(ctx, resource, "fake-vpc", fakeServer)
-// 	require.NoError(t, err)
-// 	assert.False(t, overlaps, "Expected no overlap between VPC and Paraglider address spaces")
-// }
+	addressSpaces, err := GetVPCAddressSpace(ctx, fakeProject, "fake-vpc", fakeClients)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"10.10.0.0/16", "10.11.0.0/16"}, addressSpaces)
+}
 
 func TestReadAndProvisionResource(t *testing.T) {
 	// Test for instance

--- a/pkg/gcp/resources_test.go
+++ b/pkg/gcp/resources_test.go
@@ -166,12 +166,12 @@ func TestGetResourceNetworkInfo(t *testing.T) {
 	assert.Equal(t, *address.Address, netInfo.Address)
 }
 
-func TestIsValidResource(t *testing.T) {
+func TestIsValidResourceFromDescription(t *testing.T) {
 	// Test for instance
 	resource, fakeInstance, err := getFakeInstanceResourceDescription()
 	require.NoError(t, err)
 
-	resourceInfo, err := IsValidResource(context.Background(), resource)
+	resourceInfo, err := IsValidResourceFromDescription(context.Background(), resource)
 
 	require.NoError(t, err)
 	assert.Equal(t, fakeZone, resourceInfo.Zone)
@@ -181,7 +181,7 @@ func TestIsValidResource(t *testing.T) {
 	resource, fakeCluster, err := getFakeClusterResourceDescription()
 	require.NoError(t, err)
 
-	resourceInfo, err = IsValidResource(context.Background(), resource)
+	resourceInfo, err = IsValidResourceFromDescription(context.Background(), resource)
 
 	require.NoError(t, err)
 	assert.Equal(t, fakeZone, resourceInfo.Zone)
@@ -191,12 +191,192 @@ func TestIsValidResource(t *testing.T) {
 	resource, _, err = getFakePSCRequest(false)
 	require.NoError(t, err)
 
-	resourceInfo, err = IsValidResource(context.Background(), resource)
+	resourceInfo, err = IsValidResourceFromDescription(context.Background(), resource)
 
 	require.NoError(t, err)
 	assert.Equal(t, fakeRegion, resourceInfo.Region)
 	assert.Equal(t, resource.Name, resourceInfo.Name)
 }
+
+func TestValidateResourceCompliesWithParagliderRequirements(t *testing.T) {
+	resource, _, err := getFakeInstanceResourceDescription()
+	require.NoError(t, err)
+
+	rInfo := &resourceInfo{
+		Project:      fakeProject,
+		Zone:         fakeZone,
+		Name:         fakeInstanceName,
+		ResourceType: instanceTypeName,
+		Namespace:    fakeNamespace,
+	}
+	instance := getFakeInstance(true)
+	subnetworks := []*computepb.Subnetwork{
+		{
+			Network:     to.Ptr(getVpcName(fakeNamespace)),
+			SelfLink:    to.Ptr("fake-subnet-url"),
+			IpCidrRange: to.Ptr("10.0.0.0/24"),
+		},
+	}
+	firewalls := []*computepb.Firewall{{Name: to.Ptr("fw-1")}}
+
+	serverState := fakeServerState{
+		instance:     instance,
+		subnetworks:  map[string][]*computepb.Subnetwork{fakeRegion: subnetworks},
+		firewallMap:  map[string]*computepb.Firewall{"fw-1": firewalls[0]},
+	}
+	fakeServer, ctx, fakeClients, fakeGRPCServer := setup(t, &serverState)
+	defer teardown(fakeServer, fakeClients, fakeGRPCServer)
+
+	handler := &instanceHandler{client: fakeClients.ComputeInstances}
+	resourceInfo, networkInfo, err := handler.ValidateResourceCompliesWithParagliderRequirements(
+		ctx, resource, fakeProject, "resource-id", fakeServer,
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, fakeInstanceName, resourceInfo.Name)
+	assert.Equal(t, "10.0.0.0/24", networkInfo.Address)
+}
+
+func TestGetVPCAddressSpace(t *testing.T) {
+	subnetUrl := "https://www.googleapis.com/compute/v1/projects/fake-project/regions/fake-region/subnetworks/fake-subnet"
+	subnet := &computepb.Subnetwork{
+		IpCidrRange: to.Ptr("10.10.0.0/16"),
+		SecondaryIpRanges: []*computepb.SubnetworkSecondaryRange{
+			{IpCidrRange: to.Ptr("10.11.0.0/16")},
+		},
+	}
+	serverState := fakeServerState{
+		network: &computepb.Network{
+			Subnetworks: []string{subnetUrl},
+		},
+		subnetworkMap: map[string]*computepb.Subnetwork{
+			subnetUrl: subnet,
+		},
+	}
+	fakeServer, ctx, fakeClients, fakeGRPCServer := setup(t, &serverState)
+	defer teardown(fakeServer, fakeClients, fakeGRPCServer)
+
+	addressSpaces, err := GetVPCAddressSpace(ctx, fakeProject, "fake-vpc")
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"10.10.0.0/16", "10.11.0.0/16"}, addressSpaces)
+}
+
+func TestDoesVPCOverlapWithParaglider(t *testing.T) {
+	paragliderCIDR := "10.0.0.0/16"
+
+	resource := &resourceInfo{
+		Project:   fakeProject,
+		Namespace: fakeNamespace,
+	}
+
+	subnetURL := "https://www.googleapis.com/compute/v1/projects/fake-project/regions/fake-region/subnetworks/fake-subnet"
+	network := &computepb.Network{Subnetworks: []string{subnetURL}}
+
+	// Initial fake server state with overlapping VPC CIDR
+	serverState := fakeServerState{
+		network:       network,
+		subnetworkMap: map[string]*computepb.Subnetwork{},
+		usedAddressSpaces: []*paragliderpb.AddressSpaceMapping{
+			{
+				Cloud:         utils.GCP,
+				Namespace:     fakeNamespace,
+				AddressSpaces: []string{paragliderCIDR},
+			},
+		},
+	}
+
+	// Fake server setup for test
+	fakeServer, ctx, _, fakeGRPCServer := setup(t, &serverState)
+	defer teardown(fakeServer, nil, fakeGRPCServer)
+
+	// Overlapping VPC CIDR
+	vpcOverlapCIDR := "10.0.0.0/16"
+	subnet := &computepb.Subnetwork{
+		IpCidrRange: to.Ptr(vpcOverlapCIDR),
+	}
+	serverState.subnetworkMap[subnetURL] = subnet // Update subnet in server state
+
+	overlaps, err := DoesVPCOverlapWithParaglider(ctx, resource, "fake-vpc", fakeServer)
+	require.NoError(t, err)
+	assert.True(t, overlaps, "Expected address spaces to overlap")
+
+	// Non-overlapping CIDR (reset subnet state and run again)
+	vpcNonOverlapCIDR := "192.168.0.0/16"
+	subnetNonOverlap := &computepb.Subnetwork{
+		IpCidrRange: to.Ptr(vpcNonOverlapCIDR),
+	}
+	serverState.subnetworkMap[subnetURL] = subnetNonOverlap // Update subnet for non-overlapping CIDR
+
+	overlaps, err = DoesVPCOverlapWithParaglider(ctx, resource, "fake-vpc", fakeServer)
+	require.NoError(t, err)
+	assert.False(t, overlaps, "Expected address spaces not to overlap")
+}
+
+// func TestDoesVPCOverlapWithParaglider(t *testing.T) {
+// 	vpcAddress := "10.0.0.0/16"
+// 	paragliderAddress := "10.0.0.0/16"
+
+// 	resource := &resourceInfo{
+// 		Project:   fakeProject,
+// 		Namespace: fakeNamespace,
+// 	}
+
+// 	subnetUrl := "https://www.googleapis.com/compute/v1/projects/fake-project/regions/fake-region/subnetworks/fake-subnet"
+// 	network := &computepb.Network{Subnetworks: []string{subnetUrl}}
+// 	subnet := &computepb.Subnetwork{
+// 		IpCidrRange: to.Ptr(vpcAddress),
+// 	}
+
+// 	serverState := fakeServerState{
+// 		network:       network,
+// 		subnetworkMap: map[string]*computepb.Subnetwork{subnetUrl: subnet},
+// 	}
+
+// 	fakeServer, ctx, fakeClients, fakeGRPCServer := setup(t, &serverState)
+// 	defer teardown(fakeServer, fakeClients, fakeGRPCServer)
+
+// 	overlaps, err := DoesVPCOverlapWithParaglider(ctx, resource, "fake-vpc", fakeServer)
+// 	require.NoError(t, err)
+// 	assert.True(t, overlaps)
+// }
+
+// func TestDoesVPCOverlapWithParagliderNoOverlap(t *testing.T) {
+// 	vpcCIDR := "192.168.0.0/16"
+// 	paragliderCIDR := "10.0.0.0/16"
+
+// 	resource := &resourceInfo{
+// 		Project:   fakeProject,
+// 		Namespace: fakeNamespace,
+// 	}
+
+// 	subnetUrl := "https://www.googleapis.com/compute/v1/projects/fake-project/regions/fake-region/subnetworks/fake-subnet"
+// 	network := &computepb.Network{
+// 		Subnetworks: []string{subnetUrl},
+// 	}
+// 	subnet := &computepb.Subnetwork{
+// 		IpCidrRange: to.Ptr(vpcCIDR),
+// 	}
+
+// 	// Fake server that returns VPC with 192.168.0.0/16 and Paraglider with 10.0.0.0/16
+// 	serverState := fakeServerState{
+// 		network:       network,
+// 		subnetworkMap: map[string]*computepb.Subnetwork{subnetUrl: subnet},
+// 		usedAddressSpaces: []*paragliderpb.AddressSpaceMapping{
+// 			{
+// 				Cloud:         utils.GCP,
+// 				Namespace:     fakeNamespace,
+// 				AddressSpaces: []string{paragliderCIDR},
+// 			},
+// 		},
+// 	}
+
+// 	fakeServer, ctx, _, fakeGRPCServer := setup(t, &serverState)
+// 	defer teardown(fakeServer, nil, fakeGRPCServer)
+
+// 	overlaps, err := DoesVPCOverlapWithParaglider(ctx, resource, "fake-vpc", fakeServer)
+// 	require.NoError(t, err)
+// 	assert.False(t, overlaps, "Expected no overlap between VPC and Paraglider address spaces")
+// }
 
 func TestReadAndProvisionResource(t *testing.T) {
 	// Test for instance

--- a/pkg/gcp/resources_test.go
+++ b/pkg/gcp/resources_test.go
@@ -709,11 +709,10 @@ func TestPrivateServiceGetResourceInfo(t *testing.T) {
 	assert.Equal(t, fakePscName, resourceInfo.Name)
 }
 
-func TestGCPPrivateServiceGetResourceInfo(t *testing.T) {
+func TestPrivateServiceGetResourceInfoGoogleService(t *testing.T) {
 	pscHandler := &privateServiceHandler{}
 	resource, _, err := getFakePSCRequest(true)
 	require.NoError(t, err)
-
 	resourceInfo, err := pscHandler.getResourceInfo(context.Background(), resource)
 
 	require.NoError(t, err)

--- a/pkg/gcp/resources_test.go
+++ b/pkg/gcp/resources_test.go
@@ -247,6 +247,145 @@ func TestValidateResourceCompliesWithParagliderRequirements(t *testing.T) {
 	assert.Equal(t, req.GetNamespace(), verifiedResourceInfo.Namespace)
 }
 
+func TestValidateResourceCompliesWithParagliderRequirementsResourceUrlError(t *testing.T) {
+	instanceHandler := &instanceHandler{}
+	req := &paragliderpb.AttachResourceRequest{
+		Resource:  "invalid-resource-url",
+		Namespace: "ns",
+	}
+
+	_, _, err := instanceHandler.ValidateResourceCompliesWithParagliderRequirements(
+		context.Background(), req, "project", "resourceId", "orchestratorAddr", &GCPClients{},
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse resource URL")
+}
+
+func TestValidateResourceCompliesWithParagliderRequirementsNoInstance(t *testing.T) {
+	instanceHandler := &instanceHandler{}
+	firewallMap := map[string]*computepb.Firewall{
+		*fakeDenyAllRule.Name: fakeDenyAllRule,
+	}
+
+	serverState := fakeServerState{
+		firewallMap: firewallMap,
+		network: &computepb.Network{
+			Subnetworks: []string{fmt.Sprintf("regions/%s/subnetworks/%s", fakeRegion, "paraglider-"+fakeRegion+"-subnet")},
+		},
+		subnetwork: &computepb.Subnetwork{
+			IpCidrRange: proto.String("10.10.0.0/16"),
+			SecondaryIpRanges: []*computepb.SubnetworkSecondaryRange{
+				{IpCidrRange: proto.String("10.11.0.0/16")},
+			},
+		},
+	}
+	fakeServer, ctx, fakeClients, fakeGRPCServer := setup(t, &serverState)
+	defer teardown(fakeServer, fakeClients, fakeGRPCServer)
+
+	_, fakeOrchestratorServerAddr, err := fake.SetupFakeOrchestratorRPCServer(utils.GCP)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req := &paragliderpb.AttachResourceRequest{
+		Resource:  fmt.Sprintf("projects/%s/zones/%s/instances/%s", fakeProject, fakeZone, fakeInstanceName),
+		Namespace: fakeNamespace,
+	}
+
+	err = instanceHandler.initClients(ctx, fakeClients)
+	require.NoError(t, err)
+
+	_, _, err = instanceHandler.ValidateResourceCompliesWithParagliderRequirements(
+		ctx, req, fakeProject, fakeResourceId, fakeOrchestratorServerAddr, fakeClients,
+	)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unable to get instance")
+}
+
+func TestValidateResourceCompliesWithParagliderRequirementsVPCOverlap(t *testing.T) {
+	instanceHandler := &instanceHandler{}
+
+	// Overlapping
+	serverState := fakeServerState{
+		network: &computepb.Network{
+			Subnetworks: []string{fmt.Sprintf("regions/%s/subnetworks/%s", fakeRegion, "paraglider-"+fakeRegion+"-subnet")},
+		},
+		subnetwork: &computepb.Subnetwork{
+			IpCidrRange: proto.String("10.0.0.0/16"), // this will overlap with orchestrator's 10.0.0.0/16
+		},
+	}
+
+	fakeServer, ctx, fakeClients, fakeGRPCServer := setup(t, &serverState)
+	defer teardown(fakeServer, fakeClients, fakeGRPCServer)
+
+	// Setup fake orchestrator with Counter = 1 so it returns 10.0.0.0/16 as used address space
+	fakeOrchestrator, fakeOrchestratorServerAddr, err := fake.SetupFakeOrchestratorRPCServer(utils.GCP)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fakeOrchestrator.Counter = 1
+
+	req := &paragliderpb.AttachResourceRequest{
+		Resource:  fmt.Sprintf("projects/%s/zones/%s/instances/%s", fakeProject, fakeZone, fakeInstanceName),
+		Namespace: fakeNamespace,
+	}
+
+	err = instanceHandler.initClients(ctx, fakeClients)
+	require.NoError(t, err)
+
+	_, _, err = instanceHandler.ValidateResourceCompliesWithParagliderRequirements(
+		ctx, req, fakeProject, fakeResourceId, fakeOrchestratorServerAddr, fakeClients,
+	)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Error in getting resource")
+}
+
+func TestValidateResourceCompliesWithParagliderRequirementsFirewallsError(t *testing.T) {
+	instanceHandler := &instanceHandler{}
+	firewallMap := map[string]*computepb.Firewall{
+		*fakeDenyAllRule.Name: nil,
+	}
+
+	serverState := fakeServerState{
+		instance:    getFakeInstance(true),
+		firewallMap: firewallMap,
+		network: &computepb.Network{
+			Subnetworks: []string{fmt.Sprintf("regions/%s/subnetworks/%s", fakeRegion, "paraglider-"+fakeRegion+"-subnet")},
+		},
+		subnetwork: &computepb.Subnetwork{
+			IpCidrRange: proto.String("10.10.0.0/16"),
+			SecondaryIpRanges: []*computepb.SubnetworkSecondaryRange{
+				{IpCidrRange: proto.String("10.11.0.0/16")},
+			},
+		},
+	}
+	fakeServer, ctx, fakeClients, fakeGRPCServer := setup(t, &serverState)
+	defer teardown(fakeServer, fakeClients, fakeGRPCServer)
+
+	_, fakeOrchestratorServerAddr, err := fake.SetupFakeOrchestratorRPCServer(utils.GCP)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req := &paragliderpb.AttachResourceRequest{
+		Resource:  fmt.Sprintf("projects/%s/zones/%s/instances/%s", fakeProject, fakeZone, fakeInstanceName),
+		Namespace: fakeNamespace,
+	}
+
+	err = instanceHandler.initClients(ctx, fakeClients)
+	require.NoError(t, err)
+
+	_, _, err = instanceHandler.ValidateResourceCompliesWithParagliderRequirements(
+		ctx, req, fakeProject, fakeResourceId, fakeOrchestratorServerAddr, fakeClients,
+	)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Firewall rules are not compliant")
+}
+
 func TestGetVPCAddressSpace(t *testing.T) {
 	serverState := fakeServerState{
 		network: &computepb.Network{
@@ -265,6 +404,53 @@ func TestGetVPCAddressSpace(t *testing.T) {
 	addressSpaces, err := GetVPCAddressSpace(ctx, fakeProject, "fake-vpc", fakeClients)
 	require.NoError(t, err)
 	assert.ElementsMatch(t, []string{"10.10.0.0/16", "10.11.0.0/16"}, addressSpaces)
+}
+
+func TestDoesVPCOverlapWithParaglider(t *testing.T) {
+	// Overlapping
+	serverState := fakeServerState{
+		network: &computepb.Network{
+			Subnetworks: []string{fmt.Sprintf("regions/%s/subnetworks/%s", fakeRegion, "paraglider-"+fakeRegion+"-subnet")},
+		},
+		subnetwork: &computepb.Subnetwork{
+			IpCidrRange: proto.String("10.0.0.0/16"), // this will overlap with orchestrator's 10.0.0.0/16
+		},
+	}
+
+	fakeServer, ctx, fakeClients, fakeGRPCServer := setup(t, &serverState)
+	defer teardown(fakeServer, fakeClients, fakeGRPCServer)
+
+	// Setup fake orchestrator with Counter = 1 so it returns 10.0.0.0/16 as used address space
+	fakeOrchestrator, orchestratorAddr, err := fake.SetupFakeOrchestratorRPCServer(utils.GCP)
+	if err != nil {
+		t.Fatalf("failed to setup fake orchestrator: %v", err)
+	}
+	fakeOrchestrator.Counter = 1
+
+	resource := &resourceInfo{
+		Project: fakeProject,
+	}
+
+	overlap, err := DoesVPCOverlapWithParaglider(ctx, resource, "fake-vpc", orchestratorAddr, fakeClients)
+	require.NoError(t, err)
+	assert.True(t, overlap, "Expected VPC to overlap with orchestrator-used CIDR space")
+
+	// Nonoverlapping
+	serverState = fakeServerState{
+		network: &computepb.Network{
+			Subnetworks: []string{fmt.Sprintf("regions/%s/subnetworks/%s", fakeRegion, "paraglider-"+fakeRegion+"-subnet")},
+		},
+		subnetwork: &computepb.Subnetwork{
+			IpCidrRange: proto.String("192.168.0.0/16"), // this will not overlap with orchestrator's 10.0.0.0/16
+		},
+	}
+
+	fakeServer, ctx, fakeClients, fakeGRPCServer = setup(t, &serverState)
+	defer teardown(fakeServer, fakeClients, fakeGRPCServer)
+
+	overlap, err = DoesVPCOverlapWithParaglider(ctx, resource, "fake-vpc", orchestratorAddr, fakeClients)
+	require.NoError(t, err)
+	assert.False(t, overlap, "Expected VPC to not overlap with orchestrator-used CIDR space")
 }
 
 func TestReadAndProvisionResource(t *testing.T) {


### PR DESCRIPTION
- Adds functions and tests to determine the compliance of existing GCP resources with paraglider for attachment
- Criteria for compliance:
  - [x] Validate that resource is valid and is a supported type
  - [x] Ensure VPC address isn't overlapping within the deployment
  - [x] Ensure that permit list of the VNet has a deny all rule with the lowest priority (i.e. highest priority number)
  - [x] Ensures that all rules with higher priority than the deny all rule are allow rules
  - [x] Any deny rule must be a deny all rule. All rule verifications disregard the default rules created by GCP with priority > 65534