### PR TITLE
[Azure] Change all instances of "westus" to "westus2" for our current backend subscription

### DIFF
--- a/.github/workflows/functional-tests.yaml
+++ b/.github/workflows/functional-tests.yaml
@@ -90,10 +90,10 @@ jobs:
         with:
           workload_identity_provider: 'projects/112338121957/locations/global/workloadIdentityPools/github/providers/paraglider'
           service_account: 'invisinets-cicd@invisinets-cicd.iam.gserviceaccount.com'
-      - name: Authenticate to Azure
-        uses: azure/login@v2
-        with:
-            creds: ${{ secrets.AZURE_CREDENTIALS }}
+      # - name: Authenticate to Azure
+      #   uses: azure/login@v2
+      #   with:
+      #       creds: ${{ secrets.AZURE_CREDENTIALS }}
       - name: Authenticate to AWS
         uses: aws-actions/configure-aws-credentials@v4
         with:

--- a/build/test.mk
+++ b/build/test.mk
@@ -29,7 +29,7 @@ integration-test:
 	$(GOTEST_CMD) -tags=integration -timeout 70m
 
 .PHONY: azure-integration-test
-integration-test:
+azure-integration-test:
 	$(GOTEST_CMD) -tags=integrationazure -timeout 70m
 
 .PHONY: multicloud-test

--- a/build/test.mk
+++ b/build/test.mk
@@ -28,7 +28,7 @@ test: ## Runs unit tests in the internal and pkg folders
 integration-test:
 	$(GOTEST_CMD) -tags=integration -timeout 70m
 
-.PHONY: integration-test-azure
+.PHONY: azure-integration-test
 integration-test:
 	$(GOTEST_CMD) -tags=integrationazure -timeout 70m
 

--- a/build/test.mk
+++ b/build/test.mk
@@ -30,7 +30,7 @@ integration-test:
 
 .PHONY: integration-test-azure
 integration-test:
-	$(GOTEST_CMD) -tags=integration-azure -timeout 70m
+	$(GOTEST_CMD) -tags=integrationazure -timeout 70m
 
 .PHONY: multicloud-test
 multicloud-test:

--- a/build/test.mk
+++ b/build/test.mk
@@ -28,6 +28,10 @@ test: ## Runs unit tests in the internal and pkg folders
 integration-test:
 	$(GOTEST_CMD) -tags=integration -timeout 70m
 
+.PHONY: integration-test-azure
+integration-test:
+	$(GOTEST_CMD) -tags=integration-azure -timeout 70m
+
 .PHONY: multicloud-test
 multicloud-test:
 	$(GOTEST_CMD) -tags=multicloud -timeout 2h

--- a/pkg/azure/plugin.go
+++ b/pkg/azure/plugin.go
@@ -43,7 +43,7 @@ type azurePluginServer struct {
 }
 
 const (
-	vpnLocation                = "westus" // TODO @seankimkdy: should this be configurable/dynamic?
+	vpnLocation                = "westus2" // TODO @seankimkdy: should this be configurable/dynamic?
 	gatewaySubnetName          = "GatewaySubnet"
 	gatewaySubnetAddressPrefix = "192.168.255.0/27"
 )

--- a/pkg/azure/plugin_integration_test.go
+++ b/pkg/azure/plugin_integration_test.go
@@ -395,6 +395,11 @@ func TestAttachResourceIntegration(t *testing.T) {
 				},
 			},
 		},
+		FeatureFlags: map[string]config.FeatureFlags{
+			utils.AZURE: {
+				AttachResourceEnabled: true,
+			},
+		},
 	}
 	orchestratorServerAddr := orchestratorServerConfig.Server.Host + ":" + orchestratorServerConfig.Server.RpcPort
 	orchestrator.Setup(orchestratorServerConfig, true)

