### PR TITLE
[Dev] Fixing dev container creation in json

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,7 @@
 // README at: https://github.com/devcontainers/templates/tree/main/src/go
 {
 	"name": "Go",
-	"image": "mcr.microsoft.com/devcontainers/go:1.22",
+	"image": "mcr.microsoft.com/devcontainers/go:1.23",
 	"features": {
 		"ghcr.io/guiyomh/features/golangci-lint:0": {
 			"version": "latest"
@@ -13,8 +13,8 @@
         },
 		"azure-cli": "latest",
 		"ghcr.io/devcontainers/features/aws-cli": "latest",
-		"ghcr.io/devcontainers-contrib/features/protoc:1": "latest",
-		"ghcr.io/devcontainers-contrib/features/tmux-apt-get:1": "latest",
+		"ghcr.io/devcontainers-extra/features/protoc:1": "latest",
+		"ghcr.io/devcontainers-extra/features/tmux-apt-get:1": "latest",
 		"ghcr.io/devcontainers/features/python:1": {"version": "3.11"}
 	},
 


### PR DESCRIPTION
- Updated dev container to use go version 1.23
- Updated dev container references from protoc and tmux-apt-get