### PR TITLE
[Orchestrator] Allow multiple rules to be added at once when applying to a tag

### DIFF
--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -387,8 +387,8 @@ func (s *ControllerServer) permitListRuleAddTag(c *gin.Context) {
 	tag := c.Param("tag")
 
 	// Parse permit list rules to add
-	var rule *paragliderpb.PermitListRule
-	if err := c.BindJSON(&rule); err != nil {
+	var rules []*paragliderpb.PermitListRule
+	if err := c.BindJSON(&rules); err != nil {
 		c.AbortWithStatusJSON(400, createErrorResponse(err.Error()))
 		return
 	}
@@ -441,7 +441,7 @@ func (s *ControllerServer) permitListRuleAddTag(c *gin.Context) {
 
 		// Send RPC to add rule
 		client := paragliderpb.NewCloudPluginClient(conn)
-		_, err = client.AddPermitListRules(context.Background(), &paragliderpb.AddPermitListRulesRequest{Rules: []*paragliderpb.PermitListRule{rule}, Namespace: namespace, Resource: *mapping.Uri})
+		_, err = client.AddPermitListRules(context.Background(), &paragliderpb.AddPermitListRulesRequest{Rules: rules, Namespace: namespace, Resource: *mapping.Uri})
 		if err != nil {
 			c.AbortWithStatusJSON(400, createErrorResponse(err.Error()))
 			return

--- a/pkg/orchestrator/orchestrator_test.go
+++ b/pkg/orchestrator/orchestrator_test.go
@@ -375,13 +375,13 @@ func TestPermitListRuleTagAdd(t *testing.T) {
 
 	// Well-formed request
 	tags := []string{"1.1.1.1"}
-	rule := &paragliderpb.PermitListRule{
+	rule := []*paragliderpb.PermitListRule{&paragliderpb.PermitListRule{
 		Name:      "rulename",
 		Tags:      tags,
 		Direction: paragliderpb.Direction_INBOUND,
 		SrcPort:   1,
 		DstPort:   2,
-		Protocol:  1}
+		Protocol:  1}}
 	jsonValue, _ := json.Marshal(rule)
 
 	url := fmt.Sprintf(GetFormatterString(RuleOnTagURL), defaultNamespace+"."+exampleCloudName+"."+faketagservice.ValidTagName)


### PR DESCRIPTION
I found this bug by attempting to add a rule with the `--ping` flag to a tag rather than a resource (eg, `default.azure.vm1` instead of `azure vm1`). This results in two rules being sent in the payload to the orchestrator. While this is fine when applied to the function for resources, the one for tags only parsed one rule. 

I updated it to accept a list of rules (as the other APIs do)