--- a/pkg/azure/plugin_integration_test.go
+++ b/pkg/azure/plugin_integration_test.go
@@ -1,4 +1,4 @@
-//go:build integration-azure
+//go:build integrationazure
 
 /*
 Copyright 2023 The Paraglider Authors.

--- a/pkg/azure/plugin_integration_test.go
+++ b/pkg/azure/plugin_integration_test.go
@@ -68,7 +68,7 @@ func TestBasicPermitListOps(t *testing.T) {
 	ctx := context.Background()
 
 	vmNamePrefix := "sample-vm"
-	vmLocation := "westus"
+	vmLocation := "westus2"
 	parameters := GetTestVmParameters(vmLocation)
 	descriptionJson, err := json.Marshal(parameters)
 	require.NoError(t, err)
@@ -170,7 +170,7 @@ func TestCrossNamespaces(t *testing.T) {
 
 	// Create vm1 in rg1
 	vm1Name := "vm-paraglider-test1"
-	vm1Location := "westus"
+	vm1Location := "westus2"
 	createVM1Resp, err := createVM(ctx, azureServer, subscriptionId, resourceGroup1Name, resourceGroup1Namespace, vm1Location, vm1Name)
 	require.NoError(t, err)
 	require.NotNil(t, createVM1Resp)
@@ -178,7 +178,7 @@ func TestCrossNamespaces(t *testing.T) {
 
 	// Create vm2 in rg2
 	vm2Name := "vm-paraglider-test2"
-	vm2Location := "westus"
+	vm2Location := "westus2"
 	createVM2Resp, err := createVM(ctx, azureServer, subscriptionId, resourceGroup2Name, resourceGroup2Namespace, vm2Location, vm2Name)
 	require.NoError(t, err)
 	require.NotNil(t, createVM2Resp)
@@ -288,7 +288,7 @@ func TestMultipleRegionsIntraNamespace(t *testing.T) {
 
 	// Create 2 VMs in different regions
 	vm1Name := "vm-paraglider-test-west"
-	vm1Location := "westus"
+	vm1Location := "westus2"
 	createVM1Resp, err := createVM(ctx, azureServer, subscriptionId, resourceGroupName, defaultNamespace, vm1Location, vm1Name)
 	require.NoError(t, err)
 	require.NotNil(t, createVM1Resp)
@@ -402,7 +402,7 @@ func TestAttachResourceIntegration(t *testing.T) {
 	// Setup Azure plugin server
 	azureServer := Setup(azureServerPort, orchestratorServerAddr)
 
-	vmLocation := "westus"
+	vmLocation := "westus2"
 	externalVmParameters := GetTestVmParameters(vmLocation)
 	externalVmName := "external-vm"
 	externalVnetName := "external-vnet"
@@ -563,7 +563,7 @@ func TestPublicIPAddressTarget(t *testing.T) {
 	ctx := context.Background()
 
 	// Create VM
-	vmLocation := "westus"
+	vmLocation := "westus2"
 	vmParameters := GetTestVmParameters(vmLocation)
 	vmDescriptionJson, err := json.Marshal(vmParameters)
 	require.NoError(t, err)

--- a/pkg/azure/plugin_integration_test.go
+++ b/pkg/azure/plugin_integration_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 /*
 Copyright 2023 The Paraglider Authors.
 Licensed under the Apache License, Version 2.0 (the "License");

--- a/pkg/azure/plugin_integration_test.go
+++ b/pkg/azure/plugin_integration_test.go
@@ -1,3 +1,5 @@
+//go:build integration-azure
+
 /*
 Copyright 2023 The Paraglider Authors.
 Licensed under the Apache License, Version 2.0 (the "License");

--- a/pkg/azure/plugin_integration_test.go
+++ b/pkg/azure/plugin_integration_test.go
@@ -438,7 +438,7 @@ func TestAttachResourceIntegration(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create Non-Paraglider Vnet
-	externalVnetParams := getVirtualNetworkParameters(vmLocation, externalAddressSpace)
+	externalVnetParams := GetVirtualNetworkParameters(vmLocation, externalAddressSpace)
 	externalVnet, err := azureHandler.CreateOrUpdateVirtualNetwork(ctx, externalVnetName, externalVnetParams)
 	require.NotNil(t, externalVnet)
 	require.NoError(t, err)

--- a/pkg/azure/utils.go
+++ b/pkg/azure/utils.go
@@ -44,6 +44,7 @@ const (
 	virtualNetworkGatewayTypeName = "Microsoft.Network/virtualNetworkGateways"
 	virtualNetworkTypeName        = "Microsoft.Network/virtualNetworks"
 	networkWatcherTypeName        = "Microsoft.Network/networkWatchers"
+	natGatewayTypeName            = "Microsoft.Network/natGateways"
 )
 
 // Gets subscription ID defined in environment variable
@@ -176,6 +177,7 @@ func TeardownAzureTesting(subscriptionId string, resourceGroupName string, names
 					connectionTypeName,
 					virtualNetworkGatewayTypeName,
 					localNetworkGatewayTypeName,
+					natGatewayTypeName,
 					publicIPAddressTypeName,
 					virtualNetworkTypeName,
 					networkSecurityGroupTypeName,

--- a/pkg/azure/utils.go
+++ b/pkg/azure/utils.go
@@ -83,7 +83,7 @@ func SetupAzureTesting(subscriptionId string, testName string) string {
 	}
 	resourceGroupsClient := createResourceGroupsClient(subscriptionId)
 	_, err := resourceGroupsClient.CreateOrUpdate(context.Background(), resourceGroupName, armresources.ResourceGroup{
-		Location: to.Ptr("westus"),
+		Location: to.Ptr("westus2"),
 	}, nil)
 	if err != nil {
 		panic(fmt.Sprintf("Error while creating resource group: %v", err))

--- a/pkg/azure/utils.go
+++ b/pkg/azure/utils.go
@@ -433,11 +433,11 @@ func DoesVnetOverlapWithParaglider(ctx context.Context, handler *AzureSDKHandler
 	return false, nil
 }
 
-// getVirtualNetworkParameters creates and returns an instance of armnetwork.VirtualNetwork
+// GetVirtualNetworkParameters creates and returns an instance of armnetwork.VirtualNetwork
 // with the specified parameters.
 //
 // Subnet address space is the same as the Vnet address space.
-func getVirtualNetworkParameters(location string, addressSpace string) armnetwork.VirtualNetwork {
+func GetVirtualNetworkParameters(location string, addressSpace string) armnetwork.VirtualNetwork {
 	return armnetwork.VirtualNetwork{
 		Location: to.Ptr(location),
 		Properties: &armnetwork.VirtualNetworkPropertiesFormat{

--- a/pkg/multicloud/multicloud_test.go
+++ b/pkg/multicloud/multicloud_test.go
@@ -107,7 +107,7 @@ func TestMulticloud(t *testing.T) {
 	ctx := context.Background()
 
 	// Create Azure VM 1
-	azureVm1Location := "westus"
+	azureVm1Location := "westus2"
 	azureVm1Parameters := azure.GetTestVmParameters(azureVm1Location)
 	azureVm1Description, err := json.Marshal(azureVm1Parameters)
 	azureVm1Name := "paraglider-vm-test-1"
@@ -443,7 +443,7 @@ func TestMulticloudIBMAzure(t *testing.T) {
 
 	// Create Azure VM
 	fmt.Println("\nCreating Azure VM...")
-	azureVm1Location := "westus"
+	azureVm1Location := "westus2"
 	azureVm1Parameters := azure.GetTestVmParameters(azureVm1Location)
 	azureVm1Description, err := json.Marshal(azureVm1Parameters)
 	require.NoError(t, err)


### PR DESCRIPTION
As mentioned in #525, we currently cannot create resources anywhere but westus2. While this is getting resolved, let's move all non-region-dependent instances of an arbitrary region to "westus2" so that it can work in the meantime.

Also, I added a change to put Azure integration tests on their own `make` command so that the pipeline can proceed without it (Authentication issues in #525), but we can run them locally for people who have access to an account. 