### PR TITLE
Go Version and Linter Updates

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -11,6 +11,9 @@ run:
   modules-download-mode: readonly
   # use the Go version from the go.mod file.
   go: ""
+  build-tags:
+    - unit
+    - integration
 
 linters:
   # set to true to run only fast linters (e.g., for pre-commit)
@@ -18,55 +21,21 @@ linters:
 
   disable-all: true
   enable:
-    - asasalint
-    - asciicheck
-    - bidichk
-    - bodyclose
-    - contextcheck
-    - durationcheck
-    - errcheck 
-    - errname
-    - errorlint
-    - ginkgolinter
-    - gocritic
-    - godot
-    - gosec
+    - errcheck
     - govet
-    - grouper
-    - lll
-    - loggercheck
-    - importas
     - ineffassign
-    - makezero
-    - misspell
-    - nakedret
-    - nestif
-    - nilerr
-    - nolintlint
-    - nonamedreturns
-    - nosprintfhostport
-    - prealloc
-    - predeclared
-    - promlinter
-    - reassign
-    - revive
     - staticcheck
-    - tagliatelle
-    - testableexamples
-    - thelper
-    - testpackage
-    - tparallel
-    - unconvert
-    - unparam
     - unused
-    - usestdlibvars
-    - varnamelen
-    - whitespace
+    - goheader
 
 formatters:
   enable:
     - gofumpt
     - goimports
+
+linters-settings:
+  goheader:
+    template-path: build/header.tmpl
 
 output:
   sort-order:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,19 +1,88 @@
-linters:
-  enable:
-  - goheader
-issues:
-  exclude-rules:
-    # Ignore test files which have unit/integration tags
-    - path: _test\.go
-      linters:
-        - goheader
-linters-settings:
-  # Settings for linter 'goheader'
-  #
-  # This is used to validate that all go files have the required copyright header.
-  goheader:
-    template-path: build/header.tmpl
+version: "2"
+
 run:
-  build-tags:
-    - unit
-    - integration
+  # linter execution
+  timeout: 30m
+  issues-exit-code: 1
+  concurrency: 4
+  # check tests as well
+  tests: true
+  # fail if go.mod file is outdated.
+  modules-download-mode: readonly
+  # use the Go version from the go.mod file.
+  go: ""
+
+linters:
+  # set to true to run only fast linters (e.g., for pre-commit)
+  fast: false
+
+  disable-all: true
+  enable:
+    - asasalint
+    - asciicheck
+    - bidichk
+    - bodyclose
+    - contextcheck
+    - durationcheck
+    - errcheck 
+    - errname
+    - errorlint
+    - ginkgolinter
+    - gocritic
+    - godot
+    - gosec
+    - govet
+    - grouper
+    - lll
+    - loggercheck
+    - importas
+    - ineffassign
+    - makezero
+    - misspell
+    - nakedret
+    - nestif
+    - nilerr
+    - nolintlint
+    - nonamedreturns
+    - nosprintfhostport
+    - prealloc
+    - predeclared
+    - promlinter
+    - reassign
+    - revive
+    - staticcheck
+    - tagliatelle
+    - testableexamples
+    - thelper
+    - testpackage
+    - tparallel
+    - unconvert
+    - unparam
+    - unused
+    - usestdlibvars
+    - varnamelen
+    - whitespace
+
+formatters:
+  enable:
+    - gofumpt
+    - goimports
+
+output:
+  sort-order:
+    - file # filepath, line, and column.
+    - linter
+    - severity
+  # Show statistics per linter.
+  # Default: false
+  show-stats: true
+
+issues:
+  # setting 0 to have all the results.
+  max-issues-per-linter: 0
+  # nothing should be skipped to not miss errors.
+  max-same-issues: 0
+  # analyze only new code (manually set to false to check existing code)
+  new: false
+  # do not automatically fix 
+  fix: true

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/paraglider-project/paraglider
 
-go 1.23.2
-
-toolchain go1.24.1
+go 1.26.0
 
 require (
 	cloud.google.com/go/billing v1.20.4

--- a/internal/cli/common/version.go
+++ b/internal/cli/common/version.go
@@ -29,7 +29,7 @@ func NewVersionCommand() *cobra.Command {
 		Short: "Display the version of the Paraglider CLI",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			fmt.Fprintln(cmd.OutOrStderr(), version.VersionString(version.NewVersionInfo()))
+			_, _ = fmt.Fprintln(cmd.OutOrStderr(), version.VersionString(version.NewVersionInfo()))
 			return nil
 		},
 	}

--- a/internal/cli/glide/config/config.go
+++ b/internal/cli/glide/config/config.go
@@ -28,9 +28,7 @@ const (
 	DefaultNamespace      = "default"
 )
 
-var (
-	ActiveConfig *CliConfig
-)
+var ActiveConfig *CliConfig
 
 type CliConfig struct {
 	Settings CliSettings
@@ -55,7 +53,7 @@ func ReadOrCreateConfig() error {
 		parentDir := filepath.Dir(newConfig.Path)
 		_, err := os.Stat(parentDir)
 		if os.IsNotExist(err) {
-			err := os.MkdirAll(parentDir, 0755)
+			err := os.MkdirAll(parentDir, 0o755)
 			if err != nil {
 				return err
 			}
@@ -83,7 +81,7 @@ func SaveActiveConfig() error {
 		return err
 	}
 
-	err = os.WriteFile(ActiveConfig.Path, data, 0644)
+	err = os.WriteFile(ActiveConfig.Path, data, 0o644)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/glide/namespace/get/get.go
+++ b/internal/cli/glide/namespace/get/get.go
@@ -53,7 +53,7 @@ func (e *executor) Validate(cmd *cobra.Command, args []string) error {
 }
 
 func (e *executor) Execute(cmd *cobra.Command, args []string) error {
-	fmt.Fprintf(e.writer, "Active namespace: %s\n", e.cliSettings.ActiveNamespace)
+	_, _ = fmt.Fprintf(e.writer, "Active namespace: %s\n", e.cliSettings.ActiveNamespace)
 
 	return nil
 }

--- a/internal/cli/glide/namespace/list/list.go
+++ b/internal/cli/glide/namespace/list/list.go
@@ -56,12 +56,11 @@ func (e *executor) Validate(cmd *cobra.Command, args []string) error {
 func (e *executor) Execute(cmd *cobra.Command, args []string) error {
 	c := client.Client{ControllerAddress: e.cliSettings.ServerAddr}
 	namespaces, err := c.ListNamespaces()
-
 	if err != nil {
 		return err
 	}
 
-	fmt.Fprintf(e.writer, "Namespaces: %v", namespaces)
+	_, _ = fmt.Fprintf(e.writer, "Namespaces: %v", namespaces)
 
 	return nil
 }

--- a/internal/cli/glide/namespace/set/set.go
+++ b/internal/cli/glide/namespace/set/set.go
@@ -53,7 +53,6 @@ func (e *executor) Validate(cmd *cobra.Command, args []string) error {
 	// Get all namespaces from the orchestrator and confirm that the given string is one of them
 	c := &client.Client{ControllerAddress: e.cliSettings.ServerAddr}
 	namespaces, err := c.ListNamespaces()
-
 	if err != nil {
 		return err
 	}

--- a/internal/cli/glide/resource/attach/attach.go
+++ b/internal/cli/glide/resource/attach/attach.go
@@ -55,17 +55,17 @@ func (e *executor) Validate(cmd *cobra.Command, args []string) error {
 }
 
 func (e *executor) Execute(cmd *cobra.Command, args []string) error {
-	fmt.Fprintf(e.writer, "Attaching resource to %s namespace\n", e.cliSettings.ActiveNamespace)
+	_, _ = fmt.Fprintf(e.writer, "Attaching resource to %s namespace\n", e.cliSettings.ActiveNamespace)
 	paragliderClient := client.Client{ControllerAddress: e.cliSettings.ServerAddr}
 
 	resource := &orchestrator.ResourceID{Id: args[1]}
 	resourceInfo, err := paragliderClient.AttachResource(e.cliSettings.ActiveNamespace, args[0], resource)
 	if err != nil {
-		fmt.Fprintf(e.writer, "Failed to attach resource: %v\n", err)
+		_, _ = fmt.Fprintf(e.writer, "Failed to attach resource: %v\n", err)
 		return err
 	}
 
-	fmt.Fprintf(e.writer, "Resource Attached.\ntag: %s\nuri: %s\nip: %s\n", resourceInfo["name"], resourceInfo["uri"], resourceInfo["ip"])
+	_, _ = fmt.Fprintf(e.writer, "Resource Attached.\ntag: %s\nuri: %s\nip: %s\n", resourceInfo["name"], resourceInfo["uri"], resourceInfo["ip"])
 
 	return nil
 }

--- a/internal/cli/glide/resource/create/create.go
+++ b/internal/cli/glide/resource/create/create.go
@@ -58,7 +58,7 @@ func (e *executor) Validate(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	defer descriptionFile.Close()
+	defer func() { _ = descriptionFile.Close() }()
 	e.description, err = io.ReadAll(descriptionFile)
 	if err != nil {
 		return err
@@ -75,16 +75,15 @@ func (e *executor) Validate(cmd *cobra.Command, args []string) error {
 func (e *executor) Execute(cmd *cobra.Command, args []string) error {
 	resource := &paragliderpb.ResourceDescriptionString{Description: string(e.description)}
 
-	fmt.Fprintf(e.writer, "Creating resource: %v\n", args[1])
+	_, _ = fmt.Fprintf(e.writer, "Creating resource: %v\n", args[1])
 	c := client.Client{ControllerAddress: e.cliSettings.ServerAddr}
 	resourceInfo, err := c.CreateResource(e.cliSettings.ActiveNamespace, args[0], args[1], resource)
-
 	if err != nil {
-		fmt.Fprintf(e.writer, "Failed to create resource: %v\n", err)
+		_, _ = fmt.Fprintf(e.writer, "Failed to create resource: %v\n", err)
 		return err
 	}
 
-	fmt.Fprintf(e.writer, "Resource Created.\ntag: %s\nuri: %s\nip: %s\n", resourceInfo["name"], resourceInfo["uri"], resourceInfo["ip"])
+	_, _ = fmt.Fprintf(e.writer, "Resource Created.\ntag: %s\nuri: %s\nip: %s\n", resourceInfo["name"], resourceInfo["uri"], resourceInfo["ip"])
 
 	return nil
 }

--- a/internal/cli/glide/root.go
+++ b/internal/cli/glide/root.go
@@ -18,6 +18,7 @@ package cli
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/signal"
@@ -61,7 +62,7 @@ func Execute() {
 	defer cancel()
 
 	err := rootCmd.ExecuteContext(ctx)
-	if err != nil && err == ctx.Err() {
+	if err != nil && errors.Is(err, ctx.Err()) {
 		fmt.Fprintln(os.Stderr, "Cancelled.")
 		os.Exit(1)
 	} else if err != nil {

--- a/internal/cli/glide/rule/add/add.go
+++ b/internal/cli/glide/rule/add/add.go
@@ -83,7 +83,7 @@ func (e *executor) Execute(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return err
 		}
-		defer ruleFile.Close()
+		defer func() { _ = ruleFile.Close() }()
 		fileRules, err := io.ReadAll(ruleFile)
 		if err != nil {
 			return err
@@ -113,7 +113,7 @@ func (e *executor) Execute(cmd *cobra.Command, args []string) error {
 	if len(args) == 1 {
 		err = c.AddPermitListRulesTag(args[0], rules)
 	} else {
-		fmt.Fprintf(e.writer, "Adding permit list rule\n")
+		_, _ = fmt.Fprintf(e.writer, "Adding permit list rule\n")
 		err = c.AddPermitListRules(e.cliSettings.ActiveNamespace, args[0], args[1], rules)
 	}
 

--- a/internal/cli/glide/rule/get/get.go
+++ b/internal/cli/glide/rule/get/get.go
@@ -62,9 +62,9 @@ func (e *executor) Execute(cmd *cobra.Command, args []string) error {
 	}
 
 	// Print the rules
-	fmt.Fprintf(e.writer, "Permit list for %s:\n", args[1])
+	_, _ = fmt.Fprintf(e.writer, "Permit list for %s:\n", args[1])
 	for i, rule := range permitList {
-		fmt.Fprintf(e.writer, "%d. %v\n", i, rule)
+		_, _ = fmt.Fprintf(e.writer, "%d. %v\n", i, rule)
 	}
 
 	return nil

--- a/internal/cli/glide/server/get/get.go
+++ b/internal/cli/glide/server/get/get.go
@@ -54,6 +54,6 @@ func (e *executor) Validate(cmd *cobra.Command, args []string) error {
 }
 
 func (e *executor) Execute(cmd *cobra.Command, args []string) error {
-	fmt.Fprintln(e.writer, "Server address: ", e.cliSettings.ServerAddr)
+	_, _ = fmt.Fprintln(e.writer, "Server address: ", e.cliSettings.ServerAddr)
 	return nil
 }

--- a/internal/cli/glide/tag/get/get.go
+++ b/internal/cli/glide/tag/get/get.go
@@ -71,7 +71,7 @@ func (e *executor) Execute(cmd *cobra.Command, args []string) error {
 		}
 
 		// Print the tag
-		fmt.Fprintf(e.writer, "Tag %s:\n %v\n", args[0], tagMappings)
+		_, _ = fmt.Fprintf(e.writer, "Tag %s:\n %v\n", args[0], tagMappings)
 	} else {
 		tagMapping, err := c.GetTag(args[0])
 		if err != nil {
@@ -79,7 +79,7 @@ func (e *executor) Execute(cmd *cobra.Command, args []string) error {
 		}
 
 		// Print the tag
-		fmt.Fprintln(e.writer, tagMapping)
+		_, _ = fmt.Fprintln(e.writer, tagMapping)
 	}
 
 	return nil

--- a/internal/cli/glide/tag/list/list.go
+++ b/internal/cli/glide/tag/list/list.go
@@ -45,7 +45,6 @@ type executor struct {
 }
 
 func (e *executor) Execute(cmd *cobra.Command, args []string) error {
-
 	c := client.Client{ControllerAddress: e.cliSettings.ServerAddr}
 	tagMappings, err := c.ListTags()
 	if err != nil {
@@ -53,7 +52,7 @@ func (e *executor) Execute(cmd *cobra.Command, args []string) error {
 	}
 	// Print the tags
 	for i, tagMap := range tagMappings {
-		fmt.Fprintf(e.writer, "%d). %v\n", i, tagMap)
+		_, _ = fmt.Fprintf(e.writer, "%d). %v\n", i, tagMap)
 	}
 	return nil
 }

--- a/internal/cli/glided/orchestrator/orchestrator.go
+++ b/internal/cli/glided/orchestrator/orchestrator.go
@@ -34,8 +34,7 @@ func NewCommand() *cobra.Command {
 	}
 }
 
-type executor struct {
-}
+type executor struct{}
 
 func (e *executor) Validate(cmd *cobra.Command, args []string) error {
 	return nil

--- a/internal/cli/glided/startup/startup.go
+++ b/internal/cli/glided/startup/startup.go
@@ -63,7 +63,7 @@ func (e *executor) Validate(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	var cfg config.Config
 	decoder := yaml.NewDecoder(f)
@@ -87,17 +87,18 @@ func (e *executor) Validate(cmd *cobra.Command, args []string) error {
 	}
 
 	for _, cloud := range cfg.CloudPlugins {
-		if cloud.Name == "gcp" {
+		switch cloud.Name {
+		case "gcp":
 			e.gcpPort, err = strconv.Atoi(cloud.Port)
 			if err != nil {
 				return err
 			}
-		} else if cloud.Name == "azure" {
+		case "azure":
 			e.azPort, err = strconv.Atoi(cloud.Port)
 			if err != nil {
 				return err
 			}
-		} else if cloud.Name == "ibm" {
+		case "ibm":
 			e.ibmPort, err = strconv.Atoi(cloud.Port)
 			if err != nil {
 				return err

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -75,9 +75,8 @@ func Version() string {
 	return version
 }
 
-// VersionString returns a formatted string representation of the version from a list of supported
+// VersionString returns a formatted string representation of the version from a list of supported.
 func VersionString(v VersionInfo) string {
 	format := "Release: %s \nVersion: %s\n\nCommit: %s\n"
 	return fmt.Sprintf(format, v.Release, v.Version, v.Commit)
-
 }

--- a/pkg/aws/plugin.go
+++ b/pkg/aws/plugin.go
@@ -93,7 +93,7 @@ func (s *AwsPluginServer) _CreateResource(ctx context.Context, req *paragliderpb
 			if err != nil {
 				return nil, fmt.Errorf("unable to establish connection with orchestrator: %w", err)
 			}
-			defer orchestratorConn.Close()
+			defer func() { _ = orchestratorConn.Close() }()
 			orchestratorClient := paragliderpb.NewControllerClient(orchestratorConn)
 			findUnusedAddressSpacesReq := &paragliderpb.FindUnusedAddressSpacesRequest{}
 			findUnusedAddressSpacesResp, err := orchestratorClient.FindUnusedAddressSpaces(ctx, findUnusedAddressSpacesReq)

--- a/pkg/aws/test_utils.go
+++ b/pkg/aws/test_utils.go
@@ -30,7 +30,7 @@ import (
 	"github.com/aws/smithy-go/middleware"
 )
 
-// Fake AWS parameters for testing
+// Fake AWS parameters for testing.
 const (
 	fakeAccountId                = "123456789"
 	fakeInstanceName             = "fake-instance"
@@ -46,7 +46,7 @@ const (
 	fakeVpcCidrBlock             = "10.0.0.0/16"
 )
 
-// Fake AWS parameters for testing
+// Fake AWS parameters for testing.
 var (
 	fakeSubnet = &types.Subnet{
 		SubnetId:         aws.String(fakeSubnetId),
@@ -72,8 +72,10 @@ type fakeServerState struct {
 
 // fakeServerStateContextKey is an empty struct to be used as a key for context values.
 // See SA1029 (https://staticcheck.dev/docs/checks#SA1029) on why we shouldn't use string keys.
-type fakeServerStateContextKey struct{}
-type requestContextKey struct{}
+type (
+	fakeServerStateContextKey struct{}
+	requestContextKey         struct{}
+)
 
 // fakeInitializeMiddleware is a middleware in the initialize step for faking AWS API calls during tests.
 var fakeInitializeMiddleware = middleware.InitializeMiddlewareFunc("FakeInput", func(
@@ -92,6 +94,7 @@ var fakeDeserializeMiddleware = middleware.DeserializeMiddlewareFunc("FakeOutput
 	out middleware.DeserializeOutput, metadata middleware.Metadata, err error,
 ) {
 	fakeServerState := ctx.Value(&fakeServerStateContextKey{}).(fakeServerState)
+	_ = fakeServerState // Used in some switch cases below
 	switch ctx.Value(&requestContextKey{}).(type) {
 	// VPCs
 	case *ec2.CreateVpcInput:
@@ -125,14 +128,14 @@ var fakeDeserializeMiddleware = middleware.DeserializeMiddlewareFunc("FakeOutput
 	case *ec2.DescribeInstancesInput:
 		out.Result = &ec2.DescribeInstancesOutput{Reservations: []types.Reservation{{Instances: []types.Instance{*fakeInstance}}}}
 	}
-	return
+	return out, metadata, err
 })
 
 // setupTest sets up necessary fake components for a unit test.
 func setupTest(fakeServerState fakeServerState) (context.Context, *awsClients, error) {
 	// Set fake AWS credentials which are required for config
-	os.Setenv("AWS_ACCESS_KEY_ID", "AKIAIOSFODNN7EXAMPLE")
-	os.Setenv("AWS_SECRET_ACCESS_KEY", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY")
+	_ = os.Setenv("AWS_ACCESS_KEY_ID", "AKIAIOSFODNN7EXAMPLE")
+	_ = os.Setenv("AWS_SECRET_ACCESS_KEY", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY")
 
 	// Load AWS config
 	ctx := context.WithValue(context.TODO(), &fakeServerStateContextKey{}, fakeServerState)
@@ -220,7 +223,7 @@ func TeardownAwsTesting(namespace string, region string) {
 	}
 	describeInstancesOutput, err := ec2Client.DescribeInstances(ctx, describeInstancesInput)
 	if err != nil {
-		panic(fmt.Errorf("Failed to describe instances: %w", err))
+		panic(fmt.Errorf("failed to describe instances: %w", err))
 	}
 
 	// Delete instances
@@ -256,13 +259,13 @@ func TeardownAwsTesting(namespace string, region string) {
 	}
 	describeSubnetsOutput, err := ec2Client.DescribeSubnets(ctx, describeSubnetsInput)
 	if err != nil {
-		panic(fmt.Errorf("Failed to describe subnets: %w", err))
+		panic(fmt.Errorf("failed to describe subnets: %w", err))
 	}
 	for _, subnet := range describeSubnetsOutput.Subnets {
 		deleteSubnetInput := &ec2.DeleteSubnetInput{SubnetId: subnet.SubnetId}
 		_, err := ec2Client.DeleteSubnet(ctx, deleteSubnetInput)
 		if err != nil {
-			panic(fmt.Errorf("Failed to delete subnet %s: %w", *subnet.SubnetId, err))
+			panic(fmt.Errorf("failed to delete subnet %s: %w", *subnet.SubnetId, err))
 		}
 	}
 
@@ -272,13 +275,13 @@ func TeardownAwsTesting(namespace string, region string) {
 	}
 	describeSecurityGroupsOutput, err := ec2Client.DescribeSecurityGroups(ctx, describeSecurityGroupsInput)
 	if err != nil {
-		panic(fmt.Errorf("Failed to describe security groups: %w", err))
+		panic(fmt.Errorf("failed to describe security groups: %w", err))
 	}
 	for _, securityGroup := range describeSecurityGroupsOutput.SecurityGroups {
 		deleteSecurityGroupInput := &ec2.DeleteSecurityGroupInput{GroupId: securityGroup.GroupId}
 		_, err := ec2Client.DeleteSecurityGroup(ctx, deleteSecurityGroupInput)
 		if err != nil {
-			panic(fmt.Errorf("Failed to delete security group %s: %w", *securityGroup.GroupId, err))
+			panic(fmt.Errorf("failed to delete security group %s: %w", *securityGroup.GroupId, err))
 		}
 	}
 
@@ -288,7 +291,7 @@ func TeardownAwsTesting(namespace string, region string) {
 	}
 	describeVpcsOutput, err := ec2Client.DescribeVpcs(ctx, describeVpcsInput)
 	if err != nil {
-		panic(fmt.Errorf("Failed to describe VPCs: %w", err))
+		panic(fmt.Errorf("failed to describe VPCs: %w", err))
 	}
 	for _, vpc := range describeVpcsOutput.Vpcs {
 		deleteVpcInput := &ec2.DeleteVpcInput{
@@ -296,7 +299,7 @@ func TeardownAwsTesting(namespace string, region string) {
 		}
 		_, err := ec2Client.DeleteVpc(ctx, deleteVpcInput)
 		if err != nil {
-			panic(fmt.Errorf("Failed to delete VPC %s: %w", *vpc.VpcId, err))
+			panic(fmt.Errorf("failed to delete VPC %s: %w", *vpc.VpcId, err))
 		}
 	}
 }

--- a/pkg/azure/naming.go
+++ b/pkg/azure/naming.go
@@ -52,7 +52,7 @@ func getDnsServiceCidr(serviceCidr string) string {
 	return fmt.Sprintf("%s.%s.%s.10", split[0], split[1], split[2])
 }
 
-// Extract the Vnet name from the subnet ID
+// Extract the Vnet name from the subnet ID.
 func getVnetFromSubnetId(subnetId string) string {
 	parts := strings.Split(subnetId, "/")
 	return parts[8] // TODO @smcclure20: do this in a less brittle way
@@ -60,7 +60,7 @@ func getVnetFromSubnetId(subnetId string) string {
 
 // getResourceIDInfo parses the resourceID to extract subscriptionID and resourceGroupName (and VM name if needed)
 // and returns a ResourceIDInfo object filled with the extracted values
-// a valid resourceID should be in the format of '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/...'
+// a valid resourceID should be in the format of '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/...'.
 func getResourceIDInfo(resourceID string) (ResourceIDInfo, error) {
 	parts := strings.Split(resourceID, "/")
 	if len(parts) < 5 {
@@ -80,13 +80,13 @@ func getResourceIDInfo(resourceID string) (ResourceIDInfo, error) {
 	return info, nil
 }
 
-// getParagliderResourceName returns a name for the Paraglider resource
+// getParagliderResourceName returns a name for the Paraglider resource.
 func getParagliderResourceName(resourceType string) string {
 	// TODO @nnomier: change based on paraglider naming convention
 	return paragliderPrefix + "-" + resourceType + "-" + uuid.New().String()
 }
 
-// getNSGRuleName returns a name for the Paraglider rule
+// getNSGRuleName returns a name for the Paraglider rule.
 func getNSGRuleName(ruleName string) string {
 	return paragliderPrefix + "-" + ruleName
 }
@@ -104,7 +104,7 @@ func getParagliderNamespacePrefix(namespace string) string {
 }
 
 // getVnetName returns the name of the paraglider vnet in the given location
-// since a paraglider vnet is unique per location
+// since a paraglider vnet is unique per location.
 func getVnetName(location string, namespace string) string {
 	return getParagliderNamespacePrefix(namespace) + "-" + location + "-vnet"
 }

--- a/pkg/azure/plugin.go
+++ b/pkg/azure/plugin.go
@@ -32,8 +32,10 @@ import (
 	"google.golang.org/protobuf/types/known/emptypb"
 )
 
-const minPriority = 100
-const maxPriority = 4096
+const (
+	minPriority = 100
+	maxPriority = 4096
+)
 
 type azurePluginServer struct {
 	paragliderpb.UnimplementedCloudPluginServer
@@ -52,14 +54,14 @@ func (s *azurePluginServer) setupAzureHandler(resourceIdInfo ResourceIDInfo, nam
 	var azureHandler AzureSDKHandler
 	cred, err := s.azureCredentialGetter.GetAzureCredentials()
 	if err != nil {
-		utils.Log.Printf("An error occured while getting azure credentials:%+v", err)
+		utils.Log.Printf("An error occurred while getting azure credentials:%+v", err)
 		return nil, err
 	}
 	azureHandler.SetSubIdAndResourceGroup(resourceIdInfo.SubscriptionID, resourceIdInfo.ResourceGroupName)
 	azureHandler.paragliderNamespace = namespace
 	err = azureHandler.InitializeClients(cred)
 	if err != nil {
-		utils.Log.Printf("An error occured while initializing azure clients: %+v", err)
+		utils.Log.Printf("An error occurred while initializing azure clients: %+v", err)
 		return nil, err
 	}
 
@@ -72,12 +74,12 @@ func (s *azurePluginServer) SetFlags(ctx context.Context, req *paragliderpb.SetF
 }
 
 // GetPermitList returns the permit list for the given resource by getting the NSG rules
-// associated with the resource and filtering out the Paraglider rules
+// associated with the resource and filtering out the Paraglider rules.
 func (s *azurePluginServer) GetPermitList(ctx context.Context, req *paragliderpb.GetPermitListRequest) (*paragliderpb.GetPermitListResponse, error) {
 	resourceId := req.Resource
 	resourceIdInfo, err := getResourceIDInfo(resourceId)
 	if err != nil {
-		utils.Log.Printf("An error occured while getting resource ID info: %+v", err)
+		utils.Log.Printf("An error occurred while getting resource ID info: %+v", err)
 		return nil, err
 	}
 	azureHandler, err := s.setupAzureHandler(resourceIdInfo, req.Namespace)
@@ -99,7 +101,7 @@ func (s *azurePluginServer) GetPermitList(ctx context.Context, req *paragliderpb
 		if !strings.HasPrefix(*rule.Name, denyAllNsgRulePrefix) && strings.HasPrefix(*rule.Name, paragliderPrefix) {
 			plRule, err := azureHandler.GetPermitListRuleFromNSGRule(rule)
 			if err != nil {
-				utils.Log.Printf("An error occured while getting Paraglider rule from NSG rule: %+v", err)
+				utils.Log.Printf("An error occurred while getting Paraglider rule from NSG rule: %+v", err)
 				return nil, err
 			}
 			plRule.Name = getRuleNameFromNSGRuleName(plRule.Name)
@@ -116,7 +118,7 @@ func (s *azurePluginServer) AddPermitListRules(ctx context.Context, req *paragli
 	resourceID := req.GetResource()
 	resourceIdInfo, err := getResourceIDInfo(resourceID)
 	if err != nil {
-		utils.Log.Printf("An error occured while getting resource ID info: %+v", err)
+		utils.Log.Printf("An error occurred while getting resource ID info: %+v", err)
 		return nil, err
 	}
 	azureHandler, err := s.setupAzureHandler(resourceIdInfo, req.Namespace)
@@ -129,12 +131,12 @@ func (s *azurePluginServer) AddPermitListRules(ctx context.Context, req *paragli
 		return nil, err
 	}
 
-	var existingRulePriorities map[string]int32 = make(map[string]int32)
-	var reservedPrioritiesInbound map[int32]*armnetwork.SecurityRule = make(map[int32]*armnetwork.SecurityRule)
-	var reservedPrioritiesOutbound map[int32]*armnetwork.SecurityRule = make(map[int32]*armnetwork.SecurityRule)
+	existingRulePriorities := make(map[string]int32)
+	reservedPrioritiesInbound := make(map[int32]*armnetwork.SecurityRule)
+	reservedPrioritiesOutbound := make(map[int32]*armnetwork.SecurityRule)
 	err = setupMaps(reservedPrioritiesInbound, reservedPrioritiesOutbound, existingRulePriorities, netInfo.NSG)
 	if err != nil {
-		utils.Log.Printf("An error occured during setup: %+v", err)
+		utils.Log.Printf("An error occurred during setup: %+v", err)
 		return nil, err
 	}
 	var outboundPriority int32 = 100
@@ -145,7 +147,7 @@ func (s *azurePluginServer) AddPermitListRules(ctx context.Context, req *paragli
 	if err != nil {
 		return nil, fmt.Errorf("unable to establish connection with orchestrator: %w", err)
 	}
-	defer orchestratorConn.Close()
+	defer func() { _ = orchestratorConn.Close() }()
 	orchestratorClient := paragliderpb.NewControllerClient(orchestratorConn)
 	getUsedAddressSpacesResp, err := orchestratorClient.GetUsedAddressSpaces(context.Background(), &emptypb.Empty{})
 	if err != nil {
@@ -156,7 +158,7 @@ func (s *azurePluginServer) AddPermitListRules(ctx context.Context, req *paragli
 	// get the vnet to be able to get both the address space as well as the peering when needed
 	resourceVnet, err := azureHandler.GetVnet(ctx, vnetName)
 	if err != nil {
-		utils.Log.Printf("An error occured while getting paraglider vnets address spaces:%+v", err)
+		utils.Log.Printf("An error occurred while getting paraglider vnets address spaces:%+v", err)
 		return nil, err
 	}
 
@@ -218,10 +220,11 @@ func (s *azurePluginServer) AddPermitListRules(ctx context.Context, req *paragli
 		// if the priority is already used, we need to find the next available priority
 		priority, ok := existingRulePriorities[getNSGRuleName(rule.Name)]
 		if !ok {
-			if rule.Direction == paragliderpb.Direction_INBOUND {
+			switch rule.Direction {
+			case paragliderpb.Direction_INBOUND:
 				priority = getNextAvailablePriority(reservedPrioritiesInbound, inboundPriority, maxPriority, true)
 				inboundPriority = priority + 1
-			} else if rule.Direction == paragliderpb.Direction_OUTBOUND {
+			case paragliderpb.Direction_OUTBOUND:
 				priority = getNextAvailablePriority(reservedPrioritiesOutbound, outboundPriority, maxPriority, true)
 				outboundPriority = priority + 1
 			}
@@ -230,7 +233,7 @@ func (s *azurePluginServer) AddPermitListRules(ctx context.Context, req *paragli
 		// Create the NSG rule
 		securityRule, err := azureHandler.CreateSecurityRuleFromPermitList(ctx, rule, *netInfo.NSG.Name, getNSGRuleName(rule.Name), netInfo.Address, priority, allowRule)
 		if err != nil {
-			utils.Log.Printf("An error occured while creating security rule:%+v", err)
+			utils.Log.Printf("An error occurred while creating security rule:%+v", err)
 			return nil, err
 		}
 		utils.Log.Printf("Successfully created network security rule: %s", *securityRule.ID)
@@ -244,7 +247,7 @@ func (s *azurePluginServer) DeletePermitListRules(c context.Context, req *paragl
 	resourceID := req.GetResource()
 	resourceIdInfo, err := getResourceIDInfo(resourceID)
 	if err != nil {
-		utils.Log.Printf("An error occured while getting resource ID info: %+v", err)
+		utils.Log.Printf("An error occurred while getting resource ID info: %+v", err)
 		return nil, err
 	}
 	azureHandler, err := s.setupAzureHandler(resourceIdInfo, req.Namespace)
@@ -260,7 +263,7 @@ func (s *azurePluginServer) DeletePermitListRules(c context.Context, req *paragl
 	for _, rule := range req.GetRuleNames() {
 		err := azureHandler.DeleteSecurityRule(c, *netInfo.NSG.Name, getNSGRuleName(rule))
 		if err != nil {
-			utils.Log.Printf("An error occured while deleting security rule:%+v", err)
+			utils.Log.Printf("An error occurred while deleting security rule:%+v", err)
 			return nil, err
 		}
 		utils.Log.Printf("Successfully deleted network security rule: %s", rule)
@@ -286,7 +289,7 @@ func (s *azurePluginServer) CreateResource(ctx context.Context, resourceDesc *pa
 
 	resourceIdInfo, err := getResourceIDInfo(resourceDesc.Deployment.Id)
 	if err != nil {
-		utils.Log.Printf("An error occured while getting resource id info:%+v", err)
+		utils.Log.Printf("An error occurred while getting resource id info:%+v", err)
 		return nil, err
 	}
 
@@ -298,7 +301,7 @@ func (s *azurePluginServer) CreateResource(ctx context.Context, resourceDesc *pa
 	vnetName := getVnetName(resourceDescInfo.Location, resourceDesc.Deployment.Namespace)
 	paragliderVnet, err := azureHandler.GetParagliderVnet(ctx, vnetName, resourceDescInfo.Location, resourceDesc.Deployment.Namespace, s.orchestratorServerAddr)
 	if err != nil {
-		utils.Log.Printf("An error occured while getting paraglider vnet:%+v", err)
+		utils.Log.Printf("An error occurred while getting paraglider vnet:%+v", err)
 		return nil, err
 	}
 
@@ -317,7 +320,7 @@ func (s *azurePluginServer) CreateResource(ctx context.Context, resourceDesc *pa
 		if !subnetExists {
 			resourceSubnet, err = azureHandler.AddSubnetToParagliderVnet(ctx, resourceDesc.Deployment.Namespace, vnetName, getSubnetName(resourceDescInfo.ResourceName), s.orchestratorServerAddr)
 			if err != nil {
-				utils.Log.Printf("An error occured while creating subnet:%+v", err)
+				utils.Log.Printf("An error occurred while creating subnet:%+v", err)
 				return nil, err
 			}
 		}
@@ -331,7 +334,7 @@ func (s *azurePluginServer) CreateResource(ctx context.Context, resourceDesc *pa
 			utils.Log.Printf("Could not dial the orchestrator")
 			return nil, err
 		}
-		defer conn.Close()
+		defer func() { _ = conn.Close() }()
 		client := paragliderpb.NewControllerClient(conn)
 		reqAddressSpaces := make([]int32, resourceDescInfo.NumAdditionalAddressSpaces)
 		response, err := client.FindUnusedAddressSpaces(context.Background(), &paragliderpb.FindUnusedAddressSpacesRequest{Sizes: reqAddressSpaces})
@@ -345,7 +348,7 @@ func (s *azurePluginServer) CreateResource(ctx context.Context, resourceDesc *pa
 	// Create the resource
 	ip, err := ReadAndProvisionResource(ctx, resourceDesc, resourceSubnet, &resourceIdInfo, azureHandler, additionalAddrs)
 	if err != nil {
-		utils.Log.Printf("An error occured while creating resource:%+v", err)
+		utils.Log.Printf("An error occurred while creating resource:%+v", err)
 		return nil, err
 	}
 
@@ -354,7 +357,7 @@ func (s *azurePluginServer) CreateResource(ctx context.Context, resourceDesc *pa
 	// Note that vnets are free, so this is not a problem.
 	vpnGwVnet, err := GetOrCreateVpnGatewayVNet(ctx, azureHandler, resourceDesc.Deployment.Namespace)
 	if err != nil {
-		utils.Log.Printf("An error occured while getting or creating VPN gateway vnet:%+v", err)
+		utils.Log.Printf("An error occurred while getting or creating VPN gateway vnet:%+v", err)
 		return nil, err
 	}
 
@@ -365,14 +368,14 @@ func (s *azurePluginServer) CreateResource(ctx context.Context, resourceDesc *pa
 	// - If the VPN gateway hasn't been created, then the gateway transit relationship will be established on VPN gateway creation.
 	err = CreateGatewayVnetPeering(ctx, azureHandler, vnetName, *vpnGwVnet.Name, resourceDesc.Deployment.Namespace)
 	if err != nil {
-		utils.Log.Printf("An error occured while creating VPN gateway vnet peering:%+v", err)
+		utils.Log.Printf("An error occurred while creating VPN gateway vnet peering:%+v", err)
 		return nil, err
 	}
 
 	return &paragliderpb.CreateResourceResponse{Name: resourceDescInfo.ResourceName, Uri: resourceDescInfo.ResourceID, Ip: ip}, nil
 }
 
-// GetUsedAddressSpaces returns the address spaces used by paraglider which are the address spaces of the paraglider vnets
+// GetUsedAddressSpaces returns the address spaces used by paraglider which are the address spaces of the paraglider vnets.
 func (s *azurePluginServer) GetUsedAddressSpaces(ctx context.Context, req *paragliderpb.GetUsedAddressSpacesRequest) (*paragliderpb.GetUsedAddressSpacesResponse, error) {
 	resp := &paragliderpb.GetUsedAddressSpacesResponse{}
 	resp.AddressSpaceMappings = make([]*paragliderpb.AddressSpaceMapping, len(req.Deployments))
@@ -383,7 +386,7 @@ func (s *azurePluginServer) GetUsedAddressSpaces(ctx context.Context, req *parag
 		}
 		resourceIdInfo, err := getResourceIDInfo(deployment.Id)
 		if err != nil {
-			utils.Log.Printf("An error occured while getting resource ID info: %+v", err)
+			utils.Log.Printf("An error occurred while getting resource ID info: %+v", err)
 			return nil, err
 		}
 		azureHandler, err := s.setupAzureHandler(resourceIdInfo, deployment.Namespace)
@@ -393,7 +396,7 @@ func (s *azurePluginServer) GetUsedAddressSpaces(ctx context.Context, req *parag
 
 		addressSpaces, err := azureHandler.GetAllVnetsAddressSpaces(ctx, deployment.Namespace)
 		if err != nil {
-			utils.Log.Printf("An error occured while getting address spaces:%+v", err)
+			utils.Log.Printf("An error occurred while getting address spaces:%+v", err)
 			return nil, err
 		}
 		paragliderAddressList := []string{}
@@ -405,7 +408,6 @@ func (s *azurePluginServer) GetUsedAddressSpaces(ctx context.Context, req *parag
 		resp.AddressSpaceMappings[i].AddressSpaces = paragliderAddressList
 	}
 	return resp, nil
-
 }
 
 func (s *azurePluginServer) GetUsedAsns(ctx context.Context, req *paragliderpb.GetUsedAsnsRequest) (*paragliderpb.GetUsedAsnsResponse, error) {
@@ -413,7 +415,7 @@ func (s *azurePluginServer) GetUsedAsns(ctx context.Context, req *paragliderpb.G
 	for _, deployment := range req.Deployments {
 		resourceIdInfo, err := getResourceIDInfo(deployment.Id)
 		if err != nil {
-			utils.Log.Printf("An error occured while getting resource ID info: %+v", err)
+			utils.Log.Printf("An error occurred while getting resource ID info: %+v", err)
 			return nil, err
 		}
 		azureHandler, err := s.setupAzureHandler(resourceIdInfo, deployment.Namespace)
@@ -440,7 +442,7 @@ func (s *azurePluginServer) GetUsedBgpPeeringIpAddresses(ctx context.Context, re
 	for _, deployment := range req.Deployments {
 		resourceIdInfo, err := getResourceIDInfo(deployment.Id)
 		if err != nil {
-			utils.Log.Printf("An error occured while getting resource ID info: %+v", err)
+			utils.Log.Printf("An error occurred while getting resource ID info: %+v", err)
 			return nil, err
 		}
 		azureHandler, err := s.setupAzureHandler(resourceIdInfo, deployment.Namespace)
@@ -521,7 +523,7 @@ func (s *azurePluginServer) CreateVpnGateway(ctx context.Context, req *paraglide
 			if err != nil {
 				return nil, fmt.Errorf("unable to establish connection with orchestrator: %w", err)
 			}
-			defer conn.Close()
+			defer func() { _ = conn.Close() }()
 			client := paragliderpb.NewControllerClient(conn)
 			findUnusedAsnResp, err := client.FindUnusedAsn(ctx, &paragliderpb.FindUnusedAsnRequest{})
 			if err != nil {
@@ -728,7 +730,7 @@ func (s *azurePluginServer) CreateVpnConnections(ctx context.Context, req *parag
 	return &paragliderpb.CreateVpnConnectionsResponse{}, nil
 }
 
-// Peer with another virtual network
+// Peer with another virtual network.
 func (s *azurePluginServer) createPeering(ctx context.Context, azureHandler AzureSDKHandler, resourceIDInfo ResourceIDInfo, resourceVnetName string, peeringCloudInfo *utils.PeeringCloudInfo, permitListRuleTarget string) error {
 	peeringCloudResourceIDInfo, err := getResourceIDInfo(peeringCloudInfo.Deployment)
 	if err != nil {
@@ -768,7 +770,7 @@ func (s *azurePluginServer) createPeering(ctx context.Context, azureHandler Azur
 	return nil
 }
 
-// returns an IPSec policy to configure a VPN connection that's compatible the specified cloud
+// returns an IPSec policy to configure a VPN connection that's compatible the specified cloud.
 func getIPSecPolicy(cloud string) []*armnetwork.IPSecPolicy {
 	if cloud == utils.IBM {
 		ipSecPolicies := make([]*armnetwork.IPSecPolicy, 1)
@@ -787,7 +789,7 @@ func getIPSecPolicy(cloud string) []*armnetwork.IPSecPolicy {
 	return nil
 }
 
-// GetNetworkAddressSpaces returns the subnets addresses of the VNet containing the specified address space
+// GetNetworkAddressSpaces returns the subnets addresses of the VNet containing the specified address space.
 func (s *azurePluginServer) GetNetworkAddressSpaces(ctx context.Context, req *paragliderpb.GetNetworkAddressSpacesRequest) (*paragliderpb.GetNetworkAddressSpacesResponse, error) {
 	// TODO Implement method
 	// This is a placeholder implementation, that translates the specified address space to a CIDR, in case an IP is provided. Instead:
@@ -806,7 +808,7 @@ func (s *azurePluginServer) GetNetworkAddressSpaces(ctx context.Context, req *pa
 	return &paragliderpb.GetNetworkAddressSpacesResponse{AddressSpaces: []string{resourceAddress}}, nil
 }
 
-// Add an existing Azure resource to a paraglider deployment
+// Add an existing Azure resource to a paraglider deployment.
 func (s *azurePluginServer) AttachResource(ctx context.Context, attachResourceReq *paragliderpb.AttachResourceRequest) (*paragliderpb.AttachResourceResponse, error) {
 	if !s.flags.GetAttachResourceEnabled() {
 		utils.Log.Printf("Attach resource is disabled")
@@ -816,7 +818,7 @@ func (s *azurePluginServer) AttachResource(ctx context.Context, attachResourceRe
 	resourceId := attachResourceReq.GetResource()
 	resourceIdInfo, err := getResourceIDInfo(resourceId)
 	if err != nil {
-		utils.Log.Printf("An error occured while getting resource id info:%+v", err)
+		utils.Log.Printf("An error occurred while getting resource id info:%+v", err)
 		return nil, err
 	}
 
@@ -827,14 +829,14 @@ func (s *azurePluginServer) AttachResource(ctx context.Context, attachResourceRe
 
 	resource, networkInfo, err := ValidateResourceCompliesWithParagliderRequirements(ctx, resourceId, azureHandler, s)
 	if err != nil {
-		utils.Log.Printf("An error occured while validating resource:%+v", err)
+		utils.Log.Printf("An error occurred while validating resource:%+v", err)
 		return nil, err
 	}
 
 	// Create VPN gateway vnet if not already created
 	vpnGwVnet, err := GetOrCreateVpnGatewayVNet(ctx, azureHandler, namespace)
 	if err != nil {
-		utils.Log.Printf("An error occured while getting or creating VPN gateway vnet:%+v", err)
+		utils.Log.Printf("An error occurred while getting or creating VPN gateway vnet:%+v", err)
 		return nil, err
 	}
 
@@ -842,13 +844,13 @@ func (s *azurePluginServer) AttachResource(ctx context.Context, attachResourceRe
 	// Create peering between the VPN gateway vnet and VM vnet. If the VPN gateway already exists, then establish a VPN gateway transit relationship where the vnet can use the gatewayVnet's VPN gateway.
 	err = CreateGatewayVnetPeering(ctx, azureHandler, vnetName, *vpnGwVnet.Name, namespace)
 	if err != nil {
-		utils.Log.Printf("An error occured while creating VPN gateway vnet peering:%+v", err)
+		utils.Log.Printf("An error occurred while creating VPN gateway vnet peering:%+v", err)
 		return nil, err
 	}
 
 	vnet, err := azureHandler.GetVirtualNetwork(ctx, vnetName)
 	if err != nil {
-		utils.Log.Printf("An error occured while getting vnet:%+v", err)
+		utils.Log.Printf("An error occurred while getting vnet:%+v", err)
 		return nil, err
 	}
 
@@ -856,7 +858,7 @@ func (s *azurePluginServer) AttachResource(ctx context.Context, attachResourceRe
 	azureHandler.createParagliderNamespaceTag(&vnet.Tags)
 	_, err = azureHandler.CreateOrUpdateVirtualNetwork(ctx, vnetName, *vnet)
 	if err != nil {
-		utils.Log.Printf("An error occured while creating vnet:%+v", err)
+		utils.Log.Printf("An error occurred while creating vnet:%+v", err)
 		return nil, err
 	}
 

--- a/pkg/azure/plugin_test.go
+++ b/pkg/azure/plugin_test.go
@@ -130,7 +130,6 @@ func TestCreateResource(t *testing.T) {
 				},
 			},
 		})
-
 		if err != nil {
 			t.Errorf("Error while marshalling description: %v", err)
 		}

--- a/pkg/azure/priority_utils.go
+++ b/pkg/azure/priority_utils.go
@@ -22,12 +22,13 @@ import (
 
 // setupMaps fills the reservedPrioritiesInbound and reservedPrioritiesOutbound maps with the priorities of the existing rules in the NSG
 // This is done to avoid priorities conflicts when creating new rules
-// Existing rules map is filled to ensure that rules that just need their contents updated do not get recreated with new priorities
+// Existing rules map is filled to ensure that rules that just need their contents updated do not get recreated with new priorities.
 func setupMaps(reservedPrioritiesInbound map[int32]*armnetwork.SecurityRule, reservedPrioritiesOutbound map[int32]*armnetwork.SecurityRule, existingRulePriorities map[string]int32, nsg *armnetwork.SecurityGroup) error {
 	for _, rule := range nsg.Properties.SecurityRules {
-		if *rule.Properties.Direction == armnetwork.SecurityRuleDirectionInbound {
+		switch *rule.Properties.Direction {
+		case armnetwork.SecurityRuleDirectionInbound:
 			reservedPrioritiesInbound[*rule.Properties.Priority] = rule
-		} else if *rule.Properties.Direction == armnetwork.SecurityRuleDirectionOutbound {
+		case armnetwork.SecurityRuleDirectionOutbound:
 			reservedPrioritiesOutbound[*rule.Properties.Priority] = rule
 		}
 

--- a/pkg/azure/priority_utils_test.go
+++ b/pkg/azure/priority_utils_test.go
@@ -26,10 +26,10 @@ import (
 )
 
 func TestGetNextAvailabilityPriority(t *testing.T) {
-	var reservedPriorities = make(map[int32]*armnetwork.SecurityRule)
+	reservedPriorities := make(map[int32]*armnetwork.SecurityRule)
 	var start int32 = minPriority
 	var end int32 = maxPriority
-	var lowestPriority bool = true
+	lowestPriority := true
 	var priority int32
 
 	t.Run("TestGetNextLowestAvailabilityPriority", func(t *testing.T) {

--- a/pkg/azure/resources.go
+++ b/pkg/azure/resources.go
@@ -47,7 +47,7 @@ type resourceInfo struct {
 	NumAdditionalAddressSpaces int
 }
 
-// Determine type of resource based on ID and return the relevant full resource handler
+// Determine type of resource based on ID and return the relevant full resource handler.
 func getResourceHandler(resourceID string) (AzureResourceHandler, error) {
 	if strings.Contains(resourceID, virtualMachineTypeName) {
 		return &azureResourceHandlerVM{}, nil
@@ -91,7 +91,7 @@ func GetAndCheckResourceState(ctx context.Context, handler *AzureSDKHandler, res
 	// Check the vnet tags for paraglider namespace if prefix doesn't match
 	vnet, err := handler.GetVirtualNetwork(ctx, vnetName)
 	if err != nil {
-		return nil, fmt.Errorf("Error in getting vnet %s: %w", vnetName, err)
+		return nil, fmt.Errorf("error in getting vnet %s: %w", vnetName, err)
 	}
 
 	for _, tag := range vnet.Tags {
@@ -103,31 +103,31 @@ func GetAndCheckResourceState(ctx context.Context, handler *AzureSDKHandler, res
 	return nil, fmt.Errorf("resource %s is not in the namespace %s (subnet ID: %s)", resourceID, namespace, netInfo.SubnetID)
 }
 
-// Gets the resource and returns relevant networking state
+// Gets the resource and returns relevant networking state.
 func GetNetworkInfoFromResource(ctx context.Context, handler *AzureSDKHandler, resourceID string) (*resourceNetworkInfo, error) {
 	// get a generic resource
 	resource, err := handler.GetResource(ctx, resourceID)
 	if err != nil {
-		utils.Log.Printf("An error occured while getting resource %s: %+v", resourceID, err)
+		utils.Log.Printf("An error occurred while getting resource %s: %+v", resourceID, err)
 		return nil, err
 	}
 
 	// get the network info using network handler
 	resourceHandler, err := getResourceHandler(resourceID)
 	if err != nil {
-		utils.Log.Printf("An error occured while getting the resource handler for resource %s: %+v", resourceID, err)
-		return nil, fmt.Errorf("Getting Resource Handler error: %w", err)
+		utils.Log.Printf("An error occurred while getting the resource handler for resource %s: %+v", resourceID, err)
+		return nil, fmt.Errorf("getting Resource Handler error: %w", err)
 	}
 	networkInfo, err := resourceHandler.getNetworkInfo(ctx, resource, handler)
 	if err != nil {
-		utils.Log.Printf("An error occured while getting network info for resource %s: %+v", resourceID, err)
+		utils.Log.Printf("An error occurred while getting network info for resource %s: %+v", resourceID, err)
 		return nil, err
 	}
 	return networkInfo, nil
 }
 
 // Gets basic resource information from the description
-// Returns the resource name, ID, location, and whether the resource will require its own subnet in a struct
+// Returns the resource name, ID, location, and whether the resource will require its own subnet in a struct.
 func GetResourceInfoFromResourceDesc(ctx context.Context, resource *paragliderpb.CreateResourceRequest) (*resourceInfo, error) {
 	handler, err := getResourceHandlerFromDescription(resource.Description)
 	if err != nil {
@@ -136,7 +136,7 @@ func GetResourceInfoFromResourceDesc(ctx context.Context, resource *paragliderpb
 	return handler.getResourceInfoFromDescription(ctx, resource)
 }
 
-// Verify that resourceID exists and is supported by paraglider. Returns the resource if it exists
+// Verify that resourceID exists and is supported by paraglider. Returns the resource if it exists.
 func ValidateResourceExists(ctx context.Context, handler *AzureSDKHandler, resourceID string) (*armresources.GenericResource, error) {
 	// Verify resource is supported
 	_, err := getResourceHandler(resourceID)
@@ -153,7 +153,7 @@ func ValidateResourceExists(ctx context.Context, handler *AzureSDKHandler, resou
 	return resource, nil
 }
 
-// Reads the resource description and provisions the resource with the given subnet
+// Reads the resource description and provisions the resource with the given subnet.
 func ReadAndProvisionResource(ctx context.Context, resource *paragliderpb.CreateResourceRequest, subnet *armnetwork.Subnet, resourceInfo *ResourceIDInfo, sdkHandler *AzureSDKHandler, additionalAddressSpaces []string) (string, error) {
 	handler, err := getResourceHandlerFromDescription(resource.Description)
 	if err != nil {
@@ -162,7 +162,7 @@ func ReadAndProvisionResource(ctx context.Context, resource *paragliderpb.Create
 	return handler.readAndProvisionResource(ctx, resource, subnet, resourceInfo, sdkHandler, additionalAddressSpaces)
 }
 
-// Returns the resource and network info if the resource complies with paraglider requirements. Otherwise, it returns an error
+// Returns the resource and network info if the resource complies with paraglider requirements. Otherwise, it returns an error.
 func ValidateResourceCompliesWithParagliderRequirements(ctx context.Context, resourceID string, azureHandler *AzureSDKHandler, server *azurePluginServer) (*armresources.GenericResource, *resourceNetworkInfo, error) {
 	// Ensure the resource exists
 	resource, err := ValidateResourceExists(ctx, azureHandler, resourceID)
@@ -172,7 +172,7 @@ func ValidateResourceCompliesWithParagliderRequirements(ctx context.Context, res
 
 	networkInfo, err := GetNetworkInfoFromResource(ctx, azureHandler, resourceID)
 	if err != nil {
-		return nil, nil, fmt.Errorf("Error in getting resource %s network info: %w", resourceID, err)
+		return nil, nil, fmt.Errorf("error in getting resource %s network info: %w", resourceID, err)
 	}
 
 	// Ensure the Vnet address space doesn't overlap with paraglider's address space
@@ -183,7 +183,7 @@ func ValidateResourceCompliesWithParagliderRequirements(ctx context.Context, res
 	}
 
 	if isOverlapping {
-		return nil, nil, fmt.Errorf("Resource %s Network Address Space overlaps with Paraglider Network Address Space. Not allowed", resourceID)
+		return nil, nil, fmt.Errorf("resource %s Network Address Space overlaps with Paraglider Network Address Space. Not allowed", resourceID)
 	}
 
 	// Ensure the resource's security rules are compliant. Make compliant if possible
@@ -195,7 +195,7 @@ func ValidateResourceCompliesWithParagliderRequirements(ctx context.Context, res
 	return resource, networkInfo, nil
 }
 
-// Interface that must be implemented for a resource to be supported
+// Interface that must be implemented for a resource to be supported.
 type AzureResourceHandler interface {
 	// Gets the network information for the resource
 	getNetworkInfo(ctx context.Context, resource *armresources.GenericResource, sdkHandler *AzureSDKHandler) (*resourceNetworkInfo, error)
@@ -205,12 +205,12 @@ type AzureResourceHandler interface {
 	readAndProvisionResource(ctx context.Context, resource *paragliderpb.CreateResourceRequest, subnet *armnetwork.Subnet, resourceInfo *ResourceIDInfo, sdkHandler *AzureSDKHandler, additionalAddressSpaces []string) (string, error)
 }
 
-// VM implementation of the AzureResourceHandler interface
+// VM implementation of the AzureResourceHandler interface.
 type azureResourceHandlerVM struct {
 	AzureResourceHandler
 }
 
-// Gets the network information for a virtual machine
+// Gets the network information for a virtual machine.
 func (r *azureResourceHandlerVM) getNetworkInfo(ctx context.Context, resource *armresources.GenericResource, sdkHandler *AzureSDKHandler) (*resourceNetworkInfo, error) {
 	properties, ok := resource.Properties.(map[string]interface{})
 	if !ok {
@@ -226,7 +226,7 @@ func (r *azureResourceHandlerVM) getNetworkInfo(ctx context.Context, resource *a
 	}
 	nic, err := sdkHandler.GetNetworkInterface(ctx, nicName)
 	if err != nil {
-		utils.Log.Printf("An error occured while getting the network interface:%+v", err)
+		utils.Log.Printf("An error occurred while getting the network interface:%+v", err)
 		return nil, err
 	}
 
@@ -236,7 +236,7 @@ func (r *azureResourceHandlerVM) getNetworkInfo(ctx context.Context, resource *a
 	}
 	nsg, err := sdkHandler.GetSecurityGroup(ctx, nsgName)
 	if err != nil {
-		utils.Log.Printf("An error occured while getting the network security group:%+v", err)
+		utils.Log.Printf("An error occurred while getting the network security group:%+v", err)
 		return nil, err
 	}
 
@@ -249,7 +249,7 @@ func (r *azureResourceHandlerVM) getNetworkInfo(ctx context.Context, resource *a
 	return &info, nil
 }
 
-// Gets the resource information from the description
+// Gets the resource information from the description.
 func (r *azureResourceHandlerVM) getResourceInfoFromDescription(ctx context.Context, resource *paragliderpb.CreateResourceRequest) (*resourceInfo, error) {
 	vm, err := r.fromResourceDecription(resource.Description)
 	if err != nil {
@@ -263,7 +263,7 @@ func (r *azureResourceHandlerVM) getResourceInfoFromDescription(ctx context.Cont
 	return &resourceInfo{ResourceName: resource.Name, ResourceID: getVmUri(resourceDeploymentIdInfo.SubscriptionID, resourceDeploymentIdInfo.ResourceGroupName, resource.Name), Location: *vm.Location, RequiresSubnet: requiresSubnet, NumAdditionalAddressSpaces: extraPrefixes}, nil
 }
 
-// Reads the resource description and provisions the resource with the given subnet
+// Reads the resource description and provisions the resource with the given subnet.
 func (r *azureResourceHandlerVM) readAndProvisionResource(ctx context.Context, resource *paragliderpb.CreateResourceRequest, subnet *armnetwork.Subnet, resourceInfo *ResourceIDInfo, sdkHandler *AzureSDKHandler, additionalAddressSpaces []string) (string, error) {
 	vm, err := r.fromResourceDecription(resource.Description)
 	if err != nil {
@@ -276,17 +276,17 @@ func (r *azureResourceHandlerVM) readAndProvisionResource(ctx context.Context, r
 	return ip, nil
 }
 
-// Returns the network requirements (requires its own subnet, how many address spaces) for a virtual machine
+// Returns the network requirements (requires its own subnet, how many address spaces) for a virtual machine.
 func (r *azureResourceHandlerVM) getNetworkRequirements() (bool, int) {
 	return false, 0
 }
 
 // Creates a virtual machine with the given subnet
-// Returns the private IP address of the virtual machine
+// Returns the private IP address of the virtual machine.
 func (r *azureResourceHandlerVM) createWithNetwork(ctx context.Context, vm *armcompute.VirtualMachine, subnet *armnetwork.Subnet, resourceName string, sdkHandler *AzureSDKHandler, additionalAddressSpaces []string) (string, error) {
 	nic, err := sdkHandler.CreateNetworkInterface(ctx, *subnet.ID, *vm.Location, getParagliderResourceName("nic"))
 	if err != nil {
-		utils.Log.Printf("An error occured while creating network interface:%+v", err)
+		utils.Log.Printf("An error occurred while creating network interface:%+v", err)
 		return "", err
 	}
 
@@ -300,7 +300,7 @@ func (r *azureResourceHandlerVM) createWithNetwork(ctx context.Context, vm *armc
 
 	vm, err = sdkHandler.CreateVirtualMachine(ctx, *vm, resourceName)
 	if err != nil {
-		utils.Log.Printf("An error occured while creating the virtual machine:%+v", err)
+		utils.Log.Printf("An error occurred while creating the virtual machine:%+v", err)
 		return "", err
 	}
 
@@ -311,19 +311,19 @@ func (r *azureResourceHandlerVM) createWithNetwork(ctx context.Context, vm *armc
 
 	nic, err = sdkHandler.GetNetworkInterface(ctx, nicName)
 	if err != nil {
-		utils.Log.Printf("An error occured while getting the network interface:%+v", err)
+		utils.Log.Printf("An error occurred while getting the network interface:%+v", err)
 		return "", err
 	}
 
 	return *nic.Properties.IPConfigurations[0].Properties.PrivateIPAddress, nil
 }
 
-// Converts the resource description to a virtual machine object
+// Converts the resource description to a virtual machine object.
 func (r *azureResourceHandlerVM) fromResourceDecription(resourceDesc []byte) (*armcompute.VirtualMachine, error) {
 	vm := &armcompute.VirtualMachine{}
 	err := json.Unmarshal(resourceDesc, vm)
 	if err != nil {
-		return nil, fmt.Errorf("failed to unmarshal resource description:%+v", err)
+		return nil, fmt.Errorf("failed to unmarshal resource description:%+w", err)
 	}
 
 	// Some validations on the VM
@@ -339,12 +339,12 @@ func (r *azureResourceHandlerVM) fromResourceDecription(resourceDesc []byte) (*a
 	return vm, nil
 }
 
-// AKS implementation of the NewAzureResourceHandler interface
+// AKS implementation of the NewAzureResourceHandler interface.
 type azureResourceHandlerAKS struct {
 	AzureResourceHandler
 }
 
-// Gets the network information for an AKS cluster
+// Gets the network information for an AKS cluster.
 func (r *azureResourceHandlerAKS) getResourceInfoFromDescription(ctx context.Context, resource *paragliderpb.CreateResourceRequest) (*resourceInfo, error) {
 	aks, err := r.fromResourceDecription(resource.Description)
 	if err != nil {
@@ -358,7 +358,7 @@ func (r *azureResourceHandlerAKS) getResourceInfoFromDescription(ctx context.Con
 	return &resourceInfo{ResourceName: resource.Name, ResourceID: getClusterUri(resourceDeploymentIdInfo.SubscriptionID, resourceDeploymentIdInfo.ResourceGroupName, resource.Name), Location: *aks.Location, RequiresSubnet: requiresSubnet, NumAdditionalAddressSpaces: extraPrefixes}, nil
 }
 
-// Reads the resource description and provisions the resource with the given subnet
+// Reads the resource description and provisions the resource with the given subnet.
 func (r *azureResourceHandlerAKS) readAndProvisionResource(ctx context.Context, resource *paragliderpb.CreateResourceRequest, subnet *armnetwork.Subnet, resourceInfo *ResourceIDInfo, sdkHandler *AzureSDKHandler, additionalAddressSpaces []string) (string, error) {
 	aks, err := r.fromResourceDecription(resource.Description)
 	if err != nil {
@@ -371,12 +371,12 @@ func (r *azureResourceHandlerAKS) readAndProvisionResource(ctx context.Context, 
 	return ip, nil
 }
 
-// Returns the network requirements (requires its own subnet, how many address spaces) for an AKS cluster
+// Returns the network requirements (requires its own subnet, how many address spaces) for an AKS cluster.
 func (r *azureResourceHandlerAKS) getNetworkRequirements() (bool, int) {
 	return true, 1 // TODO @smcclure20: change with support for kubenet
 }
 
-// Gets the network information for an AKS cluster
+// Gets the network information for an AKS cluster.
 func (r *azureResourceHandlerAKS) getNetworkInfo(ctx context.Context, resource *armresources.GenericResource, sdkHandler *AzureSDKHandler) (*resourceNetworkInfo, error) {
 	properties, ok := resource.Properties.(map[string]interface{})
 	if !ok {
@@ -387,7 +387,7 @@ func (r *azureResourceHandlerAKS) getNetworkInfo(ctx context.Context, resource *
 	subnetID := firstProfile["vnetSubnetID"].(string)
 	subnet, err := sdkHandler.GetSubnetByID(context.Background(), subnetID)
 	if err != nil {
-		utils.Log.Printf("An error occured while getting the subnet:%+v", err)
+		utils.Log.Printf("An error occurred while getting the subnet:%+v", err)
 		return nil, err
 	}
 	nsgName, err := GetLastSegment(*subnet.Properties.NetworkSecurityGroup.ID)
@@ -396,7 +396,7 @@ func (r *azureResourceHandlerAKS) getNetworkInfo(ctx context.Context, resource *
 	}
 	nsg, err := sdkHandler.GetSecurityGroup(context.Background(), nsgName)
 	if err != nil {
-		utils.Log.Printf("An error occured while getting the network security group:%+v", err)
+		utils.Log.Printf("An error occurred while getting the network security group:%+v", err)
 		return nil, err
 	}
 
@@ -409,7 +409,7 @@ func (r *azureResourceHandlerAKS) getNetworkInfo(ctx context.Context, resource *
 }
 
 // Creates an AKS cluster with the given subnet
-// Returns the address prefix of the subnet
+// Returns the address prefix of the subnet.
 func (r *azureResourceHandlerAKS) createWithNetwork(ctx context.Context, resource *armcontainerservice.ManagedCluster, subnet *armnetwork.Subnet, resourceName string, sdkHandler *AzureSDKHandler, additionalAddressSpaces []string) (string, error) {
 	// Set network parameters
 	for _, profile := range resource.Properties.AgentPoolProfiles {
@@ -425,7 +425,7 @@ func (r *azureResourceHandlerAKS) createWithNetwork(ctx context.Context, resourc
 	// Create the AKS cluster
 	_, err := sdkHandler.CreateAKSCluster(ctx, *resource, resourceName)
 	if err != nil {
-		utils.Log.Printf("An error occured while creating the AKS cluster:%+v", err)
+		utils.Log.Printf("An error occurred while creating the AKS cluster:%+v", err)
 		return "", err
 	}
 
@@ -433,25 +433,25 @@ func (r *azureResourceHandlerAKS) createWithNetwork(ctx context.Context, resourc
 	allowedAddrs := map[string]string{"localsubnet": *subnet.Properties.AddressPrefix} // TODO @smcclure20: change with support for kubenet (include pod cidr)
 	nsg, err := sdkHandler.CreateSecurityGroup(ctx, resourceName, *resource.Location, allowedAddrs)
 	if err != nil {
-		utils.Log.Printf("An error occured while creating the network security group:%+v", err)
+		utils.Log.Printf("An error occurred while creating the network security group:%+v", err)
 		return "", err
 	}
 
 	err = sdkHandler.AssociateNSGWithSubnet(ctx, *subnet.ID, *nsg.ID)
 	if err != nil {
-		utils.Log.Printf("An error occured while associating the network security group with the subnet:%+v", err)
+		utils.Log.Printf("An error occurred while associating the network security group with the subnet:%+v", err)
 		return "", err
 	}
 
 	return *subnet.Properties.AddressPrefix, nil // TODO @smcclure20: change with support for kubenet
 }
 
-// Converts the resource description to an AKS cluster object
+// Converts the resource description to an AKS cluster object.
 func (r *azureResourceHandlerAKS) fromResourceDecription(resourceDesc []byte) (*armcontainerservice.ManagedCluster, error) {
 	aks := &armcontainerservice.ManagedCluster{}
 	err := json.Unmarshal(resourceDesc, aks)
 	if err != nil {
-		return nil, fmt.Errorf("failed to unmarshal resource description:%+v", err)
+		return nil, fmt.Errorf("failed to unmarshal resource description:%+w", err)
 	}
 
 	// Some validations on the AKS

--- a/pkg/azure/rule_utils.go
+++ b/pkg/azure/rule_utils.go
@@ -35,13 +35,13 @@ const (
 //  1. A deny all rule is present and has the lowest priority (i.e. highest priority number)
 //  2. All rules with higher priority (i.e. lower priority number) are allow rules
 //
-// Creates a deny all rule if there's none to ensure conformant rules for condition 1. (Given condition 2 is met)
+// Creates a deny all rule if there's none to ensure conformant rules for condition 1. (Given condition 2 is met).
 func CheckSecurityRulesCompliance(ctx context.Context, azureHandler *AzureSDKHandler, nsg *armnetwork.SecurityGroup) (bool, error) {
 	reservedPrioritiesInbound := make(map[int32]*armnetwork.SecurityRule)
 	reservedPrioritiesOutbound := make(map[int32]*armnetwork.SecurityRule)
 	err := setupMaps(reservedPrioritiesInbound, reservedPrioritiesOutbound, nil, nsg)
 	if err != nil {
-		utils.Log.Printf("An error occured during setup: %+v", err)
+		utils.Log.Printf("An error occurred during setup: %+v", err)
 		return false, err
 	}
 
@@ -62,7 +62,7 @@ func CheckSecurityRulesCompliance(ctx context.Context, azureHandler *AzureSDKHan
 	priority, err = validateSecurityRulesConform(reservedPrioritiesOutbound)
 	if err != nil {
 		if priority == -1 {
-			return false, fmt.Errorf("Non-compliant: %v", err)
+			return false, fmt.Errorf("non-compliant: %w", err)
 		}
 
 		_, err := setupAndCreateDenyAllRule(ctx, azureHandler, priority, outboundDirectionRule, *nsg.Name)
@@ -82,7 +82,7 @@ func CheckSecurityRulesCompliance(ctx context.Context, azureHandler *AzureSDKHan
 //
 // 2. If no deny all rule exists, priority number to create a deny all rule & an error
 //
-// 3. If the rules are non-conformant, a priority number of -1 & an error
+// 3. If the rules are non-conformant, a priority number of -1 & an error.
 func validateSecurityRulesConform(reservedPriorities map[int32]*armnetwork.SecurityRule) (int32, error) {
 	var lowestRule *armnetwork.SecurityRule
 	lowestDenyPriorityNum := int32(maxPriority)
@@ -97,7 +97,7 @@ func validateSecurityRulesConform(reservedPriorities map[int32]*armnetwork.Secur
 		if (access == armnetwork.SecurityRuleAccessDeny) && (priority <= lowestDenyPriorityNum) {
 			// Any deny rule must be a deny all rule
 			if !isDenyAllRule(rule) {
-				return -1, fmt.Errorf("Deny Rule at priority(%d) is not a Deny all rule", priority)
+				return -1, fmt.Errorf("deny Rule at priority(%d) is not a Deny all rule", priority)
 			}
 
 			lowestRule = rule
@@ -107,23 +107,23 @@ func validateSecurityRulesConform(reservedPriorities map[int32]*armnetwork.Secur
 
 	// An allow rule's priority number is higher than a deny rule's priority number
 	if highestAllowPriorityNum > lowestDenyPriorityNum {
-		return -1, fmt.Errorf("Allow Rule with lower priority(%d) than Deny Rule(%d)", highestAllowPriorityNum, lowestDenyPriorityNum)
+		return -1, fmt.Errorf("allow Rule with lower priority(%d) than Deny Rule(%d)", highestAllowPriorityNum, lowestDenyPriorityNum)
 	}
 
 	if lowestRule == nil {
 		if reservedPriorities[maxPriority] != nil {
 			// The max priority number should not be associated to an allow rule
-			return -1, fmt.Errorf("Allow Rule at lowest priority(%d). Must be a deny all rule", maxPriority)
+			return -1, fmt.Errorf("allow Rule at lowest priority(%d). Must be a deny all rule", maxPriority)
 		}
 
 		// No deny all rule exists; return priority to create deny all rule
-		return maxPriority, fmt.Errorf("No deny rule present")
+		return maxPriority, fmt.Errorf("no deny rule present")
 	}
 
 	// If not a deny all rule, return priority to create a deny all rule
 	if !isDenyAllRule(lowestRule) {
 		lastPriority := getNextAvailablePriority(reservedPriorities, minPriority, maxPriority, false)
-		return lastPriority, fmt.Errorf("Deny Rule not at lowest priority(%d) is not a Deny all rule", lowestDenyPriorityNum)
+		return lastPriority, fmt.Errorf("deny Rule not at lowest priority(%d) is not a Deny all rule", lowestDenyPriorityNum)
 	}
 
 	return lowestDenyPriorityNum, nil
@@ -162,7 +162,7 @@ func setupDenyAllRuleWithPriority(priority int32, direction armnetwork.SecurityR
 	}
 }
 
-// Returns true if the rule is a deny all rule, false otherwise
+// Returns true if the rule is a deny all rule, false otherwise.
 func isDenyAllRule(rule *armnetwork.SecurityRule) bool {
 	var anyDestPrefix, anySourcePrefix bool
 

--- a/pkg/azure/sdk_handler.go
+++ b/pkg/azure/sdk_handler.go
@@ -79,7 +79,7 @@ const (
 	virtualNetworkResourceID   = "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/virtualNetworks/%s"
 )
 
-// mapping from IANA protocol numbers (what paraglider uses) to Azure SecurityRuleProtocol except for * which is -1 for all protocols
+// mapping from IANA protocol numbers (what paraglider uses) to Azure SecurityRuleProtocol except for * which is -1 for all protocols.
 var paragliderToAzureprotocol = map[int32]armnetwork.SecurityRuleProtocol{
 	-1: armnetwork.SecurityRuleProtocolAsterisk,
 	1:  armnetwork.SecurityRuleProtocolIcmp,
@@ -89,7 +89,7 @@ var paragliderToAzureprotocol = map[int32]armnetwork.SecurityRuleProtocol{
 	51: armnetwork.SecurityRuleProtocolAh,
 }
 
-// mapping from Azure SecurityRuleProtocol to IANA protocol numbers
+// mapping from Azure SecurityRuleProtocol to IANA protocol numbers.
 var azureToParagliderProtocol = map[armnetwork.SecurityRuleProtocol]int32{
 	armnetwork.SecurityRuleProtocolAsterisk: -1,
 	armnetwork.SecurityRuleProtocolIcmp:     1,
@@ -99,19 +99,19 @@ var azureToParagliderProtocol = map[armnetwork.SecurityRuleProtocol]int32{
 	armnetwork.SecurityRuleProtocolAh:       51,
 }
 
-// mapping from paraglider direction to Azure SecurityRuleDirection
+// mapping from paraglider direction to Azure SecurityRuleDirection.
 var paragliderToAzureDirection = map[paragliderpb.Direction]armnetwork.SecurityRuleDirection{
 	paragliderpb.Direction_INBOUND:  armnetwork.SecurityRuleDirectionInbound,
 	paragliderpb.Direction_OUTBOUND: armnetwork.SecurityRuleDirectionOutbound,
 }
 
-// mapping from Azure SecurityRuleDirection to paraglider direction
+// mapping from Azure SecurityRuleDirection to paraglider direction.
 var azureToParagliderDirection = map[armnetwork.SecurityRuleDirection]paragliderpb.Direction{
 	armnetwork.SecurityRuleDirectionInbound:  paragliderpb.Direction_INBOUND,
 	armnetwork.SecurityRuleDirectionOutbound: paragliderpb.Direction_OUTBOUND,
 }
 
-// InitializeClients initializes the necessary azure clients for the necessary operations
+// InitializeClients initializes the necessary azure clients for the necessary operations.
 func (h *AzureSDKHandler) InitializeClients(cred azcore.TokenCredential) error {
 	var err error
 	h.resourcesClientFactory, err = armresources.NewClientFactory(h.subscriptionID, cred, nil)
@@ -173,7 +173,7 @@ func (h *AzureSDKHandler) SetSubIdAndResourceGroup(subid string, resourceGroupNa
 }
 
 func (h *AzureSDKHandler) GetResource(ctx context.Context, resourceID string) (*armresources.GenericResource, error) {
-	var apiVersion string = "2024-03-01"
+	apiVersion := "2024-03-01"
 	options := armresources.ClientGetByIDOptions{}
 
 	resource, err := h.resourcesClient.GetByID(ctx, resourceID, apiVersion, &options)
@@ -237,12 +237,12 @@ func (h *AzureSDKHandler) CreateSecurityRuleFromPermitList(ctx context.Context, 
 func (h *AzureSDKHandler) CreateSecurityRule(ctx context.Context, nsgName string, ruleName string, rule *armnetwork.SecurityRule) (*armnetwork.SecurityRule, error) {
 	pollerResp, err := h.securityRulesClient.BeginCreateOrUpdate(ctx, h.resourceGroupName, nsgName, ruleName, *rule, nil)
 	if err != nil {
-		return nil, fmt.Errorf("cannot create HTTP security rule: %v", err)
+		return nil, fmt.Errorf("cannot create HTTP security rule: %w", err)
 	}
 
 	resp, err := pollerResp.PollUntilDone(ctx, nil)
 	if err != nil {
-		return nil, fmt.Errorf("cannot get security rule create or update future response: %v", err)
+		return nil, fmt.Errorf("cannot get security rule create or update future response: %w", err)
 	}
 
 	return &resp.SecurityRule, nil
@@ -334,7 +334,7 @@ func (h *AzureSDKHandler) GetVnetAddressSpace(ctx context.Context, vnetName stri
 }
 
 // Temporarily needed method to deal with the mess of AzureSDKHandlers
-// TODO @seankimkdy: remove once AzureSDKHandler is no longer a mess
+// TODO @seankimkdy: remove once AzureSDKHandler is no longer a mess.
 func (h *AzureSDKHandler) CreateVnetPeeringOneWay(ctx context.Context, vnet1Name string, vnet2Name string, vnet2SubscriptionID string, vnet2ResourceGroupName string) error {
 	// create first link from vnet1 to vnet2
 	vnet1ToVnet2PeeringParameters := armnetwork.VirtualNetworkPeering{
@@ -372,7 +372,7 @@ func (h *AzureSDKHandler) CreateVnetPeering(ctx context.Context, vnet1Name strin
 	return nil
 }
 
-// Creates (if not exists) or updates vnet peering to use remote gateway
+// Creates (if not exists) or updates vnet peering to use remote gateway.
 func (h *AzureSDKHandler) CreateOrUpdateVnetPeeringRemoteGateway(ctx context.Context, vnetName string, gatewayVnetName string, vnetToGatewayVnetPeering *armnetwork.VirtualNetworkPeering, gatewayVnetToVnetPeering *armnetwork.VirtualNetworkPeering) error {
 	// Gateway vnet to vnet peering must be created/updated first to allow gateway transit before creating/updating vnet to gateway vnet peering
 	if gatewayVnetToVnetPeering == nil {
@@ -452,7 +452,7 @@ func (h *AzureSDKHandler) GetPermitListRuleFromNSGRule(rule *armnetwork.Security
 	} else {
 		srcPort, err = strconv.Atoi(*rule.Properties.SourcePortRange)
 		if err != nil {
-			return nil, fmt.Errorf("cannot convert source port range to int: %v", err)
+			return nil, fmt.Errorf("cannot convert source port range to int: %w", err)
 		}
 	}
 
@@ -461,7 +461,7 @@ func (h *AzureSDKHandler) GetPermitListRuleFromNSGRule(rule *armnetwork.Security
 	} else {
 		dstPort, err = strconv.Atoi(*rule.Properties.DestinationPortRange)
 		if err != nil {
-			return nil, fmt.Errorf("cannot convert destination port range to int: %v", err)
+			return nil, fmt.Errorf("cannot convert destination port range to int: %w", err)
 		}
 	}
 
@@ -478,7 +478,7 @@ func (h *AzureSDKHandler) GetPermitListRuleFromNSGRule(rule *armnetwork.Security
 	return permitListRule, nil
 }
 
-// GetSecurityGroup reutrns the network security group object given the nsg name
+// GetSecurityGroup reutrns the network security group object given the nsg name.
 func (h *AzureSDKHandler) GetSecurityGroup(ctx context.Context, nsgName string) (*armnetwork.SecurityGroup, error) {
 	nsgResp, err := h.securityGroupsClient.Get(ctx, h.resourceGroupName, nsgName, &armnetwork.SecurityGroupsClientGetOptions{Expand: nil})
 	if err != nil {
@@ -489,7 +489,7 @@ func (h *AzureSDKHandler) GetSecurityGroup(ctx context.Context, nsgName string) 
 }
 
 // GetParagliderVnet returns a valid paraglider vnet. A paraglider vnet is a vnet created by Paraglider
-// with a default subnet with the same address space as the vnet and there is only one vnet per location
+// with a default subnet with the same address space as the vnet and there is only one vnet per location.
 func (h *AzureSDKHandler) GetParagliderVnet(ctx context.Context, vnetName string, location string, namespace string, orchestratorAddr string) (*armnetwork.VirtualNetwork, error) {
 	// Get the virtual network
 	res, err := h.virtualNetworksClient.Get(ctx, h.resourceGroupName, vnetName, &armnetwork.VirtualNetworksClientGetOptions{Expand: nil})
@@ -503,7 +503,7 @@ func (h *AzureSDKHandler) GetParagliderVnet(ctx context.Context, vnetName string
 				utils.Log.Printf("could not dial the orchestrator")
 				return nil, err
 			}
-			defer conn.Close()
+			defer func() { _ = conn.Close() }()
 			client := paragliderpb.NewControllerClient(conn)
 			response, err := client.FindUnusedAddressSpaces(context.Background(), &paragliderpb.FindUnusedAddressSpacesRequest{})
 			if err != nil {
@@ -520,7 +520,7 @@ func (h *AzureSDKHandler) GetParagliderVnet(ctx context.Context, vnetName string
 	return &res.VirtualNetwork, nil
 }
 
-// AddSubnetToParagliderVnet adds a subnet to an paraglider vnet
+// AddSubnetToParagliderVnet adds a subnet to an paraglider vnet.
 func (h *AzureSDKHandler) AddSubnetToParagliderVnet(ctx context.Context, namespace string, vnetName string, subnetName string, orchestratorAddr string) (*armnetwork.Subnet, error) {
 	// Get a new address space
 	conn, err := grpc.NewClient(orchestratorAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
@@ -528,11 +528,10 @@ func (h *AzureSDKHandler) AddSubnetToParagliderVnet(ctx context.Context, namespa
 		utils.Log.Printf("could not dial the orchestrator")
 		return nil, err
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 
 	client := paragliderpb.NewControllerClient(conn)
 	response, err := client.FindUnusedAddressSpaces(context.Background(), &paragliderpb.FindUnusedAddressSpacesRequest{})
-
 	if err != nil {
 		return nil, err
 	}
@@ -558,7 +557,7 @@ func (h *AzureSDKHandler) AddSubnetToParagliderVnet(ctx context.Context, namespa
 }
 
 // CreateParagliderVirtualNetwork creates a new paraglider virtual network with a default subnet with the same address
-// space as the vnet
+// space as the vnet.
 func (h *AzureSDKHandler) CreateParagliderVirtualNetwork(ctx context.Context, location string, vnetName string, addressSpace string) (*armnetwork.VirtualNetwork, error) {
 	// TODO @seankimkdy: delete and consolidate calls to this method with CreateParagliderVirtualNetwork
 	parameters := armnetwork.VirtualNetwork{
@@ -665,7 +664,7 @@ func (h *AzureSDKHandler) CreateSecurityGroup(ctx context.Context, resourceName 
 	return &nsgResp.SecurityGroup, nil
 }
 
-// CreateNetworkInterface creates a new network interface with a dynamic private IP address
+// CreateNetworkInterface creates a new network interface with a dynamic private IP address.
 func (h *AzureSDKHandler) CreateNetworkInterface(ctx context.Context, subnetID string, location string, nicName string) (*armnetwork.Interface, error) {
 	nsg, err := h.CreateSecurityGroup(ctx, nicName, location, map[string]string{})
 	if err != nil {
@@ -705,7 +704,7 @@ func (h *AzureSDKHandler) CreateNetworkInterface(ctx context.Context, subnetID s
 	return &resp.Interface, err
 }
 
-// CreateVirtualMachine creates a new virtual machine with the given parameters and name
+// CreateVirtualMachine creates a new virtual machine with the given parameters and name.
 func (h *AzureSDKHandler) CreateVirtualMachine(ctx context.Context, parameters armcompute.VirtualMachine, vmName string) (*armcompute.VirtualMachine, error) {
 	h.createParagliderNamespaceTag(&parameters.Tags)
 	pollerResponse, err := h.virtualMachinesClient.BeginCreateOrUpdate(ctx, h.resourceGroupName, vmName, parameters, nil)
@@ -720,7 +719,7 @@ func (h *AzureSDKHandler) CreateVirtualMachine(ctx context.Context, parameters a
 	return &resp.VirtualMachine, nil
 }
 
-// CreateAKSCluster creates a new AKS cluster with the given parameters and name
+// CreateAKSCluster creates a new AKS cluster with the given parameters and name.
 func (h *AzureSDKHandler) CreateAKSCluster(ctx context.Context, parameters armcontainerservice.ManagedCluster, clusterName string) (*armcontainerservice.ManagedCluster, error) {
 	h.createParagliderNamespaceTag(&parameters.Tags)
 	pollerResponse, err := h.managedClustersClient.BeginCreateOrUpdate(ctx, h.resourceGroupName, clusterName, parameters, nil)
@@ -735,7 +734,7 @@ func (h *AzureSDKHandler) CreateAKSCluster(ctx context.Context, parameters armco
 	return &resp.ManagedCluster, nil
 }
 
-// GetVnet returns the virtual network with the given name
+// GetVnet returns the virtual network with the given name.
 func (h *AzureSDKHandler) GetVnet(ctx context.Context, vnetName string) (*armnetwork.VirtualNetwork, error) {
 	vnet, err := h.virtualNetworksClient.Get(ctx, h.resourceGroupName, vnetName, nil)
 	if err != nil {
@@ -881,7 +880,7 @@ func (h *AzureSDKHandler) GetNatGateway(ctx context.Context, name string) (*armn
 	return &resp.NatGateway, nil
 }
 
-// Creates a tag for the Paraglider namespace in the "Tag" field of various resource parameters
+// Creates a tag for the Paraglider namespace in the "Tag" field of various resource parameters.
 func (h *AzureSDKHandler) createParagliderNamespaceTag(tags *map[string]*string) {
 	if *tags == nil {
 		*tags = make(map[string]*string)
@@ -923,14 +922,15 @@ func getIPs(rule *paragliderpb.PermitListRule, resourceIP string) ([]*string, []
 	return sourceIP, destIP
 }
 
-// getTarget returns the paraglider targets for a given nsg rule
+// getTarget returns the paraglider targets for a given nsg rule.
 func getTargets(rule *armnetwork.SecurityRule) []string {
 	var targets []string
-	if *rule.Properties.Direction == armnetwork.SecurityRuleDirectionInbound {
+	switch *rule.Properties.Direction {
+	case armnetwork.SecurityRuleDirectionInbound:
 		for _, ptr := range rule.Properties.SourceAddressPrefixes {
 			targets = append(targets, *ptr)
 		}
-	} else if *rule.Properties.Direction == armnetwork.SecurityRuleDirectionOutbound {
+	case armnetwork.SecurityRuleDirectionOutbound:
 		for _, ptr := range rule.Properties.DestinationAddressPrefixes {
 			targets = append(targets, *ptr)
 		}
@@ -938,7 +938,7 @@ func getTargets(rule *armnetwork.SecurityRule) []string {
 	return targets
 }
 
-// Format the description to keep metadata about tags
+// Format the description to keep metadata about tags.
 func getRuleDescription(tags []string) string {
 	if len(tags) == 0 {
 		return nsgRuleDescriptionPrefix
@@ -946,7 +946,7 @@ func getRuleDescription(tags []string) string {
 	return fmt.Sprintf("%s:%v", nsgRuleDescriptionPrefix, tags)
 }
 
-// Parses description string to get tags
+// Parses description string to get tags.
 func parseDescriptionTags(description *string) []string {
 	var tags []string
 	if description != nil && strings.HasPrefix(*description, nsgRuleDescriptionPrefix+":[") {
@@ -958,14 +958,14 @@ func parseDescriptionTags(description *string) []string {
 	return tags
 }
 
-// Checks if Azure error response is a not found error
+// Checks if Azure error response is a not found error.
 func isErrorNotFound(err error) bool {
 	var azError *azcore.ResponseError
 	ok := errors.As(err, &azError)
 	return ok && azError.StatusCode == http.StatusNotFound
 }
 
-// Returns peering name from local vnet to remote vnet
+// Returns peering name from local vnet to remote vnet.
 func getPeeringName(localVnetName string, remoteVnetName string) string {
 	return localVnetName + "-to-" + remoteVnetName
 }

--- a/pkg/azure/test_utils.go
+++ b/pkg/azure/test_utils.go
@@ -102,7 +102,8 @@ func getFakeServerHandler(fakeServerState *fakeServerState) http.HandlerFunc {
 		// NSGs
 		case strings.HasPrefix(path, urlPrefix+"/Microsoft.Network/networkSecurityGroups/"):
 			if strings.Contains(path, "/securityRules") {
-				if r.Method == "PUT" {
+				switch r.Method {
+				case http.MethodPut:
 					rule := &armnetwork.SecurityRule{}
 					err = json.Unmarshal(body, rule)
 					if err != nil {
@@ -114,12 +115,12 @@ func getFakeServerHandler(fakeServerState *fakeServerState) http.HandlerFunc {
 					}
 					sendResponse(w, rule)
 					return
-				} else if r.Method == "DELETE" {
+				case http.MethodDelete:
 					w.WriteHeader(http.StatusOK)
 					return
 				}
 			} else {
-				if r.Method == "GET" {
+				if r.Method == http.MethodGet {
 					if fakeServerState.nsg == nil {
 						http.Error(w, "nsg not found", http.StatusNotFound)
 						return
@@ -127,7 +128,7 @@ func getFakeServerHandler(fakeServerState *fakeServerState) http.HandlerFunc {
 					sendResponse(w, fakeServerState.nsg)
 					return
 				}
-				if r.Method == "PUT" {
+				if r.Method == http.MethodPut {
 					nsg := &armnetwork.SecurityGroup{}
 					err = json.Unmarshal(body, nsg)
 					if err != nil {
@@ -140,7 +141,7 @@ func getFakeServerHandler(fakeServerState *fakeServerState) http.HandlerFunc {
 			}
 		// VMs
 		case strings.HasPrefix(path, urlPrefix+"/Microsoft.Compute/virtualMachines/"):
-			if r.Method == "GET" {
+			if r.Method == http.MethodGet {
 				if fakeServerState.vm == nil {
 					http.Error(w, "vm not found", http.StatusNotFound)
 					return
@@ -148,7 +149,7 @@ func getFakeServerHandler(fakeServerState *fakeServerState) http.HandlerFunc {
 				sendResponse(w, fakeServerState.vm)
 				return
 			}
-			if r.Method == "PUT" {
+			if r.Method == http.MethodPut {
 				vm := &armcompute.VirtualMachine{}
 				err = json.Unmarshal(body, vm)
 				if err != nil {
@@ -160,7 +161,7 @@ func getFakeServerHandler(fakeServerState *fakeServerState) http.HandlerFunc {
 			}
 		// NICs
 		case strings.HasPrefix(path, urlPrefix+"/Microsoft.Network/networkInterfaces/"):
-			if r.Method == "GET" {
+			if r.Method == http.MethodGet {
 				if fakeServerState.nic == nil {
 					http.Error(w, "nic not found", http.StatusNotFound)
 					return
@@ -168,7 +169,7 @@ func getFakeServerHandler(fakeServerState *fakeServerState) http.HandlerFunc {
 				sendResponse(w, fakeServerState.nic)
 				return
 			}
-			if r.Method == "PUT" {
+			if r.Method == http.MethodPut {
 				nic := &armnetwork.Interface{}
 				err = json.Unmarshal(body, nic)
 				if err != nil {
@@ -181,7 +182,7 @@ func getFakeServerHandler(fakeServerState *fakeServerState) http.HandlerFunc {
 		// Virtual Networks (and their sub-resources)
 		case strings.HasPrefix(path, urlPrefix+"/Microsoft.Network/virtualNetworks"):
 			if strings.Contains(path, "/virtualNetworkPeerings/") { // VirtualNetworkPeerings
-				if r.Method == "GET" {
+				if r.Method == http.MethodGet {
 					if fakeServerState.vnetPeering == nil {
 						http.Error(w, "vnet peering not found", http.StatusNotFound)
 						return
@@ -189,7 +190,7 @@ func getFakeServerHandler(fakeServerState *fakeServerState) http.HandlerFunc {
 					sendResponse(w, fakeServerState.vnetPeering)
 					return
 				}
-				if r.Method == "PUT" {
+				if r.Method == http.MethodPut {
 					peering := &armnetwork.VirtualNetworkPeering{}
 					err = json.Unmarshal(body, peering)
 					if err != nil {
@@ -200,7 +201,7 @@ func getFakeServerHandler(fakeServerState *fakeServerState) http.HandlerFunc {
 					return
 				}
 			} else if strings.Contains(path, "/subnets/") { // Subnets
-				if r.Method == "GET" {
+				if r.Method == http.MethodGet {
 					if fakeServerState.subnet == nil {
 						http.Error(w, "subnet not found", http.StatusNotFound)
 						return
@@ -208,7 +209,7 @@ func getFakeServerHandler(fakeServerState *fakeServerState) http.HandlerFunc {
 					sendResponse(w, fakeServerState.subnet)
 					return
 				}
-				if r.Method == "PUT" {
+				if r.Method == http.MethodPut {
 					subnet := &armnetwork.Subnet{}
 					err = json.Unmarshal(body, subnet)
 					if err != nil {
@@ -219,7 +220,7 @@ func getFakeServerHandler(fakeServerState *fakeServerState) http.HandlerFunc {
 					return
 				}
 			} else {
-				if r.Method == "GET" && strings.HasSuffix(path, "/virtualNetworks") {
+				if r.Method == http.MethodGet && strings.HasSuffix(path, "/virtualNetworks") {
 					if fakeServerState.vnet == nil {
 						http.Error(w, "vnet not found", http.StatusNotFound)
 						return
@@ -229,7 +230,7 @@ func getFakeServerHandler(fakeServerState *fakeServerState) http.HandlerFunc {
 					sendResponse(w, response)
 					return
 				}
-				if r.Method == "GET" {
+				if r.Method == http.MethodGet {
 					if fakeServerState.vnet == nil {
 						http.Error(w, "vnet not found", http.StatusNotFound)
 						return
@@ -237,7 +238,7 @@ func getFakeServerHandler(fakeServerState *fakeServerState) http.HandlerFunc {
 					sendResponse(w, fakeServerState.vnet)
 					return
 				}
-				if r.Method == "PUT" {
+				if r.Method == http.MethodPut {
 					vnet := &armnetwork.VirtualNetwork{}
 					err = json.Unmarshal(body, vnet)
 					if err != nil {
@@ -250,7 +251,7 @@ func getFakeServerHandler(fakeServerState *fakeServerState) http.HandlerFunc {
 			}
 		// VirtualNetworkGateways
 		case strings.HasPrefix(path, urlPrefix+"/Microsoft.Network/virtualNetworkGateways/"):
-			if r.Method == "GET" {
+			if r.Method == http.MethodGet {
 				if fakeServerState.vpnGw == nil {
 					http.Error(w, "gateway not found", http.StatusNotFound)
 					return
@@ -258,7 +259,7 @@ func getFakeServerHandler(fakeServerState *fakeServerState) http.HandlerFunc {
 				sendResponse(w, fakeServerState.vpnGw)
 				return
 			}
-			if r.Method == "PUT" {
+			if r.Method == http.MethodPut {
 				gateway := &armnetwork.VirtualNetworkGateway{}
 				err = json.Unmarshal(body, gateway)
 				if err != nil {
@@ -270,7 +271,7 @@ func getFakeServerHandler(fakeServerState *fakeServerState) http.HandlerFunc {
 			}
 		// PublicIPAddresses
 		case strings.HasPrefix(path, urlPrefix+"/Microsoft.Network/publicIPAddresses/"):
-			if r.Method == "GET" {
+			if r.Method == http.MethodGet {
 				if fakeServerState.publicIP == nil {
 					http.Error(w, "public IP not found", http.StatusNotFound)
 					return
@@ -278,7 +279,7 @@ func getFakeServerHandler(fakeServerState *fakeServerState) http.HandlerFunc {
 				sendResponse(w, fakeServerState.publicIP)
 				return
 			}
-			if r.Method == "PUT" {
+			if r.Method == http.MethodPut {
 				publicIP := &armnetwork.PublicIPAddress{}
 				err = json.Unmarshal(body, publicIP)
 				if err != nil {
@@ -290,7 +291,7 @@ func getFakeServerHandler(fakeServerState *fakeServerState) http.HandlerFunc {
 			}
 		// LocalNetworkGateways
 		case strings.HasPrefix(path, urlPrefix+"/Microsoft.Network/localNetworkGateways/"):
-			if r.Method == "GET" {
+			if r.Method == http.MethodGet {
 				if fakeServerState.localGw == nil {
 					http.Error(w, "local gateway not found", http.StatusNotFound)
 					return
@@ -298,7 +299,7 @@ func getFakeServerHandler(fakeServerState *fakeServerState) http.HandlerFunc {
 				sendResponse(w, fakeServerState.localGw)
 				return
 			}
-			if r.Method == "PUT" {
+			if r.Method == http.MethodPut {
 				localGateway := &armnetwork.LocalNetworkGateway{}
 				err = json.Unmarshal(body, localGateway)
 				if err != nil {
@@ -310,7 +311,7 @@ func getFakeServerHandler(fakeServerState *fakeServerState) http.HandlerFunc {
 			}
 		// VirtualNetworkGatewayConnections
 		case strings.HasPrefix(path, urlPrefix+"/Microsoft.Network/connections/"):
-			if r.Method == "GET" {
+			if r.Method == http.MethodGet {
 				if fakeServerState.vpnConnection == nil {
 					http.Error(w, "vpn connection not found", http.StatusNotFound)
 					return
@@ -318,7 +319,7 @@ func getFakeServerHandler(fakeServerState *fakeServerState) http.HandlerFunc {
 				sendResponse(w, fakeServerState.vpnConnection)
 				return
 			}
-			if r.Method == "PUT" {
+			if r.Method == http.MethodPut {
 				vpnConnection := &armnetwork.VirtualNetworkGatewayConnection{}
 				err = json.Unmarshal(body, vpnConnection)
 				if err != nil {
@@ -330,7 +331,7 @@ func getFakeServerHandler(fakeServerState *fakeServerState) http.HandlerFunc {
 			}
 		// ManagedClusters
 		case strings.HasPrefix(path, urlPrefix+"/Microsoft.ContainerService/managedClusters/"):
-			if r.Method == "GET" {
+			if r.Method == http.MethodGet {
 				if fakeServerState.cluster == nil {
 					http.Error(w, "cluster not found", http.StatusNotFound)
 					return
@@ -338,7 +339,7 @@ func getFakeServerHandler(fakeServerState *fakeServerState) http.HandlerFunc {
 				sendResponse(w, fakeServerState.cluster)
 				return
 			}
-			if r.Method == "PUT" {
+			if r.Method == http.MethodPut {
 				cluster := &armcontainerservice.ManagedCluster{}
 				err = json.Unmarshal(body, cluster)
 				if err != nil {
@@ -350,7 +351,7 @@ func getFakeServerHandler(fakeServerState *fakeServerState) http.HandlerFunc {
 			}
 		// NatGateways
 		case strings.HasPrefix(path, urlPrefix+"/Microsoft.Network/natGateways/"):
-			if r.Method == "GET" {
+			if r.Method == http.MethodGet {
 				if fakeServerState.natGateway == nil {
 					http.Error(w, "nat gateway not found", http.StatusNotFound)
 					return
@@ -358,7 +359,7 @@ func getFakeServerHandler(fakeServerState *fakeServerState) http.HandlerFunc {
 				sendResponse(w, fakeServerState.natGateway)
 				return
 			}
-			if r.Method == "PUT" {
+			if r.Method == http.MethodPut {
 				natGateway := &armnetwork.NatGateway{}
 				err = json.Unmarshal(body, natGateway)
 				if err != nil {
@@ -373,7 +374,7 @@ func getFakeServerHandler(fakeServerState *fakeServerState) http.HandlerFunc {
 	})
 }
 
-// Struct to hold state for fake server
+// Struct to hold state for fake server.
 type fakeServerState struct {
 	subId         string
 	rgName        string
@@ -391,7 +392,7 @@ type fakeServerState struct {
 	natGateway    *armnetwork.NatGateway
 }
 
-// Sets up fake http server
+// Sets up fake http server.
 func SetupFakeAzureServer(t *testing.T, fakeServerState *fakeServerState) (fakeServer *httptest.Server, ctx context.Context) {
 	fakeServer = httptest.NewServer(getFakeServerHandler(fakeServerState))
 
@@ -460,7 +461,7 @@ func getFakeNSG() *armnetwork.SecurityGroup {
 	}
 }
 
-// Has "paraglider-" prefix before the vnet name
+// Has "paraglider-" prefix before the vnet name.
 func getFakeParagliderSubnet() *armnetwork.Subnet {
 	return &armnetwork.Subnet{
 		Name: to.Ptr(validSubnetName),
@@ -877,7 +878,7 @@ func runConnectivityCheck(ctx context.Context, namespace string, subscriptionId 
 			return false, err
 		}
 		// TODO @seankimkdy: Unclear why ConnectionStatus returns "Reachable" which is not a valid armnetwork.ConnectionStatus constant (https://github.com/Azure/azure-sdk-for-go/issues/21777)
-		if *resp.ConnectivityInformation.ConnectionStatus == armnetwork.ConnectionStatus("Reachable") {
+		if *resp.ConnectionStatus == armnetwork.ConnectionStatus("Reachable") {
 			return true, nil
 		}
 	}
@@ -894,7 +895,7 @@ func RunICMPConnectivityCheck(ctx context.Context, namespace string, subscriptio
 	if err != nil {
 		return false, fmt.Errorf("unable to check if destination IP address is private: %w", err)
 	} else if !isPrivate {
-		return false, fmt.Errorf("Azure does not support public destination IP address for ICMP")
+		return false, fmt.Errorf("azure does not support public destination IP address for ICMP")
 	}
 	return runConnectivityCheck(ctx, namespace, subscriptionId, resourceGroupName, sourceVmName, destinationIPAddress, 0, armnetwork.ProtocolIcmp, tries)
 }

--- a/pkg/azure/utils.go
+++ b/pkg/azure/utils.go
@@ -47,7 +47,7 @@ const (
 	natGatewayTypeName            = "Microsoft.Network/natGateways"
 )
 
-// Gets subscription ID defined in environment variable
+// Gets subscription ID defined in environment variable.
 func GetAzureSubscriptionId() string {
 	subscriptionId := os.Getenv("PARAGLIDER_AZURE_SUBSCRIPTION_ID")
 	if subscriptionId == "" {
@@ -56,7 +56,7 @@ func GetAzureSubscriptionId() string {
 	return subscriptionId
 }
 
-// Creates a resource groups client
+// Creates a resource groups client.
 func createResourceGroupsClient(subscriptionId string) *armresources.ResourceGroupsClient {
 	cred, err := azidentity.NewDefaultAzureCredential(nil)
 	if err != nil {
@@ -152,10 +152,10 @@ func TeardownAzureTesting(subscriptionId string, resourceGroupName string, names
 								providerNamespace := strings.Split(*resource.Type, "/")[0]
 								resp, err := providersClient.Get(ctx, providerNamespace, nil)
 								if err != nil {
-									panic(fmt.Errorf("Unable to get provider resource type: %w", err))
+									panic(fmt.Errorf("unable to get provider resource type: %w", err))
 								}
 								// Store all API versions under this provider namespace to reduce potential duplicate requests
-								for _, resourceType := range resp.Provider.ResourceTypes {
+								for _, resourceType := range resp.ResourceTypes {
 									// Breakdown of the term "resource type" overloading
 									// - *resource.Type = "Microsoft.Compute/virtualMachines"
 									// - providerNamespace = "Microsoft.Compute"
@@ -166,7 +166,6 @@ func TeardownAzureTesting(subscriptionId string, resourceGroupName string, names
 						}
 						resourceTypeToResources[*resource.Type] = append(resourceTypeToResources[*resource.Type], resource)
 					}
-
 				}
 				// Delete resources in the following order
 				deletionOrder := []string{
@@ -187,7 +186,7 @@ func TeardownAzureTesting(subscriptionId string, resourceGroupName string, names
 					if resources, ok := resourceTypeToResources[resourceType]; ok {
 						err = deleteResources(ctx, resourcesClient, resources, resourceTypeToAPIVersion[resourceType])
 						if err != nil {
-							panic(fmt.Errorf("Failed to delete resource type %s: %w", resourceType, err))
+							panic(fmt.Errorf("failed to delete resource type %s: %w", resourceType, err))
 						}
 						delete(resourceTypeToResources, resourceType)
 					}
@@ -198,7 +197,7 @@ func TeardownAzureTesting(subscriptionId string, resourceGroupName string, names
 					for resourceType, resources := range resourceTypeToResources {
 						err = deleteResources(ctx, resourcesClient, resources, resourceTypeToAPIVersion[resourceType])
 						if err != nil {
-							panic(fmt.Errorf("Failed to delete resource type %s: %w", resourceType, err))
+							panic(fmt.Errorf("failed to delete resource type %s: %w", resourceType, err))
 						}
 					}
 				}
@@ -211,11 +210,11 @@ func deleteResources(ctx context.Context, resourcesClient *armresources.Client, 
 	for _, resource := range resources {
 		pollerResp, err := resourcesClient.BeginDeleteByID(ctx, *resource.ID, apiVersion, nil)
 		if err != nil {
-			return fmt.Errorf("Error while deleting resource: %v", err)
+			return fmt.Errorf("error while deleting resource: %w", err)
 		}
 		_, err = pollerResp.PollUntilDone(ctx, nil)
 		if err != nil {
-			return fmt.Errorf("Error while deleting resource: %v", err)
+			return fmt.Errorf("error while deleting resource: %w", err)
 		}
 	}
 	return nil
@@ -254,7 +253,7 @@ func InitializeServer(orchestratorAddr string) *azurePluginServer {
 	}
 }
 
-// TODO @seankimkdy: figure out how to merge this with Azure SDK handler
+// TODO @seankimkdy: figure out how to merge this with Azure SDK handler.
 func GetVmIpAddress(vmId string) (string, error) {
 	resourceIdInfo, err := getResourceIDInfo(vmId)
 	if err != nil {
@@ -296,7 +295,7 @@ func findNetworkWatcher(ctx context.Context, watchersClient *armnetwork.Watchers
 	for pager.More() {
 		result, err := pager.NextPage(ctx)
 		if err != nil {
-			return nil, fmt.Errorf("failed to get next page of resources: %v", err)
+			return nil, fmt.Errorf("failed to get next page of resources: %w", err)
 		}
 
 		for _, networkWatcher := range result.Value {

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -51,7 +51,7 @@ type Client struct {
 	ControllerAddress string
 }
 
-// Proccess the response from the controller and return the body
+// Process the response from the controller and return the body.
 func (c *Client) processResponse(resp *http.Response) ([]byte, error) {
 	bodyBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
@@ -59,13 +59,13 @@ func (c *Client) processResponse(resp *http.Response) ([]byte, error) {
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return bodyBytes, fmt.Errorf("Request failed with status code %d: %s", resp.StatusCode, string(bodyBytes))
+		return bodyBytes, fmt.Errorf("request failed with status code %d: %s", resp.StatusCode, string(bodyBytes))
 	}
 
 	return bodyBytes, nil
 }
 
-// Send a request to the controller and return the response body
+// Send a request to the controller and return the response body.
 func (c *Client) sendRequest(url string, method string, body io.Reader) ([]byte, error) {
 	client := &http.Client{}
 
@@ -91,7 +91,7 @@ func (c *Client) sendRequest(url string, method string, body io.Reader) ([]byte,
 	return bodyBytes, err
 }
 
-// Get a permit list for a resource
+// Get a permit list for a resource.
 func (c *Client) GetPermitList(namespace string, cloud string, resourceName string) ([]*paragliderpb.PermitListRule, error) {
 	path := fmt.Sprintf(orchestrator.GetFormatterString(orchestrator.GetPermitListRulesURL), namespace, cloud, resourceName)
 
@@ -109,7 +109,7 @@ func (c *Client) GetPermitList(namespace string, cloud string, resourceName stri
 	return rules, nil
 }
 
-// Add permit list rules to a resource
+// Add permit list rules to a resource.
 func (c *Client) AddPermitListRules(namespace string, cloud string, resourceName string, rules []*paragliderpb.PermitListRule) error {
 	path := fmt.Sprintf(orchestrator.GetFormatterString(orchestrator.AddPermitListRulesURL), namespace, cloud, resourceName)
 
@@ -126,7 +126,7 @@ func (c *Client) AddPermitListRules(namespace string, cloud string, resourceName
 	return nil
 }
 
-// Delete permit list rules from a resource
+// Delete permit list rules from a resource.
 func (c *Client) DeletePermitListRules(namespace string, cloud string, resourceName string, rules []string) error {
 	path := fmt.Sprintf(orchestrator.GetFormatterString(orchestrator.DeletePermitListRulesURL), namespace, cloud, resourceName)
 
@@ -143,7 +143,7 @@ func (c *Client) DeletePermitListRules(namespace string, cloud string, resourceN
 	return nil
 }
 
-// Create a resource
+// Create a resource.
 func (c *Client) CreateResource(namespace string, cloud string, resourceName string, resource *paragliderpb.ResourceDescriptionString) (map[string]string, error) {
 	path := fmt.Sprintf(orchestrator.GetFormatterString(orchestrator.CreateResourcePUTURL), namespace, cloud, resourceName)
 
@@ -166,7 +166,7 @@ func (c *Client) CreateResource(namespace string, cloud string, resourceName str
 	return resourceDict, nil
 }
 
-// Attach a resource
+// Attach a resource.
 func (c *Client) AttachResource(namespace string, cloud string, resource *orchestrator.ResourceID) (map[string]string, error) {
 	path := fmt.Sprintf(orchestrator.GetFormatterString(orchestrator.CreateOrAttachResourcePOSTURL), namespace, cloud)
 
@@ -189,7 +189,7 @@ func (c *Client) AttachResource(namespace string, cloud string, resource *orches
 	return resourceDict, nil
 }
 
-// Add permit list rules to a tag
+// Add permit list rules to a tag.
 func (c *Client) AddPermitListRulesTag(tag string, rules []*paragliderpb.PermitListRule) error {
 	path := fmt.Sprintf(orchestrator.GetFormatterString(orchestrator.RuleOnTagURL), tag)
 
@@ -206,7 +206,7 @@ func (c *Client) AddPermitListRulesTag(tag string, rules []*paragliderpb.PermitL
 	return nil
 }
 
-// Remove permit list rules to a tag
+// Remove permit list rules to a tag.
 func (c *Client) DeletePermitListRulesTag(tag string, rules []string) error {
 	path := fmt.Sprintf(orchestrator.GetFormatterString(orchestrator.RuleOnTagURL), tag)
 
@@ -223,7 +223,7 @@ func (c *Client) DeletePermitListRulesTag(tag string, rules []string) error {
 	return nil
 }
 
-// Get the members of a tag
+// Get the members of a tag.
 func (c *Client) GetTag(tag string) (*tagservicepb.TagMapping, error) {
 	path := fmt.Sprintf(orchestrator.GetFormatterString(orchestrator.GetTagURL), tag)
 
@@ -241,7 +241,7 @@ func (c *Client) GetTag(tag string) (*tagservicepb.TagMapping, error) {
 	return tagMapping, nil
 }
 
-// Resolve a tag down to all IP/URI members
+// Resolve a tag down to all IP/URI members.
 func (c *Client) ResolveTag(tag string) ([]*tagservicepb.TagMapping, error) {
 	path := fmt.Sprintf(orchestrator.GetFormatterString(orchestrator.ResolveTagURL), tag)
 
@@ -259,7 +259,7 @@ func (c *Client) ResolveTag(tag string) ([]*tagservicepb.TagMapping, error) {
 	return tags, nil
 }
 
-// ListTags lists all tags and their mappings
+// ListTags lists all tags and their mappings.
 func (c *Client) ListTags() ([]*tagservicepb.TagMapping, error) {
 	path := orchestrator.GetFormatterString(orchestrator.ListTagURL)
 
@@ -277,7 +277,7 @@ func (c *Client) ListTags() ([]*tagservicepb.TagMapping, error) {
 	return tags, nil
 }
 
-// Set a tag as a member of a group or as a mapping to a URI/IP
+// Set a tag as a member of a group or as a mapping to a URI/IP.
 func (c *Client) SetTag(tag string, tagMapping *tagservicepb.TagMapping) error {
 	path := fmt.Sprintf(orchestrator.GetFormatterString(orchestrator.SetTagURL), tag)
 
@@ -294,7 +294,7 @@ func (c *Client) SetTag(tag string, tagMapping *tagservicepb.TagMapping) error {
 	return nil
 }
 
-// Delete an entire tag and all its member associations under it
+// Delete an entire tag and all its member associations under it.
 func (c *Client) DeleteTag(tag string) error {
 	path := fmt.Sprintf(orchestrator.GetFormatterString(orchestrator.DeleteTagURL), tag)
 
@@ -306,7 +306,7 @@ func (c *Client) DeleteTag(tag string) error {
 	return nil
 }
 
-// Delete member from a tag
+// Delete member from a tag.
 func (c *Client) DeleteTagMembers(tag string, member string) error {
 	path := fmt.Sprintf(orchestrator.GetFormatterString(orchestrator.DeleteTagMemberURL), tag, member)
 
@@ -318,7 +318,7 @@ func (c *Client) DeleteTagMembers(tag string, member string) error {
 	return nil
 }
 
-// List all configured namespaces
+// List all configured namespaces.
 func (c *Client) ListNamespaces() (map[string][]config.CloudDeployment, error) {
 	result, err := c.sendRequest(orchestrator.ListNamespacesURL, http.MethodGet, nil)
 	if err != nil {

--- a/pkg/fake/cloudplugin/fake_cloud_plugin.go
+++ b/pkg/fake/cloudplugin/fake_cloud_plugin.go
@@ -29,13 +29,17 @@ import (
 	fake "github.com/paraglider-project/paraglider/pkg/fake/tagservice"
 )
 
-const AddressSpaceAddress = "10.0.0.0/16"
-const Asn = 64512
+const (
+	AddressSpaceAddress = "10.0.0.0/16"
+	Asn                 = 64512
+)
 
-var BgpPeeringIpAddresses = []string{"169.254.21.1", "169.254.22.1"}
-var ExampleRule = &paragliderpb.PermitListRule{Name: "example-rule", Tags: []string{fake.ValidTagName, "1.2.3.4"}, SrcPort: 1, DstPort: 1, Protocol: 1, Direction: paragliderpb.Direction_INBOUND}
+var (
+	BgpPeeringIpAddresses = []string{"169.254.21.1", "169.254.22.1"}
+	ExampleRule           = &paragliderpb.PermitListRule{Name: "example-rule", Tags: []string{fake.ValidTagName, "1.2.3.4"}, SrcPort: 1, DstPort: 1, Protocol: 1, Direction: paragliderpb.Direction_INBOUND}
+)
 
-// Mock Cloud Plugin Server
+// Mock Cloud Plugin Server.
 type fakeCloudPluginServer struct {
 	paragliderpb.UnimplementedCloudPluginServer
 	fake.FakeTagServiceServer

--- a/pkg/fake/orchestrator/rpc/fake_orchestrator_rpc_server.go
+++ b/pkg/fake/orchestrator/rpc/fake_orchestrator_rpc_server.go
@@ -30,7 +30,7 @@ import (
 )
 
 // Sets up fake orchestrator server
-// Note: this is only meant to be used with one cloud (i.e. primarily for each cloud plugin's unit/integration tests)
+// Note: this is only meant to be used with one cloud (i.e. primarily for each cloud plugin's unit/integration tests).
 type FakeOrchestratorRPCServer struct {
 	paragliderpb.UnimplementedControllerServer
 	Cloud   string

--- a/pkg/gcp/clients.go
+++ b/pkg/gcp/clients.go
@@ -45,7 +45,7 @@ func (c *GCPClients) GetOrCreateInstancesClient(ctx context.Context) (*compute.I
 	if c.instancesClient == nil {
 		instancesClient, err := compute.NewInstancesRESTClient(ctx)
 		if err != nil {
-			return nil, fmt.Errorf("Failed to create InstancesClient: %w", err)
+			return nil, fmt.Errorf("failed to create InstancesClient: %w", err)
 		}
 		c.instancesClient = instancesClient
 	}
@@ -56,7 +56,7 @@ func (c *GCPClients) GetOrCreateClustersClient(ctx context.Context) (*container.
 	if c.clustersClient == nil {
 		clustersClient, err := container.NewClusterManagerClient(ctx)
 		if err != nil {
-			return nil, fmt.Errorf("Failed to create ClusterManagerClient: %w", err)
+			return nil, fmt.Errorf("failed to create ClusterManagerClient: %w", err)
 		}
 		c.clustersClient = clustersClient
 	}
@@ -67,7 +67,7 @@ func (c *GCPClients) GetOrCreateFirewallsClient(ctx context.Context) (*compute.F
 	if c.firewallsClient == nil {
 		firewallsClient, err := compute.NewFirewallsRESTClient(ctx)
 		if err != nil {
-			return nil, fmt.Errorf("Failed to create FirewallsClient: %w", err)
+			return nil, fmt.Errorf("failed to create FirewallsClient: %w", err)
 		}
 		c.firewallsClient = firewallsClient
 	}
@@ -78,7 +78,7 @@ func (c *GCPClients) GetOrCreateNetworksClient(ctx context.Context) (*compute.Ne
 	if c.networksClient == nil {
 		networksClient, err := compute.NewNetworksRESTClient(ctx)
 		if err != nil {
-			return nil, fmt.Errorf("Failed to create NetworksClient: %w", err)
+			return nil, fmt.Errorf("failed to create NetworksClient: %w", err)
 		}
 		c.networksClient = networksClient
 	}
@@ -89,7 +89,7 @@ func (c *GCPClients) GetOrCreateSubnetworksClient(ctx context.Context) (*compute
 	if c.subnetworksClient == nil {
 		subnetworksClient, err := compute.NewSubnetworksRESTClient(ctx)
 		if err != nil {
-			return nil, fmt.Errorf("Failed to create SubnetworksClient: %w", err)
+			return nil, fmt.Errorf("failed to create SubnetworksClient: %w", err)
 		}
 		c.subnetworksClient = subnetworksClient
 	}
@@ -100,7 +100,7 @@ func (c *GCPClients) GetOrCreateRoutersClient(ctx context.Context) (*compute.Rou
 	if c.routersClient == nil {
 		routersClient, err := compute.NewRoutersRESTClient(ctx)
 		if err != nil {
-			return nil, fmt.Errorf("Failed to create RoutersClient: %w", err)
+			return nil, fmt.Errorf("failed to create RoutersClient: %w", err)
 		}
 		c.routersClient = routersClient
 	}
@@ -111,7 +111,7 @@ func (c *GCPClients) GetOrCreateVpnGatewaysClient(ctx context.Context) (*compute
 	if c.vpnGatewaysClient == nil {
 		vpnGatewaysClient, err := compute.NewVpnGatewaysRESTClient(ctx)
 		if err != nil {
-			return nil, fmt.Errorf("Failed to create VpnGatewaysClient: %w", err)
+			return nil, fmt.Errorf("failed to create VpnGatewaysClient: %w", err)
 		}
 		c.vpnGatewaysClient = vpnGatewaysClient
 	}
@@ -122,7 +122,7 @@ func (c *GCPClients) GetOrCreateVpnTunnelsClient(ctx context.Context) (*compute.
 	if c.vpnTunnelsClient == nil {
 		vpnTunnelsClient, err := compute.NewVpnTunnelsRESTClient(ctx)
 		if err != nil {
-			return nil, fmt.Errorf("Failed to create VpnTunnelsClient: %w", err)
+			return nil, fmt.Errorf("failed to create VpnTunnelsClient: %w", err)
 		}
 		c.vpnTunnelsClient = vpnTunnelsClient
 	}
@@ -133,7 +133,7 @@ func (c *GCPClients) GetOrCreateExternalVpnGatewaysClient(ctx context.Context) (
 	if c.externalVpnGatewaysClient == nil {
 		externalVpnGatewaysClient, err := compute.NewExternalVpnGatewaysRESTClient(ctx)
 		if err != nil {
-			return nil, fmt.Errorf("Failed to create ExternalVpnGatewaysClient: %w", err)
+			return nil, fmt.Errorf("failed to create ExternalVpnGatewaysClient: %w", err)
 		}
 		c.externalVpnGatewaysClient = externalVpnGatewaysClient
 	}
@@ -144,7 +144,7 @@ func (c *GCPClients) GetOrCreateAddressesClient(ctx context.Context) (*compute.A
 	if c.addressesClient == nil {
 		addressesClient, err := compute.NewAddressesRESTClient(ctx)
 		if err != nil {
-			return nil, fmt.Errorf("Failed to create AddressesClient: %w", err)
+			return nil, fmt.Errorf("failed to create AddressesClient: %w", err)
 		}
 		c.addressesClient = addressesClient
 	}
@@ -155,7 +155,7 @@ func (c *GCPClients) GetOrCreateGlobalAddressesClient(ctx context.Context) (*com
 	if c.globalAddressesClient == nil {
 		globalAddressesClient, err := compute.NewGlobalAddressesRESTClient(ctx)
 		if err != nil {
-			return nil, fmt.Errorf("Failed to create GlobalAddressesClient: %w", err)
+			return nil, fmt.Errorf("failed to create GlobalAddressesClient: %w", err)
 		}
 		c.globalAddressesClient = globalAddressesClient
 	}
@@ -166,7 +166,7 @@ func (c *GCPClients) GetOrCreateForwardingClient(ctx context.Context) (*compute.
 	if c.forwardingClient == nil {
 		forwardingClient, err := compute.NewForwardingRulesRESTClient(ctx)
 		if err != nil {
-			return nil, fmt.Errorf("Failed to create ForwardingRulesClient: %w", err)
+			return nil, fmt.Errorf("failed to create ForwardingRulesClient: %w", err)
 		}
 		c.forwardingClient = forwardingClient
 	}
@@ -177,7 +177,7 @@ func (c *GCPClients) GetOrCreateGlobalForwardingClient(ctx context.Context) (*co
 	if c.globalForwardingClient == nil {
 		globalForwardingClient, err := compute.NewGlobalForwardingRulesRESTClient(ctx)
 		if err != nil {
-			return nil, fmt.Errorf("Failed to create GlobalForwardingRulesClient: %w", err)
+			return nil, fmt.Errorf("failed to create GlobalForwardingRulesClient: %w", err)
 		}
 		c.globalForwardingClient = globalForwardingClient
 	}
@@ -188,7 +188,7 @@ func (c *GCPClients) GetOrCreateServiceAttachmentsClient(ctx context.Context) (*
 	if c.serviceAttachmentClient == nil {
 		serviceAttachmentClient, err := compute.NewServiceAttachmentsRESTClient(ctx)
 		if err != nil {
-			return nil, fmt.Errorf("Failed to create ServiceAttachmentsClient: %w", err)
+			return nil, fmt.Errorf("failed to create ServiceAttachmentsClient: %w", err)
 		}
 		c.serviceAttachmentClient = serviceAttachmentClient
 	}
@@ -197,45 +197,45 @@ func (c *GCPClients) GetOrCreateServiceAttachmentsClient(ctx context.Context) (*
 
 func (c *GCPClients) Close() {
 	if c.instancesClient != nil {
-		c.instancesClient.Close()
+		_ = c.instancesClient.Close()
 	}
 	if c.clustersClient != nil {
-		c.clustersClient.Close()
+		_ = c.clustersClient.Close()
 	}
 	if c.firewallsClient != nil {
-		c.firewallsClient.Close()
+		_ = c.firewallsClient.Close()
 	}
 	if c.networksClient != nil {
-		c.networksClient.Close()
+		_ = c.networksClient.Close()
 	}
 	if c.subnetworksClient != nil {
-		c.subnetworksClient.Close()
+		_ = c.subnetworksClient.Close()
 	}
 	if c.routersClient != nil {
-		c.routersClient.Close()
+		_ = c.routersClient.Close()
 	}
 	if c.vpnGatewaysClient != nil {
-		c.vpnGatewaysClient.Close()
+		_ = c.vpnGatewaysClient.Close()
 	}
 	if c.vpnTunnelsClient != nil {
-		c.vpnTunnelsClient.Close()
+		_ = c.vpnTunnelsClient.Close()
 	}
 	if c.externalVpnGatewaysClient != nil {
-		c.externalVpnGatewaysClient.Close()
+		_ = c.externalVpnGatewaysClient.Close()
 	}
 	if c.addressesClient != nil {
-		c.addressesClient.Close()
+		_ = c.addressesClient.Close()
 	}
 	if c.globalAddressesClient != nil {
-		c.globalAddressesClient.Close()
+		_ = c.globalAddressesClient.Close()
 	}
 	if c.forwardingClient != nil {
-		c.forwardingClient.Close()
+		_ = c.forwardingClient.Close()
 	}
 	if c.globalForwardingClient != nil {
-		c.globalForwardingClient.Close()
+		_ = c.globalForwardingClient.Close()
 	}
 	if c.serviceAttachmentClient != nil {
-		c.serviceAttachmentClient.Close()
+		_ = c.serviceAttachmentClient.Close()
 	}
 }

--- a/pkg/gcp/firewalls.go
+++ b/pkg/gcp/firewalls.go
@@ -33,7 +33,7 @@ const (
 	targetTypeAddress             = "ADDRESS"
 )
 
-// Maps between of GCP and Paraglider traffic direction terminologies
+// Maps between of GCP and Paraglider traffic direction terminologies.
 var (
 	firewallDirectionMapGCPToParaglider = map[string]paragliderpb.Direction{
 		"INGRESS": paragliderpb.Direction_INBOUND,
@@ -62,12 +62,12 @@ type firewallTarget struct {
 	Target     string
 }
 
-// Checks if GCP firewall rule is a Paraglider permit list rule
+// Checks if GCP firewall rule is a Paraglider permit list rule.
 func isParagliderPermitListRule(namespace string, firewall *computepb.Firewall) bool {
 	return strings.HasSuffix(*firewall.Network, getVpcName(namespace)) && strings.HasPrefix(*firewall.Name, getFirewallNamePrefix(namespace))
 }
 
-// Converts a GCP firewall rule to a Paraglider permit list rule
+// Converts a GCP firewall rule to a Paraglider permit list rule.
 func firewallRuleToParagliderRule(namespace string, fw *computepb.Firewall) (*paragliderpb.PermitListRule, error) {
 	if len(fw.Allowed) != 1 {
 		return nil, fmt.Errorf("firewall rule has more than one allowed protocol")
@@ -113,7 +113,7 @@ func firewallRuleToParagliderRule(namespace string, fw *computepb.Firewall) (*pa
 	return rule, nil
 }
 
-// Converts a Paraglider permit list rule to a GCP firewall rule
+// Converts a Paraglider permit list rule to a GCP firewall rule.
 func paragliderRuleToFirewallRule(namespace string, project string, firewallName string, target firewallTarget, rule *paragliderpb.PermitListRule) (*computepb.Firewall, error) {
 	firewall := &computepb.Firewall{
 		Allowed: []*computepb.Allowed{
@@ -152,7 +152,7 @@ func paragliderRuleToFirewallRule(namespace string, project string, firewallName
 	return firewall, nil
 }
 
-// Determine if a firewall rule and permit list rule are equivalent
+// Determine if a firewall rule and permit list rule are equivalent.
 func isFirewallEqPermitListRule(namespace string, firewall *computepb.Firewall, rule *paragliderpb.PermitListRule) (bool, error) {
 	paragliderVersion, err := firewallRuleToParagliderRule(namespace, firewall)
 	if err != nil {
@@ -177,7 +177,7 @@ func isFirewallEqPermitListRule(namespace string, firewall *computepb.Firewall, 
 		paragliderVersion.SrcPort == rule.SrcPort, nil
 }
 
-// Gets protocol number from GCP specificiation (either a name like "tcp" or an int-string like "6")
+// Gets protocol number from GCP specificiation (either a name like "tcp" or an int-string like "6").
 func getProtocolNumber(firewallProtocol string) (int32, error) {
 	protocolNumber, ok := gcpProtocolNumberMap[firewallProtocol]
 	if !ok {
@@ -196,17 +196,17 @@ func getFirewallName(namespace string, ruleName string, resourceId string) strin
 	return fmt.Sprintf("%s-%s-%s", getFirewallNamePrefix(namespace), resourceId, ruleName)
 }
 
-// Retrieve the name of the permit list rule from the GCP firewall name
+// Retrieve the name of the permit list rule from the GCP firewall name.
 func parseFirewallName(namespace string, firewallName string) string {
 	return strings.SplitN(strings.TrimPrefix(firewallName, getFirewallNamePrefix(namespace)+"-"), "-", 2)[1]
 }
 
-// Returns name of firewall for denying all egress traffic
+// Returns name of firewall for denying all egress traffic.
 func getDenyAllIngressFirewallName(namespace string) string {
 	return getParagliderNamespacePrefix(namespace) + "-deny-all-egress"
 }
 
-// Format the description to keep metadata about tags
+// Format the description to keep metadata about tags.
 func getRuleDescription(tags []string) string {
 	if len(tags) == 0 {
 		return firewallRuleDescriptionPrefix
@@ -214,7 +214,7 @@ func getRuleDescription(tags []string) string {
 	return fmt.Sprintf("%s:%v", firewallRuleDescriptionPrefix, tags)
 }
 
-// Parses description string to get tags
+// Parses description string to get tags.
 func parseDescriptionTags(description string) []string {
 	var tags []string
 	if strings.HasPrefix(description, firewallRuleDescriptionPrefix+":[") {

--- a/pkg/gcp/networks.go
+++ b/pkg/gcp/networks.go
@@ -25,32 +25,32 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-// Gets a GCP VPC name
+// Gets a GCP VPC name.
 func getVpcName(namespace string) string {
 	return getParagliderNamespacePrefix(namespace) + "-vpc"
 }
 
-// Gets a GCP subnetwork name for Paraglider based on region
+// Gets a GCP subnetwork name for Paraglider based on region.
 func getSubnetworkName(namespace string, region string) string {
 	return getParagliderNamespacePrefix(namespace) + "-" + region + "-subnet"
 }
 
-// Returns a VPC network peering name
+// Returns a VPC network peering name.
 func getNetworkPeeringName(namespace string, peerNamespace string) string {
 	return getParagliderNamespacePrefix(namespace) + "-" + peerNamespace + "-peering"
 }
 
-// getSubnetworkUrl returns a fully qualified URL for a subnetwork
+// getSubnetworkUrl returns a fully qualified URL for a subnetwork.
 func getSubnetworkUrl(project string, region string, name string) string {
 	return computeUrlPrefix + fmt.Sprintf("projects/%s/regions/%s/subnetworks/%s", project, region, name)
 }
 
-// getVpcUrl returns a fully qualified URL for a VPC network
+// getVpcUrl returns a fully qualified URL for a VPC network.
 func getVpcUrl(project string, namespace string) string {
 	return computeUrlPrefix + fmt.Sprintf("projects/%s/global/networks/%s", project, getVpcName(namespace))
 }
 
-// Creates bi-directional peering between two VPC networks
+// Creates bi-directional peering between two VPC networks.
 func peerVpcNetwork(ctx context.Context, networksClient *compute.NetworksClient, currentProject string, currentNamespace string, peerProject string, peerNamespace string) error {
 	// Check if peering already exists
 	currentVpcName := getVpcName(currentNamespace)

--- a/pkg/gcp/plugin.go
+++ b/pkg/gcp/plugin.go
@@ -127,7 +127,7 @@ func (s *GCPPluginServer) _AddPermitListRules(ctx context.Context, req *paraglid
 	if err != nil {
 		return nil, fmt.Errorf("unable to establish connection with orchestrator: %w", err)
 	}
-	defer orchestratorConn.Close()
+	defer func() { _ = orchestratorConn.Close() }()
 	orchestratorClient := paragliderpb.NewControllerClient(orchestratorConn)
 	getUsedAddressSpacesResp, err := orchestratorClient.GetUsedAddressSpaces(context.Background(), &emptypb.Empty{})
 	if err != nil {
@@ -408,7 +408,7 @@ func (s *GCPPluginServer) _CreateResource(ctx context.Context, resourceDescripti
 		if err != nil {
 			return nil, fmt.Errorf("unable to establish connection with orchestrator: %w", err)
 		}
-		defer conn.Close()
+		defer func() { _ = conn.Close() }()
 		client := paragliderpb.NewControllerClient(conn)
 
 		if !subnetExists {
@@ -418,7 +418,6 @@ func (s *GCPPluginServer) _CreateResource(ctx context.Context, resourceDescripti
 		reqAddressSpaces := make([]int32, numAddressSpacesNeeded)
 
 		response, err := client.FindUnusedAddressSpaces(context.Background(), &paragliderpb.FindUnusedAddressSpacesRequest{Sizes: reqAddressSpaces})
-
 		if err != nil {
 			return nil, fmt.Errorf("unable to find unused address space: %w", err)
 		}
@@ -454,7 +453,6 @@ func (s *GCPPluginServer) _CreateResource(ctx context.Context, resourceDescripti
 
 	// Read and provision the resource
 	url, ip, err := ReadAndProvisionResource(ctx, resourceDescription, subnetName, resourceInfo, addressSpaces, clients)
-
 	if err != nil {
 		return nil, fmt.Errorf("unable to read and provision resource: %w", err)
 	}
@@ -663,7 +661,7 @@ func (s *GCPPluginServer) _CreateVpnGateway(ctx context.Context, req *paraglider
 	if err != nil {
 		return nil, fmt.Errorf("unable to establish connection with orchestrator: %w", err)
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 	client := paragliderpb.NewControllerClient(conn)
 	findUnusedAsnResp, err := client.FindUnusedAsn(ctx, &paragliderpb.FindUnusedAsnRequest{})
 	if err != nil {
@@ -878,7 +876,7 @@ func (s *GCPPluginServer) _CreateVpnConnections(ctx context.Context, req *paragl
 	return &paragliderpb.CreateVpnConnectionsResponse{}, nil
 }
 
-// GetNetworkAddressSpaces returns the address spaces in the virtual network containing the provided address space
+// GetNetworkAddressSpaces returns the address spaces in the virtual network containing the provided address space.
 func (s *GCPPluginServer) GetNetworkAddressSpaces(ctx context.Context, req *paragliderpb.GetNetworkAddressSpacesRequest) (*paragliderpb.GetNetworkAddressSpacesResponse, error) {
 	return nil, fmt.Errorf("GetNetworkAddressSpaces is currently not implemented by GCP, implying plugin does not support BGP disabled VPN connections")
 }

--- a/pkg/gcp/plugin_test.go
+++ b/pkg/gcp/plugin_test.go
@@ -366,8 +366,10 @@ func TestCreateResource(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	s := &GCPPluginServer{orchestratorServerAddr: fakeOrchestratorServerAddr,
-		flags: &paragliderpb.PluginFlags{KubernetesClustersEnabled: false, PrivateEndpointsEnabled: false}}
+	s := &GCPPluginServer{
+		orchestratorServerAddr: fakeOrchestratorServerAddr,
+		flags:                  &paragliderpb.PluginFlags{KubernetesClustersEnabled: false, PrivateEndpointsEnabled: false},
+	}
 	description, err := json.Marshal(&computepb.InsertInstanceRequest{
 		Project:          fakeProject,
 		Zone:             fakeZone,
@@ -402,8 +404,10 @@ func TestCreateResourceCluster(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	s := &GCPPluginServer{orchestratorServerAddr: fakeOrchestratorServerAddr,
-		flags: &paragliderpb.PluginFlags{KubernetesClustersEnabled: true, PrivateEndpointsEnabled: false}}
+	s := &GCPPluginServer{
+		orchestratorServerAddr: fakeOrchestratorServerAddr,
+		flags:                  &paragliderpb.PluginFlags{KubernetesClustersEnabled: true, PrivateEndpointsEnabled: false},
+	}
 	description, err := json.Marshal(&containerpb.CreateClusterRequest{
 		Cluster: getFakeCluster(false),
 		Parent:  fmt.Sprintf("projects/%s/locations/%s", fakeProject, fakeZone),
@@ -437,8 +441,10 @@ func TestCreateResourceClusterDisabled(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	s := &GCPPluginServer{orchestratorServerAddr: fakeOrchestratorServerAddr,
-		flags: &paragliderpb.PluginFlags{KubernetesClustersEnabled: false, PrivateEndpointsEnabled: false}}
+	s := &GCPPluginServer{
+		orchestratorServerAddr: fakeOrchestratorServerAddr,
+		flags:                  &paragliderpb.PluginFlags{KubernetesClustersEnabled: false, PrivateEndpointsEnabled: false},
+	}
 	description, err := json.Marshal(&containerpb.CreateClusterRequest{
 		Cluster: getFakeCluster(false),
 		Parent:  fmt.Sprintf("projects/%s/locations/%s", fakeProject, fakeZone),
@@ -473,8 +479,10 @@ func TestCreateResourcePsc(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	s := &GCPPluginServer{orchestratorServerAddr: fakeOrchestratorServerAddr,
-		flags: &paragliderpb.PluginFlags{KubernetesClustersEnabled: false, PrivateEndpointsEnabled: true}}
+	s := &GCPPluginServer{
+		orchestratorServerAddr: fakeOrchestratorServerAddr,
+		flags:                  &paragliderpb.PluginFlags{KubernetesClustersEnabled: false, PrivateEndpointsEnabled: true},
+	}
 	description, err := json.Marshal(&ServiceAttachmentDescription{
 		Url: fakeServiceAttachmentUrl,
 	})
@@ -508,8 +516,10 @@ func TestCreateResourcePscDisabled(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	s := &GCPPluginServer{orchestratorServerAddr: fakeOrchestratorServerAddr,
-		flags: &paragliderpb.PluginFlags{KubernetesClustersEnabled: false, PrivateEndpointsEnabled: false}}
+	s := &GCPPluginServer{
+		orchestratorServerAddr: fakeOrchestratorServerAddr,
+		flags:                  &paragliderpb.PluginFlags{KubernetesClustersEnabled: false, PrivateEndpointsEnabled: false},
+	}
 	description, err := json.Marshal(&ServiceAttachmentDescription{
 		Url: fakeServiceAttachmentUrl,
 	})

--- a/pkg/gcp/plugin_test_utils.go
+++ b/pkg/gcp/plugin_test_utils.go
@@ -40,7 +40,7 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-// Fake project and resource
+// Fake project and resource.
 const (
 	fakeProject              = "paraglider-fake"
 	fakeRegion               = "us-fake1"
@@ -59,18 +59,18 @@ const (
 
 	fakeIpAddress = "1.1.1.1"
 
-	// Missing resources not registered in fake server
+	// Missing resources not registered in fake server.
 	fakeMissingInstance   = "vm-paraglider-missing"
 	fakeMissingResourceId = computeUrlPrefix + "projects/" + fakeProject + "/zones/" + fakeZone + "/instances/" + fakeMissingInstance
 
-	// Overarching dummy operation name
+	// Overarching dummy operation name.
 	fakeOperation = "operation-fake"
 )
 
-// Fake tag for fake resource
+// Fake tag for fake resource.
 var fakeNetworkTag = getNetworkTag(fakeNamespace, instanceTypeName, convertIntIdToString(fakeInstanceId))
 
-// Portions of GCP API URLs
+// Portions of GCP API URLs.
 var (
 	urlProject  = "/compute/v1/projects/" + fakeProject
 	urlZone     = "/zones/" + fakeZone
@@ -78,7 +78,7 @@ var (
 	urlInstance = "/instances/" + fakeInstanceName
 )
 
-// Fake firewalls and permitlists
+// Fake firewalls and permitlists.
 var (
 	fakePermitListRule1 = &paragliderpb.PermitListRule{
 		Name:      "rule-name1",
@@ -126,8 +126,10 @@ var (
 	}
 )
 
-// Fake instance
-func getFakeInstance(includeNetwork bool) *computepb.Instance {
+// Fake instance.
+func getFakeInstance(
+	includeNetwork bool,
+) *computepb.Instance {
 	instance := &computepb.Instance{
 		Id:   proto.Uint64(fakeInstanceId),
 		Name: proto.String(fakeInstanceName),
@@ -145,8 +147,10 @@ func getFakeInstance(includeNetwork bool) *computepb.Instance {
 	return instance
 }
 
-// Fake cluster
-func getFakeCluster(includeNetwork bool) *containerpb.Cluster {
+// Fake cluster.
+func getFakeCluster(
+	includeNetwork bool,
+) *containerpb.Cluster {
 	cluster := &containerpb.Cluster{
 		Name: fakeClusterName,
 		Id:   fakeClusterId,
@@ -166,9 +170,12 @@ func getFakeCluster(includeNetwork bool) *containerpb.Cluster {
 	return cluster
 }
 
-func getFakeAddress(isGlobal bool) *computepb.Address {
+func getFakeAddress(
+	isGlobal bool,
+) *computepb.Address {
 	addr := &computepb.Address{
-		Address: proto.String(fakeIpAddress)}
+		Address: proto.String(fakeIpAddress),
+	}
 	if isGlobal {
 		addr.SelfLink = proto.String(computeUrlPrefix + "projects/" + fakeProject + "/global/addresses/fakeAddress")
 	} else {
@@ -185,7 +192,9 @@ func getFakeForwardingRule() *computepb.ForwardingRule {
 	}
 }
 
-func sendResponse(w http.ResponseWriter, resp any) {
+func sendResponse(
+	w http.ResponseWriter, resp any,
+) {
 	b, err := json.Marshal(resp)
 	if err != nil {
 		http.Error(w, "unable to marshal request: "+err.Error(), http.StatusBadRequest)
@@ -197,15 +206,21 @@ func sendResponse(w http.ResponseWriter, resp any) {
 	}
 }
 
-func sendResponseFakeOperation(w http.ResponseWriter) {
+func sendResponseFakeOperation(
+	w http.ResponseWriter,
+) {
 	sendResponse(w, &computepb.Operation{Name: proto.String(fakeOperation)})
 }
 
-func sendResponseDoneOperation(w http.ResponseWriter) {
+func sendResponseDoneOperation(
+	w http.ResponseWriter,
+) {
 	sendResponse(w, &computepb.Operation{Status: computepb.Operation_DONE.Enum()})
 }
 
-func getFakeServerHandler(fakeServerState *fakeServerState) http.HandlerFunc {
+func getFakeServerHandler(
+	fakeServerState *fakeServerState,
+) http.HandlerFunc {
 	// The handler should be written as minimally as possible to minimize maintenance overhead. Modifying requests (e.g. POST, DELETE)
 	// should generally not do anything other than return the operation response. Instead, initialize the fakeServerState as necessary.
 	// Keep in mind these unit tests should rely as little as possible on the functionality of this fake server.
@@ -219,7 +234,7 @@ func getFakeServerHandler(fakeServerState *fakeServerState) http.HandlerFunc {
 		switch {
 		// Instances
 		case path == urlProject+urlZone+urlInstance+"/getEffectiveFirewalls":
-			if r.Method == "GET" {
+			if r.Method == http.MethodGet {
 				firewalls := make([]*computepb.Firewall, 0, len(fakeServerState.firewallMap))
 				for _, value := range fakeServerState.firewallMap {
 					firewalls = append(firewalls, value)
@@ -231,29 +246,30 @@ func getFakeServerHandler(fakeServerState *fakeServerState) http.HandlerFunc {
 				return
 			}
 		case path == urlProject+urlZone+urlInstance+"/setTags":
-			if r.Method == "POST" {
+			if r.Method == http.MethodPost {
 				sendResponseFakeOperation(w)
 				return
 			}
 		case path == urlProject+urlZone+urlInstance:
-			if r.Method == "GET" {
+			if r.Method == http.MethodGet {
 				sendResponse(w, fakeServerState.instance)
 				return
 			}
 		case path == urlProject+urlZone+"/instances":
-			if r.Method == "POST" {
+			if r.Method == http.MethodPost {
 				sendResponseFakeOperation(w)
 				return
 			}
 		// Firewalls
 		case strings.HasPrefix(path, urlProject+"/global/firewalls"):
-			if r.Method == "POST" {
+			switch r.Method {
+			case http.MethodPost:
 				sendResponseFakeOperation(w)
 				return
-			} else if r.Method == "DELETE" {
+			case http.MethodDelete:
 				sendResponseFakeOperation(w)
 				return
-			} else if r.Method == "PATCH" {
+			case http.MethodPatch:
 				req := &computepb.Firewall{}
 				err := json.Unmarshal(body, req)
 				if err != nil {
@@ -266,7 +282,7 @@ func getFakeServerHandler(fakeServerState *fakeServerState) http.HandlerFunc {
 				}
 				sendResponseFakeOperation(w)
 				return
-			} else if r.Method == "GET" {
+			case http.MethodGet:
 				firewalls := make([]*computepb.Firewall, 0, len(fakeServerState.firewallMap))
 				for _, value := range fakeServerState.firewallMap {
 					firewalls = append(firewalls, value)
@@ -277,61 +293,66 @@ func getFakeServerHandler(fakeServerState *fakeServerState) http.HandlerFunc {
 			}
 		// Networks
 		case strings.HasPrefix(path, urlProject+"/global/networks"):
-			if r.Method == "GET" {
+			switch r.Method {
+			case http.MethodGet:
 				if fakeServerState.network != nil {
 					sendResponse(w, fakeServerState.network)
 				} else {
 					http.Error(w, "no network found", http.StatusNotFound)
 				}
 				return
-			} else if r.Method == "POST" {
+			case http.MethodPost:
 				sendResponseFakeOperation(w)
 				return
 			}
 		case strings.HasPrefix(path, urlProject+urlRegion+"/subnetworks"):
-			if r.Method == "GET" {
+			switch r.Method {
+			case http.MethodGet:
 				if fakeServerState.subnetwork != nil {
 					sendResponse(w, fakeServerState.subnetwork)
 				} else {
 					http.Error(w, "no subnetwork found", http.StatusNotFound)
 				}
 				return
-			} else if r.Method == "POST" {
+			case http.MethodPost:
 				sendResponseFakeOperation(w)
 				return
 			}
 		// Addresses (Regional)
 		case strings.HasPrefix(path, urlProject+urlRegion+"/addresses"):
-			if r.Method == "GET" {
+			switch r.Method {
+			case http.MethodGet:
 				if fakeServerState.address != nil {
 					sendResponse(w, fakeServerState.address)
 				} else {
 					http.Error(w, "no address found", http.StatusNotFound)
 				}
 				return
-			} else if r.Method == "POST" {
+			case http.MethodPost:
 				sendResponseFakeOperation(w)
 				return
 			}
 		// Addresses (Global)
 		case strings.HasPrefix(path, urlProject+"/global/addresses"):
-			if r.Method == "GET" {
+			switch r.Method {
+			case http.MethodGet:
 				if fakeServerState.address != nil {
 					sendResponse(w, fakeServerState.address)
 				} else {
 					http.Error(w, "no address found", http.StatusNotFound)
 				}
 				return
-			} else if r.Method == "POST" {
+			case http.MethodPost:
 				sendResponseFakeOperation(w)
 				return
 			}
 		// Forwarding Rules (Regional)
 		case strings.HasPrefix(path, urlProject+urlRegion+"/forwardingRules"):
-			if r.Method == "POST" {
+			switch r.Method {
+			case http.MethodPost:
 				sendResponseFakeOperation(w)
 				return
-			} else if r.Method == "GET" {
+			case http.MethodGet:
 				if fakeServerState.forwardingRule != nil {
 					sendResponse(w, fakeServerState.forwardingRule)
 				} else {
@@ -341,10 +362,11 @@ func getFakeServerHandler(fakeServerState *fakeServerState) http.HandlerFunc {
 			}
 		// Forwarding Rules (Global)
 		case strings.HasPrefix(path, urlProject+"/global/forwardingRules"):
-			if r.Method == "POST" {
+			switch r.Method {
+			case http.MethodPost:
 				sendResponseFakeOperation(w)
 				return
-			} else if r.Method == "GET" {
+			case http.MethodGet:
 				if fakeServerState.forwardingRule != nil {
 					sendResponse(w, fakeServerState.forwardingRule)
 				} else {
@@ -354,35 +376,37 @@ func getFakeServerHandler(fakeServerState *fakeServerState) http.HandlerFunc {
 			}
 		// VPN Gateways
 		case strings.HasPrefix(path, urlProject+urlRegion+"/vpnGateways"):
-			if r.Method == "GET" {
+			switch r.Method {
+			case http.MethodGet:
 				if fakeServerState.vpnGateway != nil {
 					sendResponse(w, fakeServerState.vpnGateway)
 				} else {
 					http.Error(w, "no vpn gateway found", http.StatusNotFound)
 				}
 				return
-			} else if r.Method == "POST" {
+			case http.MethodPost:
 				sendResponseFakeOperation(w)
 				return
 			}
 		// External VPN Gateways
 		case strings.HasPrefix(path, urlProject+"/global/externalVpnGateways"):
-			if r.Method == "POST" {
+			if r.Method == http.MethodPost {
 				sendResponseFakeOperation(w)
 				return
 			}
 		// VPN Tunnels
 		case strings.HasPrefix(path, urlProject+urlRegion+"/vpnTunnels"):
-			if r.Method == "POST" {
+			if r.Method == http.MethodPost {
 				sendResponseFakeOperation(w)
 				return
 			}
 		// Routers
 		case strings.HasPrefix(path, urlProject+urlRegion+"/routers"):
-			if r.Method == "POST" || r.Method == "PATCH" {
+			switch r.Method {
+			case http.MethodPost, http.MethodPatch:
 				sendResponseFakeOperation(w)
 				return
-			} else if r.Method == "GET" {
+			case http.MethodGet:
 				if fakeServerState.router != nil {
 					sendResponse(w, fakeServerState.router)
 				} else {
@@ -392,17 +416,17 @@ func getFakeServerHandler(fakeServerState *fakeServerState) http.HandlerFunc {
 			}
 		// Operations
 		case path == urlProject+"/global/operations/"+fakeOperation:
-			if r.Method == "GET" {
+			if r.Method == http.MethodGet {
 				sendResponseDoneOperation(w)
 				return
 			}
 		case path == urlProject+"/regions/"+fakeRegion+"/operations/"+fakeOperation:
-			if r.Method == "GET" {
+			if r.Method == http.MethodGet {
 				sendResponseDoneOperation(w)
 				return
 			}
 		case path == urlProject+"/zones/"+fakeZone+"/operations/"+fakeOperation:
-			if r.Method == "GET" {
+			if r.Method == http.MethodGet {
 				sendResponseDoneOperation(w)
 				return
 			}
@@ -416,22 +440,28 @@ type fakeClusterManagerServer struct {
 	containerpb.UnimplementedClusterManagerServer
 }
 
-func (f *fakeClusterManagerServer) GetCluster(ctx context.Context, req *containerpb.GetClusterRequest) (*containerpb.Cluster, error) {
+func (f *fakeClusterManagerServer) GetCluster(
+	ctx context.Context, req *containerpb.GetClusterRequest,
+) (*containerpb.Cluster, error) {
 	if strings.Contains(req.Name, fakeClusterName) {
 		return getFakeCluster(true), nil
 	}
 	return nil, fmt.Errorf("cluster not found")
 }
 
-func (f *fakeClusterManagerServer) CreateCluster(ctx context.Context, req *containerpb.CreateClusterRequest) (*containerpb.Operation, error) {
+func (f *fakeClusterManagerServer) CreateCluster(
+	ctx context.Context, req *containerpb.CreateClusterRequest,
+) (*containerpb.Operation, error) {
 	return &containerpb.Operation{Name: fakeOperation}, nil
 }
 
-func (f *fakeClusterManagerServer) UpdateCluster(ctx context.Context, req *containerpb.UpdateClusterRequest) (*containerpb.Operation, error) {
+func (f *fakeClusterManagerServer) UpdateCluster(
+	ctx context.Context, req *containerpb.UpdateClusterRequest,
+) (*containerpb.Operation, error) {
 	return &containerpb.Operation{Name: fakeOperation}, nil
 }
 
-// Struct to hold state for fake server
+// Struct to hold state for fake server.
 type fakeServerState struct {
 	firewallMap    map[string]*computepb.Firewall
 	instance       *computepb.Instance
@@ -444,8 +474,10 @@ type fakeServerState struct {
 	forwardingRule *computepb.ForwardingRule
 }
 
-// Sets up fake http server and fake GCP compute clients
-func setup(t *testing.T, fakeServerState *fakeServerState) (fakeServer *httptest.Server, ctx context.Context, fakeClients *GCPClients, gsrv *grpc.Server) {
+// Sets up fake http server and fake GCP compute clients.
+func setup(
+	t *testing.T, fakeServerState *fakeServerState,
+) (fakeServer *httptest.Server, ctx context.Context, fakeClients *GCPClients, gsrv *grpc.Server) {
 	fakeServer = httptest.NewServer(getFakeServerHandler(fakeServerState))
 	fakeClients = &GCPClients{}
 
@@ -538,11 +570,13 @@ func setup(t *testing.T, fakeServerState *fakeServerState) (fakeServer *httptest
 		t.Fatal(err)
 	}
 
-	return
+	return fakeServer, ctx, fakeClients, gsrv
 }
 
-// Cleans up fake http server and fake GCP compute clients
-func teardown(fakeServer *httptest.Server, fakeClients *GCPClients, fakeGRPCServer *grpc.Server) {
+// Cleans up fake http server and fake GCP compute clients.
+func teardown(
+	fakeServer *httptest.Server, fakeClients *GCPClients, fakeGRPCServer *grpc.Server,
+) {
 	fakeServer.Close()
 	fakeClients.Close()
 	if fakeGRPCServer != nil {
@@ -550,17 +584,17 @@ func teardown(fakeServer *httptest.Server, fakeClients *GCPClients, fakeGRPCServ
 	}
 }
 
-// RunIcmpConnectivityTest runs a ICMP connectivity test from sourceInstanceName to destinationIpAddress
+// RunIcmpConnectivityTest runs a ICMP connectivity test from sourceInstanceName to destinationIpAddress.
 func RunIcmpConnectivityTest(testName string, namespace string, project string, sourceInstanceName string, sourceInstanceZone string, destinationIpAddress string, tries int) (bool, error) {
 	return runConnectivityTest(testName, namespace, project, sourceInstanceName, sourceInstanceZone, destinationIpAddress, 0, "ICMP", tries)
 }
 
-// RunTcpConnectivityTest runs a TCP connectivity test from sourceInstanceName to destinationIpAddress:destinationPort
+// RunTcpConnectivityTest runs a TCP connectivity test from sourceInstanceName to destinationIpAddress:destinationPort.
 func RunTcpConnectivityTest(testName string, namespace string, project string, sourceInstanceName string, sourceInstanceZone string, destinationIpAddress string, destinationPort int, tries int) (bool, error) {
 	return runConnectivityTest(testName, namespace, project, sourceInstanceName, sourceInstanceZone, destinationIpAddress, destinationPort, "TCP", tries)
 }
 
-// runConnectivityTest runs a connectivity test from sourceInstanceName to destinationIpAddress:destinationPort with the specified protocol
+// runConnectivityTest runs a connectivity test from sourceInstanceName to destinationIpAddress:destinationPort with the specified protocol.
 func runConnectivityTest(testName string, namespace string, project string, sourceInstanceName string, sourceInstanceZone string, destinationIpAddress string, destinationPort int, protocol string, tries int) (bool, error) {
 	ctx := context.Background()
 	reachabilityClient, err := networkmanagement.NewReachabilityClient(ctx) // Can't use REST client for some reason (filed as bug within Google internally)
@@ -619,7 +653,7 @@ func runConnectivityTest(testName string, namespace string, project string, sour
 	return false, nil
 }
 
-// Returns connectivity test ID
+// Returns connectivity test ID.
 func getConnectivityTestId(namespace string, name string) string {
 	return getParagliderNamespacePrefix(namespace) + "-" + name + "-connectivity-test"
 }

--- a/pkg/gcp/plugin_utils.go
+++ b/pkg/gcp/plugin_utils.go
@@ -220,12 +220,12 @@ func GetInstanceId(project string, zone string, instanceName string) (uint64, er
 	return *instance.Id, nil
 }
 
-// GCP naming conventions
+// GCP naming conventions.
 const (
 	paragliderPrefix = "para"
 )
 
-// Hashes values to lowercase hex string for use in naming GCP resources
+// Hashes values to lowercase hex string for use in naming GCP resources.
 func hash(values ...string) string {
 	hash := sha256.Sum256([]byte(strings.Join(values, "")))
 	return strings.ToLower(hex.EncodeToString(hash[:]))
@@ -263,14 +263,14 @@ func parseUrl(url string) map[string]string {
 	return parsedUrl
 }
 
-// Checks if GCP error response is a not found error
+// Checks if GCP error response is a not found error.
 func isErrorNotFound(err error) bool {
 	var e *googleapi.Error
 	ok := errors.As(err, &e)
 	return ok && e.Code == http.StatusNotFound
 }
 
-// Checks if GCP error response is a duplicate error
+// Checks if GCP error response is a duplicate error.
 func isErrorDuplicate(err error) bool {
 	var e *googleapi.Error
 	ok := errors.As(err, &e)

--- a/pkg/gcp/resources.go
+++ b/pkg/gcp/resources.go
@@ -70,17 +70,17 @@ func resourceIsInNamespace(network string, namespace string) bool {
 	return strings.HasSuffix(network, getVpcName(namespace))
 }
 
-// Gets a network tag for a resource
+// Gets a network tag for a resource.
 func getNetworkTag(namespace string, resourceType string, resourceId string) string {
 	return getParagliderNamespacePrefix(namespace) + "-" + resourceType + "-" + resourceId
 }
 
-// Get name for an IP address resource
+// Get name for an IP address resource.
 func getAddressName(resourceName string) string {
 	return paragliderPrefix + "-" + resourceName + "-address"
 }
 
-// Convert integer resource IDs to a string for naming
+// Convert integer resource IDs to a string for naming.
 func convertIntIdToString(id uint64) string {
 	stringId := strconv.FormatUint(id, 16)
 	if len(stringId) > 8 {
@@ -89,27 +89,27 @@ func convertIntIdToString(id uint64) string {
 	return stringId
 }
 
-// Shorten cluster IDs for use in associated resource names
+// Shorten cluster IDs for use in associated resource names.
 func shortenClusterId(clusterId string) string {
 	return clusterId[:8]
 }
 
-// Get a network tag for a cluster
+// Get a network tag for a cluster.
 func getClusterNodeTag(namespace string, clusterName string, clusterId string) string {
 	return getParagliderNamespacePrefix(namespace) + "-gke-" + clusterName + "-" + shortenClusterId(clusterId) + "-node"
 }
 
-// getInstanceUrl returns a fully qualified URL for an instance
+// getInstanceUrl returns a fully qualified URL for an instance.
 func getInstanceUrl(project, zone, instance string) string {
 	return computeUrlPrefix + fmt.Sprintf("projects/%s/zones/%s/instances/%s", project, zone, instance)
 }
 
-// getClusterUrl returns a fully qualified URL for a cluster
+// getClusterUrl returns a fully qualified URL for a cluster.
 func getClusterUrl(project, zone, cluster string) string {
 	return containerUrlPrefix + fmt.Sprintf("projects/%s/locations/%s/clusters/%s", project, zone, cluster)
 }
 
-// Get the firewall rules associated with a resource following the naming convention
+// Get the firewall rules associated with a resource following the naming convention.
 func getFirewallRules(ctx context.Context, project string, resourceID string, clients *GCPClients) ([]*computepb.Firewall, error) {
 	client, err := clients.GetOrCreateFirewallsClient(ctx)
 	if err != nil {
@@ -137,7 +137,7 @@ func getFirewallRules(ctx context.Context, project string, resourceID string, cl
 	return firewallRules, nil
 }
 
-// parseResourceUrl parses the resource URL and returns information about the resource (such as project, zone, name, and type)
+// parseResourceUrl parses the resource URL and returns information about the resource (such as project, zone, name, and type).
 func parseResourceUrl(resourceUrl string) (*resourceInfo, error) {
 	parsedResourceId := parseUrl(resourceUrl)
 	if name, ok := parsedResourceId["instances"]; ok {
@@ -150,16 +150,17 @@ func parseResourceUrl(resourceUrl string) (*resourceInfo, error) {
 	return nil, fmt.Errorf("unable to parse resource URL")
 }
 
-// Get the resource handler for a given resource type with necessary clients initialized if provided
+// Get the resource handler for a given resource type with necessary clients initialized if provided.
 func getResourceHandler(ctx context.Context, resourceType string, clients *GCPClients) (GCPResourceHandler, error) {
 	var handler GCPResourceHandler
-	if resourceType == instanceTypeName {
+	switch resourceType {
+	case instanceTypeName:
 		handler = &instanceHandler{}
-	} else if resourceType == clusterTypeName {
+	case clusterTypeName:
 		handler = &clusterHandler{}
-	} else if resourceType == privateServiceConnectTypeName {
+	case privateServiceConnectTypeName:
 		handler = &privateServiceHandler{}
-	} else {
+	default:
 		return nil, fmt.Errorf("unknown resource type")
 	}
 	if clients != nil {
@@ -172,7 +173,7 @@ func getResourceHandler(ctx context.Context, resourceType string, clients *GCPCl
 }
 
 // Get the resource handler for a given resource description
-// The handler will not have clients initialized
+// The handler will not have clients initialized.
 func getResourceHandlerFromDescription(resourceDesc []byte) (GCPResourceHandler, error) {
 	insertInstanceRequest := &computepb.InsertInstanceRequest{}
 	createClusterRequest := &containerpb.CreateClusterRequest{}
@@ -190,7 +191,7 @@ func getResourceHandlerFromDescription(resourceDesc []byte) (GCPResourceHandler,
 }
 
 // Gets network information about a resource and confirms it is in the correct namespace
-// Returns the subnet URL and resource ID (instance ID or cluster ID, not URL since this is used for firewall rule naming)
+// Returns the subnet URL and resource ID (instance ID or cluster ID, not URL since this is used for firewall rule naming).
 func GetResourceNetworkInfo(ctx context.Context, resourceInfo *resourceInfo, clients *GCPClients) (*resourceNetworkInfo, error) {
 	if resourceInfo.Namespace == "" {
 		return nil, fmt.Errorf("namespace is empty")
@@ -211,7 +212,7 @@ func GetResourceNetworkInfo(ctx context.Context, resourceInfo *resourceInfo, cli
 	return netInfo, nil
 }
 
-// Read parameters from within the resource description and ensure it is a valid resource
+// Read parameters from within the resource description and ensure it is a valid resource.
 func IsValidResource(ctx context.Context, resource *paragliderpb.CreateResourceRequest) (*resourceInfo, error) {
 	handler, err := getResourceHandlerFromDescription(resource.Description)
 	if err != nil {
@@ -224,7 +225,7 @@ func IsValidResource(ctx context.Context, resource *paragliderpb.CreateResourceR
 	return resourceInfo, nil
 }
 
-// Read the resource description and provision the resource
+// Read the resource description and provision the resource.
 func ReadAndProvisionResource(ctx context.Context, resource *paragliderpb.CreateResourceRequest, subnetName string, resourceInfo *resourceInfo, additionalAddrSpaces []string, clients *GCPClients) (string, string, error) {
 	handler, err := getResourceHandler(ctx, resourceInfo.ResourceType, clients)
 	if err != nil {
@@ -233,7 +234,7 @@ func ReadAndProvisionResource(ctx context.Context, resource *paragliderpb.Create
 	return handler.readAndProvisionResource(ctx, resource, subnetName, resourceInfo, additionalAddrSpaces)
 }
 
-// Get the type and value of the firewall target for a resource
+// Get the type and value of the firewall target for a resource.
 func GetFirewallTarget(ctx context.Context, resourceInfo *resourceInfo, netInfo *resourceNetworkInfo) (*firewallTarget, error) {
 	handler, err := getResourceHandler(ctx, resourceInfo.ResourceType, nil)
 	if err != nil {
@@ -243,7 +244,7 @@ func GetFirewallTarget(ctx context.Context, resourceInfo *resourceInfo, netInfo 
 	return &target, nil
 }
 
-// Interface to implement to support a resource
+// Interface to implement to support a resource.
 type GCPResourceHandler interface {
 	// Read and provision the resource with the provided subnet
 	readAndProvisionResource(ctx context.Context, resource *paragliderpb.CreateResourceRequest, subnetName string, resourceInfo *resourceInfo, additionalAddrSpaces []string) (string, string, error)
@@ -257,13 +258,13 @@ type GCPResourceHandler interface {
 	getFirewallTarget(resourceInfo *resourceInfo, netInfo *resourceNetworkInfo) firewallTarget
 }
 
-// GCP instance resource handler
+// GCP instance resource handler.
 type instanceHandler struct {
 	GCPResourceHandler
 	client *compute.InstancesClient
 }
 
-// Initialize necessary clients for the handler
+// Initialize necessary clients for the handler.
 func (r *instanceHandler) initClients(ctx context.Context, clients *GCPClients) error {
 	client, err := clients.GetOrCreateInstancesClient(ctx)
 	if err != nil {
@@ -273,7 +274,7 @@ func (r *instanceHandler) initClients(ctx context.Context, clients *GCPClients) 
 	return nil
 }
 
-// Get the resource information for an instance
+// Get the resource information for an instance.
 func (r *instanceHandler) getResourceInfo(ctx context.Context, resource *paragliderpb.CreateResourceRequest) (*resourceInfo, error) {
 	insertInstanceRequest := &computepb.InsertInstanceRequest{}
 	err := json.Unmarshal(resource.Description, insertInstanceRequest)
@@ -284,7 +285,7 @@ func (r *instanceHandler) getResourceInfo(ctx context.Context, resource *paragli
 	return &resourceInfo{Name: resource.Name, Region: region, Zone: insertInstanceRequest.Zone, NumAdditionalAddressSpaces: r.getNumberAddressSpacesRequired(), ResourceType: instanceTypeName}, nil
 }
 
-// Read and provision an instance
+// Read and provision an instance.
 func (r *instanceHandler) readAndProvisionResource(ctx context.Context, resource *paragliderpb.CreateResourceRequest, subnetName string, resourceInfo *resourceInfo, additionalAddrSpaces []string) (string, string, error) {
 	vm, err := r.fromResourceDecription(resource.Description)
 	if err != nil {
@@ -293,18 +294,18 @@ func (r *instanceHandler) readAndProvisionResource(ctx context.Context, resource
 	return r.createWithNetwork(ctx, vm, subnetName, resourceInfo)
 }
 
-// Get the subnet requirements for an instance
+// Get the subnet requirements for an instance.
 func (r *instanceHandler) getNumberAddressSpacesRequired() int {
 	return 0
 }
 
-// Get the firewall target type and value for a specific instance
+// Get the firewall target type and value for a specific instance.
 func (r *instanceHandler) getFirewallTarget(resourceInfo *resourceInfo, netInfo *resourceNetworkInfo) firewallTarget {
 	return firewallTarget{TargetType: targetTypeTag, Target: getNetworkTag(resourceInfo.Namespace, instanceTypeName, netInfo.ResourceID)}
 }
 
 // Get network information about an instance
-// Returns the network name, subnet URL, IP, and instance ID converted to a string for rule naming
+// Returns the network name, subnet URL, IP, and instance ID converted to a string for rule naming.
 func (r *instanceHandler) getNetworkInfo(ctx context.Context, resourceInfo *resourceInfo) (*resourceNetworkInfo, error) {
 	instanceRequest := &computepb.GetInstanceRequest{
 		Instance: resourceInfo.Name,
@@ -323,7 +324,7 @@ func (r *instanceHandler) getNetworkInfo(ctx context.Context, resourceInfo *reso
 }
 
 // Create an instance with given network settings
-// Returns the instance URL and instance IP
+// Returns the instance URL and instance IP.
 func (r *instanceHandler) createWithNetwork(ctx context.Context, instance *computepb.InsertInstanceRequest, subnetName string, resourceInfo *resourceInfo) (string, string, error) {
 	// Set project and name
 	instance.Project = resourceInfo.Project
@@ -383,7 +384,7 @@ func (r *instanceHandler) createWithNetwork(ctx context.Context, instance *compu
 	return getInstanceUrl(resourceInfo.Project, resourceInfo.Zone, instanceName), *getInstanceResp.NetworkInterfaces[0].NetworkIP, nil
 }
 
-// Parse the resource description and return the instance request
+// Parse the resource description and return the instance request.
 func (r *instanceHandler) fromResourceDecription(resourceDesc []byte) (*computepb.InsertInstanceRequest, error) {
 	insertInstanceRequest := &computepb.InsertInstanceRequest{}
 	err := json.Unmarshal(resourceDesc, insertInstanceRequest)
@@ -396,14 +397,14 @@ func (r *instanceHandler) fromResourceDecription(resourceDesc []byte) (*computep
 	return insertInstanceRequest, nil
 }
 
-// GCP cluster resource handler
+// GCP cluster resource handler.
 type clusterHandler struct {
 	GCPResourceHandler
 	client          *container.ClusterManagerClient
 	firewallsClient *compute.FirewallsClient
 }
 
-// Initialize necessary clients for the handler
+// Initialize necessary clients for the handler.
 func (r *clusterHandler) initClients(ctx context.Context, clients *GCPClients) error {
 	client, err := clients.GetOrCreateClustersClient(ctx)
 	if err != nil {
@@ -420,7 +421,7 @@ func (r *clusterHandler) initClients(ctx context.Context, clients *GCPClients) e
 	return nil
 }
 
-// Read and provision a cluster
+// Read and provision a cluster.
 func (r *clusterHandler) readAndProvisionResource(ctx context.Context, resource *paragliderpb.CreateResourceRequest, subnetName string, resourceInfo *resourceInfo, additionalAddrSpaces []string) (string, string, error) {
 	gke, err := r.fromResourceDecription(resource.Description)
 	if err != nil {
@@ -429,7 +430,7 @@ func (r *clusterHandler) readAndProvisionResource(ctx context.Context, resource 
 	return r.createWithNetwork(ctx, gke, subnetName, resourceInfo, additionalAddrSpaces)
 }
 
-// Get the resource information for a cluster
+// Get the resource information for a cluster.
 func (r *clusterHandler) getResourceInfo(ctx context.Context, resource *paragliderpb.CreateResourceRequest) (*resourceInfo, error) {
 	createClusterRequest := &containerpb.CreateClusterRequest{}
 	err := json.Unmarshal(resource.Description, createClusterRequest)
@@ -441,18 +442,18 @@ func (r *clusterHandler) getResourceInfo(ctx context.Context, resource *paraglid
 	return &resourceInfo{Name: resource.Name, Region: region, Zone: zone, NumAdditionalAddressSpaces: r.getNumberAddressSpacesRequired(), ResourceType: clusterTypeName}, nil
 }
 
-// Get the subnet requirements for a cluster
+// Get the subnet requirements for a cluster.
 func (r *clusterHandler) getNumberAddressSpacesRequired() int {
 	return 3
 }
 
-// Get the firewall target type and value for a specific cluster
+// Get the firewall target type and value for a specific cluster.
 func (r *clusterHandler) getFirewallTarget(resourceInfo *resourceInfo, netInfo *resourceNetworkInfo) firewallTarget {
 	return firewallTarget{TargetType: targetTypeTag, Target: getNetworkTag(resourceInfo.Namespace, clusterTypeName, netInfo.ResourceID)}
 }
 
 // Get network information about a cluster
-// Returns the network name, subnet URL, and resource ID (cluster ID, not URL since this is used for firewall rule naming)
+// Returns the network name, subnet URL, and resource ID (cluster ID, not URL since this is used for firewall rule naming).
 func (r *clusterHandler) getNetworkInfo(ctx context.Context, resourceInfo *resourceInfo) (*resourceNetworkInfo, error) {
 	clusterRequest := &containerpb.GetClusterRequest{
 		Name: fmt.Sprintf(clusterNameFormat, resourceInfo.Project, resourceInfo.Zone, resourceInfo.Name),
@@ -465,7 +466,7 @@ func (r *clusterHandler) getNetworkInfo(ctx context.Context, resourceInfo *resou
 }
 
 // Create a cluster with given network settings
-// Returns the cluster URL and cluster CIDR
+// Returns the cluster URL and cluster CIDR.
 func (r *clusterHandler) createWithNetwork(ctx context.Context, cluster *containerpb.CreateClusterRequest, subnetName string, resourceInfo *resourceInfo, additionalAddrSpaces []string) (string, string, error) {
 	// Set project and name
 	cluster.Parent = fmt.Sprintf("projects/%s/locations/%s", resourceInfo.Project, resourceInfo.Zone)
@@ -559,7 +560,7 @@ func (r *clusterHandler) createWithNetwork(ctx context.Context, cluster *contain
 	return getClusterUrl(resourceInfo.Project, resourceInfo.Zone, getClusterResp.Name), getClusterResp.ClusterIpv4Cidr, nil
 }
 
-// Parse the resource description and return the cluster request
+// Parse the resource description and return the cluster request.
 func (r *clusterHandler) fromResourceDecription(resourceDesc []byte) (*containerpb.CreateClusterRequest, error) {
 	createClusterRequest := &containerpb.CreateClusterRequest{}
 	err := json.Unmarshal(resourceDesc, createClusterRequest)
@@ -580,7 +581,7 @@ func (r *clusterHandler) fromResourceDecription(resourceDesc []byte) (*container
 	return createClusterRequest, nil
 }
 
-// GCP private service connect
+// GCP private service connect.
 type privateServiceHandler struct {
 	GCPResourceHandler
 	addressesClient        *compute.AddressesClient
@@ -590,7 +591,7 @@ type privateServiceHandler struct {
 	attachmentsClient      *compute.ServiceAttachmentsClient
 }
 
-// Initialize necessary clients for the handler
+// Initialize necessary clients for the handler.
 func (r *privateServiceHandler) initClients(ctx context.Context, clients *GCPClients) error {
 	addressesClient, err := clients.GetOrCreateAddressesClient(ctx)
 	if err != nil {
@@ -625,7 +626,7 @@ func (r *privateServiceHandler) initClients(ctx context.Context, clients *GCPCli
 	return nil
 }
 
-// Read and provision a private service connect endpoint to associate with a service attachment
+// Read and provision a private service connect endpoint to associate with a service attachment.
 func (r *privateServiceHandler) readAndProvisionResource(ctx context.Context, resource *paragliderpb.CreateResourceRequest, subnetName string, resourceInfo *resourceInfo, additionalAddrSpaces []string) (string, string, error) {
 	description := &ServiceAttachmentDescription{}
 	err := json.Unmarshal(resource.Description, description)
@@ -638,7 +639,7 @@ func (r *privateServiceHandler) readAndProvisionResource(ctx context.Context, re
 	return r.createWithNetwork(ctx, *description, subnetName, resourceInfo, additionalAddrSpaces[0])
 }
 
-// Get the resource information about a service attachment
+// Get the resource information about a service attachment.
 func (r *privateServiceHandler) getResourceInfo(ctx context.Context, resource *paragliderpb.CreateResourceRequest) (*resourceInfo, error) {
 	description := &ServiceAttachmentDescription{}
 	err := json.Unmarshal(resource.Description, description)
@@ -662,7 +663,7 @@ func (r *privateServiceHandler) getResourceInfo(ctx context.Context, resource *p
 	return &resourceInfo{Region: region, NumAdditionalAddressSpaces: r.getNumberAddressSpacesRequired(description), ResourceType: privateServiceConnectTypeName, Name: resource.Name}, nil
 }
 
-// Get the subnet requirements for a private service connect attachment
+// Get the subnet requirements for a private service connect attachment.
 func (r *privateServiceHandler) getNumberAddressSpacesRequired(description *ServiceAttachmentDescription) int {
 	if description.Bundle != "" {
 		return 1
@@ -671,13 +672,13 @@ func (r *privateServiceHandler) getNumberAddressSpacesRequired(description *Serv
 	return 0
 }
 
-// Get the firewall target type and value for a specific service attachment
+// Get the firewall target type and value for a specific service attachment.
 func (r *privateServiceHandler) getFirewallTarget(resourceInfo *resourceInfo, netInfo *resourceNetworkInfo) firewallTarget {
 	return firewallTarget{TargetType: targetTypeAddress, Target: netInfo.Address}
 }
 
 // Get network information about a service attachment
-// Returns the network name, resource ID (service attachment ID, not URL since this is used for firewall rule naming), and IP address
+// Returns the network name, resource ID (service attachment ID, not URL since this is used for firewall rule naming), and IP address.
 func (r *privateServiceHandler) getNetworkInfo(ctx context.Context, resourceInfo *resourceInfo) (*resourceNetworkInfo, error) {
 	var ruleId string
 	var address string
@@ -730,7 +731,7 @@ func (r *privateServiceHandler) getNetworkInfo(ctx context.Context, resourceInfo
 	return &resourceNetworkInfo{NetworkName: getVpcName(resourceInfo.Namespace), ResourceID: ruleId, Address: address}, nil
 }
 
-// Create a private service connect endpoint with given network settings
+// Create a private service connect endpoint with given network settings.
 func (r *privateServiceHandler) createWithNetwork(ctx context.Context, service ServiceAttachmentDescription, subnetName string, resourceInfo *resourceInfo, additionalAddress string) (string, string, error) {
 	// Reserve an IP address to be the endpoint
 	addressName := getAddressName(resourceInfo.Name)

--- a/pkg/gcp/resources_test.go
+++ b/pkg/gcp/resources_test.go
@@ -329,7 +329,6 @@ func TestInstanceCreateWithNetwork(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, url, *instanceRequest.InstanceResource.Name)
 	assert.Equal(t, ip, *getFakeInstance(true).NetworkInterfaces[0].NetworkIP)
-
 }
 
 func TestClusterReadAndProvisionResource(t *testing.T) {

--- a/pkg/gcp/vpn.go
+++ b/pkg/gcp/vpn.go
@@ -25,7 +25,7 @@ const (
 	ikeVersion = 2
 )
 
-// TODO @seankimkdy: replace these in the future to be not hardcoded
+// TODO @seankimkdy: replace these in the future to be not hardcoded.
 var vpnRegion = "us-west1" // Must be var as this is changed during unit tests
 
 func getVpnGwName(namespace string) string {
@@ -36,47 +36,47 @@ func getRouterName(namespace string) string {
 	return getParagliderNamespacePrefix(namespace) + "-router"
 }
 
-// Returns a peer gateway name when connecting to another cloud
+// Returns a peer gateway name when connecting to another cloud.
 func getPeerGwName(namespace string, cloud string) string {
 	return getParagliderNamespacePrefix(namespace) + "-" + cloud + "-peer-gw"
 }
 
-// Returns a VPN tunnel name when connecting to another cloud
+// Returns a VPN tunnel name when connecting to another cloud.
 func getVpnTunnelName(namespace string, cloud string, tunnelIdx int) string {
 	return getParagliderNamespacePrefix(namespace) + "-" + cloud + "-tunnel-" + strconv.Itoa(tunnelIdx)
 }
 
-// Returns a VPN tunnel interface name when connecting to another cloud
+// Returns a VPN tunnel interface name when connecting to another cloud.
 func getVpnTunnelInterfaceName(namespace string, cloud string, tunnelIdx int, interfaceIdx int) string {
 	return getVpnTunnelName(namespace, cloud, tunnelIdx) + "-int-" + strconv.Itoa(interfaceIdx)
 }
 
-// Returns a BGP peer name
+// Returns a BGP peer name.
 func getBgpPeerName(cloud string, peerIdx int) string {
 	return cloud + "-bgp-peer-" + strconv.Itoa(peerIdx)
 }
 
-// getNatName returns a NAT name
+// getNatName returns a NAT name.
 func getNatName(namespace string) string {
 	return getParagliderNamespacePrefix(namespace) + "-nat"
 }
 
-// getVpnGatewayUrl returns a fully qualified URL for a VPN Gateway
+// getVpnGatewayUrl returns a fully qualified URL for a VPN Gateway.
 func getVpnGatewayUrl(project, region, vpnGatewayName string) string {
 	return computeUrlPrefix + fmt.Sprintf("projects/%s/regions/%s/vpnGateways/%s", project, region, vpnGatewayName)
 }
 
-// getRouterUrl returns a fully qualified URL for a router
+// getRouterUrl returns a fully qualified URL for a router.
 func getRouterUrl(project, region, routerName string) string {
 	return computeUrlPrefix + fmt.Sprintf("projects/%s/regions/%s/routers/%s", project, region, routerName)
 }
 
-// getVpnTunnelUrl returns a fully qualified URL for a VPN Tunnel
+// getVpnTunnelUrl returns a fully qualified URL for a VPN Tunnel.
 func getVpnTunnelUrl(project, region, vpnTunnelName string) string {
 	return computeUrlPrefix + fmt.Sprintf("projects/%s/regions/%s/vpnTunnels/%s", project, region, vpnTunnelName)
 }
 
-// getPeerGatewayUrl returns a fully qualified URL for a peer gateway
+// getPeerGatewayUrl returns a fully qualified URL for a peer gateway.
 func getPeerGatewayUrl(project, peerGatewayName string) string {
 	return computeUrlPrefix + fmt.Sprintf("projects/%s/global/externalVpnGateways/%s", project, peerGatewayName)
 }

--- a/pkg/ibm/auth.go
+++ b/pkg/ibm/auth.go
@@ -67,7 +67,6 @@ func (c *CloudClient) setupAuth() (string, error) {
 			utils.Log.Println("Failed to register SSH key\n", err)
 			return "", err
 		}
-
 	} else {
 		keyID = *result.ID
 	}
@@ -97,7 +96,7 @@ func (c *CloudClient) getKeyByPublicKey(publicKeyData string) (string, error) {
 			 key was found`)
 }
 
-// GetAPIKey returns API KEY ID defined in environment variable
+// GetAPIKey returns API KEY ID defined in environment variable.
 func getAPIKey() (string, error) {
 	apiKey := os.Getenv("PARAGLIDER_IBM_API_KEY")
 	if apiKey == "" {
@@ -106,7 +105,7 @@ func getAPIKey() (string, error) {
 	return apiKey, nil
 }
 
-// returns a user authenticator object to authorize IBM cloud services
+// returns a user authenticator object to authorize IBM cloud services.
 func getAuthenticator() (*core.IamAuthenticator, error) {
 	apiKey, err := getAPIKey()
 	if err != nil {
@@ -126,13 +125,13 @@ func getLocalPubKey() (string, error) {
 	}
 
 	pubKeyPath := filepath.Join(homeDir, publicSSHKey)
-	err = os.MkdirAll(filepath.Dir(filepath.Join(homeDir, publicSSHKey)), 0700)
+	err = os.MkdirAll(filepath.Dir(filepath.Join(homeDir, publicSSHKey)), 0o700)
 	if err != nil {
 		utils.Log.Println("Failed to create ssh key folder\n", err)
 		return "", err
 	}
 
-	//check if ssh keys exist
+	// check if ssh keys exist
 	_, err = os.Stat(pubKeyPath)
 
 	if err != nil {
@@ -170,11 +169,11 @@ func createSSHKeys(privateKeyPath string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	privateKeyFile, err := os.OpenFile(privateKeyPath, os.O_RDWR|os.O_CREATE, 0600)
+	privateKeyFile, err := os.OpenFile(privateKeyPath, os.O_RDWR|os.O_CREATE, 0o600)
 	if err != nil {
 		return "", err
 	}
-	defer privateKeyFile.Close()
+	defer func() { _ = privateKeyFile.Close() }()
 	privateKeyPEM := &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(privateKey)}
 	if err := pem.Encode(privateKeyFile, privateKeyPEM); err != nil {
 		return "", err
@@ -187,11 +186,11 @@ func createSSHKeys(privateKeyPath string) (string, error) {
 	}
 	pubKeyStr := strings.TrimSpace(string(ssh.MarshalAuthorizedKey(publicRsaKey)))
 
-	publicKeyFile, err := os.OpenFile(privateKeyPath+".pub", os.O_RDWR|os.O_CREATE, 0655)
+	publicKeyFile, err := os.OpenFile(privateKeyPath+".pub", os.O_RDWR|os.O_CREATE, 0o655)
 	if err != nil {
 		return "", err
 	}
-	defer publicKeyFile.Close()
+	defer func() { _ = publicKeyFile.Close() }()
 	_, err = publicKeyFile.WriteString(pubKeyStr)
 	if err != nil {
 		return "", err

--- a/pkg/ibm/plugin.go
+++ b/pkg/ibm/plugin.go
@@ -43,7 +43,7 @@ type IBMPluginServer struct {
 var defaultRegion = "us-east"
 
 // setupCloudClient fetches the cloud client for a resgroup and region from the map if cached, or creates a new one.
-// This function should be the only way the IBM plugin server to get a client
+// This function should be the only way the IBM plugin server to get a client.
 func (s *IBMPluginServer) setupCloudClient(resourceGroupID, region string) (*CloudClient, error) {
 	clientKey := getClientMapKey(resourceGroupID, region)
 	if client, ok := s.cloudClient[clientKey]; ok {
@@ -58,7 +58,7 @@ func (s *IBMPluginServer) setupCloudClient(resourceGroupID, region string) (*Clo
 	return client, nil
 }
 
-// getAllClientsForVPCs returns the paraglider VPC IDs and the corresponding clients that are present in all the regions
+// getAllClientsForVPCs returns the paraglider VPC IDs and the corresponding clients that are present in all the regions.
 func (s *IBMPluginServer) getAllClientsForVPCs(cloudClient *CloudClient, resourceGroupName string) (map[string]*CloudClient, error) {
 	cloudClients := make(map[string]*CloudClient)
 	vpcsData, err := cloudClient.GetParagliderTaggedResources(VPC, []string{}, resourceQuery{})
@@ -113,9 +113,9 @@ func (s *IBMPluginServer) CreateResource(c context.Context, resourceDesc *paragl
 	}
 
 	if res.GetTypeName() == ClusterResourceType && !s.flags.KubernetesClustersEnabled {
-		return nil, fmt.Errorf("Kubernetes clusters are disabled")
+		return nil, fmt.Errorf("kubernetes clusters are disabled")
 	} else if res.GetTypeName() == PrivateEndpointResourceType && !s.flags.PrivateEndpointsEnabled {
-		return nil, fmt.Errorf("Private endpoints are disabled")
+		return nil, fmt.Errorf("private endpoints are disabled")
 	}
 
 	// get VPCs in the request's namespace which can be shared between resources created
@@ -158,7 +158,7 @@ func (s *IBMPluginServer) CreateResource(c context.Context, resourceDesc *paragl
 		if err != nil {
 			return nil, err
 		}
-		defer conn.Close()
+		defer func() { _ = conn.Close() }()
 		client := paragliderpb.NewControllerClient(conn)
 		resp, err := client.FindUnusedAddressSpaces(context.Background(), &paragliderpb.FindUnusedAddressSpacesRequest{Sizes: []int32{0}})
 		if err != nil {
@@ -276,12 +276,12 @@ func (s *IBMPluginServer) GetPermitList(ctx context.Context, req *paragliderpb.G
 	if err != nil {
 		return nil, err
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 	client := paragliderpb.NewControllerClient(conn)
 
 	// Get the permitlist names from the rule ID
 	for _, rule := range paragliderRules {
-		//IBM rule ID is transiently stored in rule name during translation
+		// IBM rule ID is transiently stored in rule name during translation
 		ruleName, err := getRuleValFromStore(ctx, client, rule.Name, req.Namespace)
 		if err != nil {
 			utils.Log.Printf("Failed to get value from KVstore for rule %s: %v.", ruleName, err)
@@ -294,7 +294,6 @@ func (s *IBMPluginServer) GetPermitList(ctx context.Context, req *paragliderpb.G
 
 // AddPermitListRules attaches security group rules to the specified resource in PermitList.AssociatedResource.
 func (s *IBMPluginServer) AddPermitListRules(ctx context.Context, req *paragliderpb.AddPermitListRulesRequest) (*paragliderpb.AddPermitListRulesResponse, error) {
-
 	utils.Log.Printf("Adding PermitListRules %v, %v. namespace :%s \n ", req.Resource, req.Rules, req.Namespace)
 	rInfo, err := getResourceMeta(req.Resource)
 	if err != nil {
@@ -359,7 +358,7 @@ func (s *IBMPluginServer) AddPermitListRules(ctx context.Context, req *paraglide
 	if err != nil {
 		return nil, fmt.Errorf("unable to establish connection with orchestrator: %w", err)
 	}
-	defer orchestratorConn.Close()
+	defer func() { _ = orchestratorConn.Close() }()
 	controllerClient := paragliderpb.NewControllerClient(orchestratorConn)
 	addressSpaceMappings, err := controllerClient.GetUsedAddressSpaces(context.Background(), &emptypb.Empty{})
 	if err != nil {
@@ -391,7 +390,7 @@ func (s *IBMPluginServer) AddPermitListRules(ctx context.Context, req *paraglide
 				}
 				err = s.connectToPublicGateway(cloudClient, rInfo.ResourceGroup, *requestVPCData.ID, rInfo.Zone, region, subnets)
 				if err != nil {
-					return nil, fmt.Errorf("unable to connect to public gateway: %v", err)
+					return nil, fmt.Errorf("unable to connect to public gateway: %w", err)
 				}
 			} else if peeringCloudInfo.Cloud != utils.IBM {
 				ruleTargetAddress := ibmRules[i].Remote
@@ -405,7 +404,7 @@ func (s *IBMPluginServer) AddPermitListRules(ctx context.Context, req *paraglide
 					AddressSpacesCloudB: []string{ruleTargetAddress},
 				}
 				if len(ruleTargetAddress) == 0 {
-					return nil, fmt.Errorf("Missing remote address for rule %+v", ibmRules[i])
+					return nil, fmt.Errorf("missing remote address for rule %+v", ibmRules[i])
 				}
 				_, err := controllerClient.ConnectClouds(ctx, connectCloudsReq)
 				if err != nil {
@@ -458,7 +457,7 @@ func (s *IBMPluginServer) AddPermitListRules(ctx context.Context, req *paraglide
 					utils.Log.Printf("Error occurred while deleting SG rule %v, after failing to retrieve it from the KV store: %+v", ruleID, err)
 					return nil, err
 				}
-				return nil, fmt.Errorf("failed to get from kv store %v", err)
+				return nil, fmt.Errorf("failed to get from kv store %w", err)
 			}
 
 			if oldRuleID != "" {
@@ -478,7 +477,7 @@ func (s *IBMPluginServer) AddPermitListRules(ctx context.Context, req *paraglide
 				if err != nil {
 					return nil, err
 				}
-				return nil, fmt.Errorf("failed to set kv store: %v", err)
+				return nil, fmt.Errorf("failed to set kv store: %w", err)
 			}
 			// Store the reverse representation to be used to retrieve permitlist name for getpermitlist requests
 			err = setRuleValToStore(ctx, controllerClient, ruleID, ibmRule.ID, req.Namespace)
@@ -488,7 +487,7 @@ func (s *IBMPluginServer) AddPermitListRules(ctx context.Context, req *paraglide
 				if err != nil {
 					return nil, err
 				}
-				return nil, fmt.Errorf("failed to set kv store: %v", err)
+				return nil, fmt.Errorf("failed to set kv store: %w", err)
 			}
 		}
 	}
@@ -552,9 +551,8 @@ func (s *IBMPluginServer) connectToPublicGateway(cloudClient *CloudClient, resou
 }
 
 // connects the VPC matching the specified vpcCRN, and the remote VPC containing the address space in the specified ibmRule,
-// to the global transit gateway, if such a VPC exists
+// to the global transit gateway, if such a VPC exists.
 func (s *IBMPluginServer) connectToTransitGatewayIfNeeded(cloudClient *CloudClient, ibmRule SecurityGroupRule, gwID, resourceGroup, vpcCRN, region string) error {
-
 	// get the VPCs and clients to search if the remote IP resides in any of them
 	clients, err := s.getAllClientsForVPCs(cloudClient, resourceGroup)
 	if err != nil {
@@ -605,7 +603,7 @@ func (s *IBMPluginServer) connectToTransitGatewayIfNeeded(cloudClient *CloudClie
 	return nil
 }
 
-// DeletePermitListRules deletes security group rules matching the attributes of the rules contained in the relevant Security group
+// DeletePermitListRules deletes security group rules matching the attributes of the rules contained in the relevant Security group.
 func (s *IBMPluginServer) DeletePermitListRules(ctx context.Context, req *paragliderpb.DeletePermitListRulesRequest) (*paragliderpb.DeletePermitListRulesResponse, error) {
 	rInfo, err := getResourceMeta(req.Resource)
 	if err != nil {
@@ -646,13 +644,13 @@ func (s *IBMPluginServer) DeletePermitListRules(ctx context.Context, req *paragl
 	if err != nil {
 		return nil, err
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 	client := paragliderpb.NewControllerClient(conn)
 
 	for _, ruleName := range req.RuleNames {
 		ruleID, err := getRuleValFromStore(ctx, client, ruleName, req.Namespace)
 		if err != nil && !strings.Contains(err.Error(), string(redis.Nil)) {
-			return nil, fmt.Errorf("failed to get from kv store %v", err)
+			return nil, fmt.Errorf("failed to get from kv store %w", err)
 		}
 		if ruleID == "" {
 			utils.Log.Printf("Rule %s not found in KVstore.", ruleName)
@@ -691,7 +689,7 @@ func (s *IBMPluginServer) CreateVpnGateway(ctx context.Context, req *paragliderp
 		return nil, err
 	}
 	if region == "" {
-		return nil, fmt.Errorf("Failed to find a region containing address space %v", req.AddressSpace)
+		return nil, fmt.Errorf("failed to find a region containing address space %v", req.AddressSpace)
 	}
 	cloudClient, err := s.setupCloudClient(rInfo.ResourceGroup, region)
 	if err != nil {
@@ -705,7 +703,7 @@ func (s *IBMPluginServer) CreateVpnGateway(ctx context.Context, req *paragliderp
 	return &paragliderpb.CreateVpnGatewayResponse{GatewayIpAddresses: ipAddresses}, nil
 }
 
-// returns the region of the VPC containing the specified address space
+// returns the region of the VPC containing the specified address space.
 func (s *IBMPluginServer) getRegionOfAddressSpace(resourceGroup, namespace, addressSpace string) (string, error) {
 	client, err := s.setupCloudClient(resourceGroup, defaultRegion)
 	if err != nil {
@@ -735,10 +733,10 @@ func (s *IBMPluginServer) getRegionOfAddressSpace(resourceGroup, namespace, addr
 	return "", nil
 }
 
-// CreateVpnConnections creates VPN connection
+// CreateVpnConnections creates VPN connection.
 func (s *IBMPluginServer) CreateVpnConnections(ctx context.Context, req *paragliderpb.CreateVpnConnectionsRequest) (*paragliderpb.CreateVpnConnectionsResponse, error) {
 	if len(req.RemoteAddresses) == 0 {
-		return nil, fmt.Errorf("RemoteAddress is a mandatory field for IBM VPN connections.")
+		return nil, fmt.Errorf("remoteAddress is a mandatory field for IBM VPN connections")
 	}
 	rInfo, err := getResourceMeta(req.Deployment.Id)
 	if err != nil {
@@ -752,7 +750,7 @@ func (s *IBMPluginServer) CreateVpnConnections(ctx context.Context, req *paragli
 		return nil, err
 	}
 	if region == "" {
-		return nil, fmt.Errorf("Failed to find a region containing address space %v", req.AddressSpace)
+		return nil, fmt.Errorf("failed to find a region containing address space %v", req.AddressSpace)
 	}
 	cloudClient, err := s.setupCloudClient(rInfo.ResourceGroup, region)
 	if err != nil {
@@ -769,7 +767,7 @@ func (s *IBMPluginServer) CreateVpnConnections(ctx context.Context, req *paragli
 	// needless to check [vpn instances>1] case, since GetVPNInNamespaceRegion is filtered by region,
 	// 		and implementation guarantees one VPN per namespace and region.
 	if len(vpns) == 0 {
-		return nil, fmt.Errorf("No vpn found in namespace %v and region %v", req.Deployment.Namespace, region)
+		return nil, fmt.Errorf("no vpn found in namespace %v and region %v", req.Deployment.Namespace, region)
 	}
 	vpn := vpns[0]
 
@@ -785,17 +783,17 @@ func (s *IBMPluginServer) CreateVpnConnections(ctx context.Context, req *paragli
 	return &paragliderpb.CreateVpnConnectionsResponse{}, nil
 }
 
-// GetUsedBgpPeeringIpAddresses will return empty response since IBM doesn't currently support BGP peering
+// GetUsedBgpPeeringIpAddresses will return empty response since IBM doesn't currently support BGP peering.
 func (s *IBMPluginServer) GetUsedBgpPeeringIpAddresses(ctx context.Context, req *paragliderpb.GetUsedBgpPeeringIpAddressesRequest) (*paragliderpb.GetUsedBgpPeeringIpAddressesResponse, error) {
 	return &paragliderpb.GetUsedBgpPeeringIpAddressesResponse{}, nil
 }
 
-// GetUsedAsns returns an empty response, since ASNs aren't exposed on IBM cloud
+// GetUsedAsns returns an empty response, since ASNs aren't exposed on IBM cloud.
 func (s *IBMPluginServer) GetUsedAsns(ctx context.Context, req *paragliderpb.GetUsedAsnsRequest) (*paragliderpb.GetUsedAsnsResponse, error) {
 	return &paragliderpb.GetUsedAsnsResponse{}, nil
 }
 
-// GetResourceSubnetsAddress returns the subnets addresses of the VPC containing the specified address space
+// GetResourceSubnetsAddress returns the subnets addresses of the VPC containing the specified address space.
 func (s *IBMPluginServer) GetNetworkAddressSpaces(ctx context.Context, req *paragliderpb.GetNetworkAddressSpacesRequest) (*paragliderpb.GetNetworkAddressSpacesResponse, error) {
 	rInfo, err := getResourceMeta(req.Deployment.Id)
 	if err != nil {

--- a/pkg/ibm/plugin_test.go
+++ b/pkg/ibm/plugin_test.go
@@ -645,8 +645,10 @@ func TestSetFlags(t *testing.T) {
 		flags: &paragliderpb.PluginFlags{PrivateEndpointsEnabled: false, KubernetesClustersEnabled: false},
 	}
 	resp, err := s.SetFlags(context.Background(),
-		&paragliderpb.SetFlagsRequest{Flags: &paragliderpb.PluginFlags{PrivateEndpointsEnabled: true,
-			KubernetesClustersEnabled: true}})
+		&paragliderpb.SetFlagsRequest{Flags: &paragliderpb.PluginFlags{
+			PrivateEndpointsEnabled:   true,
+			KubernetesClustersEnabled: true,
+		}})
 
 	require.NoError(t, err)
 	require.NotNil(t, resp)
@@ -929,7 +931,8 @@ func TestGetUsedAddressSpaces(t *testing.T) {
 	s := &IBMPluginServer{
 		cloudClient: map[string]*CloudClient{
 			getClientMapKey(fakeID, fakeRegion): fakeClient,
-		}}
+		},
+	}
 
 	deployment := &paragliderpb.GetUsedAddressSpacesRequest{
 		Deployments: []*paragliderpb.ParagliderDeployment{
@@ -959,7 +962,8 @@ func TestGetUsedAddressSpacesMultipleVPC(t *testing.T) {
 		cloudClient: map[string]*CloudClient{
 			getClientMapKey(fakeID, fakeRegion):    fakeClient,
 			getClientMapKey(fakeID, fakeConRegion): fakeClient,
-		}}
+		},
+	}
 
 	deployment := &paragliderpb.GetUsedAddressSpacesRequest{
 		Deployments: []*paragliderpb.ParagliderDeployment{
@@ -1146,6 +1150,7 @@ func TestAddPermitListRulesWrongNamespace(t *testing.T) {
 	require.Error(t, err)
 	require.Nil(t, resp)
 }
+
 func TestAddPermitListRulesTransitGateway(t *testing.T) {
 	fakeControllerServer, fakeControllerServerAddr, err := fake.SetupFakeOrchestratorRPCServer(utils.IBM)
 	if err != nil {
@@ -1352,6 +1357,7 @@ func TestDeletePermitListRulesWrongNamespace(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 }
+
 func TestGetPermitList(t *testing.T) {
 	store := map[string]string{
 		kvstore.GetFullKey(fakeID, utils.IBM, fakeNamespace):  fakePermitListVPC[0].Name,

--- a/pkg/ibm/resource.go
+++ b/pkg/ibm/resource.go
@@ -30,25 +30,25 @@ import (
 )
 
 const (
-	// InstanceResourceType is an instance type of resource
+	// InstanceResourceType is an instance type of resource.
 	InstanceResourceType = "instance"
 	instanceReadyState   = "running"
 
-	// ClusterResourceType is a cluster type of resource
+	// ClusterResourceType is a cluster type of resource.
 	ClusterResourceType = "cluster"
 	ClusterReadyState   = "normal"
 
-	// PrivateEndpointType is a private endpoint gateway type of resource
+	// PrivateEndpointType is a private endpoint gateway type of resource.
 	PrivateEndpointResourceType = "endpoint"
 	endpointReadyState          = "stable"
 
-	// ClusterReadyState is the ideal running state of a cluster
+	// ClusterReadyState is the ideal running state of a cluster.
 	clusterType = "vpc-gen2"
 	defaultZone = "us-east-1"
 	ipResType   = "ip"
 )
 
-// ResourceResponse contains the required resource fields to be returned after creation of a resource
+// ResourceResponse contains the required resource fields to be returned after creation of a resource.
 type ResourceResponse struct {
 	// Name is the resource name
 	Name string
@@ -69,21 +69,21 @@ type ResourceIntf interface {
 	GetTypeName() string
 }
 
-// ResourceInstanceType is the handler for instance type resources
+// ResourceInstanceType is the handler for instance type resources.
 type ResourceInstanceType struct {
 	ResourceIntf
 	ID     string
 	client *CloudClient
 }
 
-// ResourceClusterType is the handler for cluster type resources
+// ResourceClusterType is the handler for cluster type resources.
 type ResourceClusterType struct {
 	ResourceIntf
 	ID     string
 	client *CloudClient
 }
 
-// ResourcePrivateEndpointType is the handler for private endpoint resources
+// ResourcePrivateEndpointType is the handler for private endpoint resources.
 type ResourcePrivateEndpointType struct {
 	ResourceIntf
 	ID     string
@@ -152,7 +152,7 @@ func (i *ResourceInstanceType) GetTypeName() string {
 	return InstanceResourceType
 }
 
-// CreateResource create an instance
+// CreateResource create an instance.
 func (i *ResourceInstanceType) CreateResource(name, vpcID, subnetID string, tags []string, resourceDesc []byte) (*ResourceResponse, error) {
 	instanceOptions, err := i.getResourceOptions(resourceDesc)
 	if err != nil {
@@ -172,7 +172,8 @@ func (i *ResourceInstanceType) CreateResource(name, vpcID, subnetID string, tags
 	}
 
 	sgGrps := []vpcv1.SecurityGroupIdentityIntf{
-		&vpcv1.SecurityGroupIdentityByID{ID: securityGroup.ID}}
+		&vpcv1.SecurityGroupIdentityByID{ID: securityGroup.ID},
+	}
 
 	subnetIdentity := vpcv1.SubnetIdentityByID{ID: &subnetID}
 
@@ -210,7 +211,6 @@ func (i *ResourceInstanceType) CreateResource(name, vpcID, subnetID string, tags
 	}
 
 	reservedIP, err := i.getInstanceIP()
-
 	if err != nil {
 		return nil, err
 	}
@@ -221,7 +221,7 @@ func (i *ResourceInstanceType) CreateResource(name, vpcID, subnetID string, tags
 }
 
 // IsInNamespace returns True if an instance resides inside the specified namespace
-// region is an optional argument used to increase effectiveness of resource search
+// region is an optional argument used to increase effectiveness of resource search.
 func (i *ResourceInstanceType) IsInNamespace(namespace, region string) (bool, error) {
 	resourceQuery := resourceQuery{}
 	vmData, err := i.getCRN()
@@ -250,17 +250,17 @@ func (i *ResourceInstanceType) IsInNamespace(namespace, region string) (bool, er
 	return false, nil
 }
 
-// IsExclusiveNetworkNeeded indicates if this resource needs an exclusive VPC to be provisioned
+// IsExclusiveNetworkNeeded indicates if this resource needs an exclusive VPC to be provisioned.
 func (i *ResourceInstanceType) IsExclusiveNetworkNeeded() bool {
 	return false
 }
 
-// GetID fetches the identifier of instance
+// GetID fetches the identifier of instance.
 func (i *ResourceInstanceType) GetID() string {
 	return i.ID
 }
 
-// GetSecurityGroupID returns the security group ID that's associated with the instance's network interfaces
+// GetSecurityGroupID returns the security group ID that's associated with the instance's network interfaces.
 func (i *ResourceInstanceType) GetSecurityGroupID() (string, error) {
 	nics, _, err := i.client.vpcService.ListInstanceNetworkInterfaces(
 		&vpcv1.ListInstanceNetworkInterfacesOptions{InstanceID: &i.ID})
@@ -278,7 +278,7 @@ func (i *ResourceInstanceType) GetSecurityGroupID() (string, error) {
 	return "", fmt.Errorf("no paraglider SG is associated with the specified instance")
 }
 
-// GetVPC returns VPC data of specified instance
+// GetVPC returns VPC data of specified instance.
 func (i *ResourceInstanceType) GetVPC() (*vpcv1.VPCReference, error) {
 	instance, _, err := i.client.vpcService.GetInstance(
 		&vpcv1.GetInstanceOptions{ID: &i.ID})
@@ -334,7 +334,7 @@ func (i *ResourceClusterType) GetTypeName() string {
 	return ClusterResourceType
 }
 
-// CreateResource creates a cluster
+// CreateResource creates a cluster.
 func (c *ResourceClusterType) CreateResource(name, vpcID, subnetID string, tags []string, resourceDesc []byte) (*ResourceResponse, error) {
 	clusterOptions, err := c.getResourceOptions(resourceDesc)
 	if err != nil {
@@ -397,7 +397,7 @@ func (c *ResourceClusterType) CreateResource(name, vpcID, subnetID string, tags 
 	return &ResourceResponse{Name: name, URI: c.createURI(*c.client.resourceGroup.ID, *clusterOptions.WorkerPool.Zones[0].ID, *cluster.ClusterID), IP: clusterCIDR}, nil
 }
 
-// IsInNamespace checks if the cluster is in the namespace
+// IsInNamespace checks if the cluster is in the namespace.
 func (c *ResourceClusterType) IsInNamespace(namespace, region string) (bool, error) {
 	resourceQuery := resourceQuery{}
 	clusterCRN, err := c.getCRN()
@@ -426,17 +426,17 @@ func (c *ResourceClusterType) IsInNamespace(namespace, region string) (bool, err
 	return false, nil
 }
 
-// IsExclusiveNetworkNeeded indicates if this resource needs an exclusive VPC to be provisioned
+// IsExclusiveNetworkNeeded indicates if this resource needs an exclusive VPC to be provisioned.
 func (c *ResourceClusterType) IsExclusiveNetworkNeeded() bool {
 	return true
 }
 
-// GetID fetches the identifier of instance
+// GetID fetches the identifier of instance.
 func (c *ResourceClusterType) GetID() string {
 	return c.ID
 }
 
-// GetVPC returns the VPC reference of the endpoint gateway of the cluster
+// GetVPC returns the VPC reference of the endpoint gateway of the cluster.
 func (c *ResourceClusterType) GetVPC() (*vpcv1.VPCReference, error) {
 	// A Cluster would have a security group with prefix of 'kube-',
 	// We infer the VPC of the cluster using the VPC of this security group
@@ -513,7 +513,7 @@ func (i *ResourcePrivateEndpointType) GetTypeName() string {
 	return PrivateEndpointResourceType
 }
 
-// CreateResource create a private endpoint (VPE)
+// CreateResource create a private endpoint (VPE).
 func (e *ResourcePrivateEndpointType) CreateResource(name, vpcID, subnetID string, tags []string, resourceDesc []byte) (*ResourceResponse, error) {
 	endpointGatewayOptions, err := e.getResourceOptions(resourceDesc)
 	if err != nil {
@@ -530,7 +530,8 @@ func (e *ResourcePrivateEndpointType) CreateResource(name, vpcID, subnetID strin
 	endpointGatewayOptions.VPC = &vpcv1.VPCIdentityByID{ID: &vpcID}
 	endpointGatewayOptions.ResourceGroup = e.client.resourceGroup
 	endpointGatewayOptions.SecurityGroups = []vpcv1.SecurityGroupIdentityIntf{
-		&vpcv1.SecurityGroupIdentityByID{ID: securityGroup.ID}}
+		&vpcv1.SecurityGroupIdentityByID{ID: securityGroup.ID},
+	}
 
 	ipName := generateResourceName(ipResType)
 
@@ -542,7 +543,8 @@ func (e *ResourcePrivateEndpointType) CreateResource(name, vpcID, subnetID strin
 	}
 	utils.Log.Printf("Created IP %s with id %s\n", ipName, *resIP.ID)
 	endpointGatewayOptions.Ips = []vpcv1.EndpointGatewayReservedIPIntf{
-		&vpcv1.EndpointGatewayReservedIPReservedIPIdentity{ID: resIP.ID}}
+		&vpcv1.EndpointGatewayReservedIPReservedIPIdentity{ID: resIP.ID},
+	}
 
 	utils.Log.Printf("Creating private endpoint : %+v", endpointGatewayOptions.Target)
 
@@ -583,7 +585,7 @@ func (e *ResourcePrivateEndpointType) CreateResource(name, vpcID, subnetID strin
 	return &resp, nil
 }
 
-// IsInNamespace checks if the private endpoint is in the namespace
+// IsInNamespace checks if the private endpoint is in the namespace.
 func (e *ResourcePrivateEndpointType) IsInNamespace(namespace, region string) (bool, error) {
 	resourceQuery := resourceQuery{}
 	endpointCRN, err := e.getCRN()
@@ -612,17 +614,17 @@ func (e *ResourcePrivateEndpointType) IsInNamespace(namespace, region string) (b
 	return false, nil
 }
 
-// IsExclusiveNetworkNeeded indicates if this resource needs an exclusive VPC to be provisioned
+// IsExclusiveNetworkNeeded indicates if this resource needs an exclusive VPC to be provisioned.
 func (e *ResourcePrivateEndpointType) IsExclusiveNetworkNeeded() bool {
 	return false
 }
 
-// GetID fetches the identifier of instance
+// GetID fetches the identifier of instance.
 func (e *ResourcePrivateEndpointType) GetID() string {
 	return e.ID
 }
 
-// GetSecurityGroupID returns the security group ID that's associated with the instance's network interfaces
+// GetSecurityGroupID returns the security group ID that's associated with the instance's network interfaces.
 func (e *ResourcePrivateEndpointType) GetSecurityGroupID() (string, error) {
 	res, _, err := e.client.vpcService.GetEndpointGateway(e.client.vpcService.NewGetEndpointGatewayOptions(e.ID))
 	if err != nil {
@@ -637,7 +639,7 @@ func (e *ResourcePrivateEndpointType) GetSecurityGroupID() (string, error) {
 	return "", fmt.Errorf("no paraglider SG is associated with the specified VPE")
 }
 
-// GetVPC returns VPC data of specified instance
+// GetVPC returns VPC data of specified instance.
 func (e *ResourcePrivateEndpointType) GetVPC() (*vpcv1.VPCReference, error) {
 	res, _, err := e.client.vpcService.GetEndpointGateway(e.client.vpcService.NewGetEndpointGatewayOptions(e.ID))
 	if err != nil {
@@ -649,7 +651,7 @@ func (e *ResourcePrivateEndpointType) GetVPC() (*vpcv1.VPCReference, error) {
 
 // NOTE: Currently not in use, as public ips are not provisioned.
 // deletes floating ips marked recyclable, that are attached to
-// any interface associated with given VM
+// any interface associated with given VM.
 func (c *CloudClient) deleteFloatingIPsOfVM(vm *vpcv1.Instance) {
 	recyclableResource := "recyclable" // placeholder indicator
 
@@ -684,7 +686,7 @@ func (c *CloudClient) waitForInstanceRemoval(vmID string) bool {
 	return false
 }
 
-// GetResourceHandlerFromDesc gets the resource handler from the resource description
+// GetResourceHandlerFromDesc gets the resource handler from the resource description.
 func (c *CloudClient) GetResourceHandlerFromDesc(resourceDesc []byte) (ResourceIntf, error) {
 	instanceOptions := vpcv1.CreateInstanceOptions{
 		InstancePrototype: &vpcv1.InstancePrototypeInstanceByImage{
@@ -715,11 +717,10 @@ func (c *CloudClient) GetResourceHandlerFromDesc(resourceDesc []byte) (ResourceI
 		return &ResourcePrivateEndpointType{client: c}, nil
 	}
 
-	return nil, fmt.Errorf("failed to unmarshal resource description:%+v", err)
-
+	return nil, fmt.Errorf("failed to unmarshal resource description:%+w", err)
 }
 
-// GetResourceHandlerFromID gets the resource handler from the resource ID/URI
+// GetResourceHandlerFromID gets the resource handler from the resource ID/URI.
 func (c *CloudClient) GetResourceHandlerFromID(deploymentID string) (ResourceIntf, error) {
 	parts := strings.Split(deploymentID, "/")
 

--- a/pkg/ibm/sdk_handler.go
+++ b/pkg/ibm/sdk_handler.go
@@ -29,7 +29,7 @@ import (
 	utils "github.com/paraglider-project/paraglider/pkg/utils"
 )
 
-// CloudClient is the client used to interact with IBM Cloud SDK
+// CloudClient is the client used to interact with IBM Cloud SDK.
 type CloudClient struct {
 	vpcService     *vpcv1.VpcV1
 	k8sService     *k8sv1.KubernetesServiceApiV1
@@ -44,7 +44,7 @@ func (c *CloudClient) Region() string {
 	return c.region
 }
 
-// updates the vpc service's url service to the specified region
+// updates the vpc service's url service to the specified region.
 func (c *CloudClient) UpdateRegion(region string) error {
 	c.region = region
 	err := c.vpcService.SetServiceURL(endpointURL(region))
@@ -95,7 +95,6 @@ func NewIBMCloudClient(resourceGroupID, region string) (*CloudClient, error) {
 	taggingService, err := globaltaggingv1.NewGlobalTaggingV1(&globaltaggingv1.GlobalTaggingV1Options{
 		Authenticator: authenticator,
 	})
-
 	if err != nil {
 		utils.Log.Println("Failed to create tagging client with error:\n", err)
 		return nil, err
@@ -125,7 +124,7 @@ func NewIBMCloudClient(resourceGroupID, region string) (*CloudClient, error) {
 	return &client, nil
 }
 
-// FakeIBMCloudClient returns a fake/mock CloudClient instance without auth, that needs to be handled in the URL
+// FakeIBMCloudClient returns a fake/mock CloudClient instance without auth, that needs to be handled in the URL.
 func FakeIBMCloudClient(fakeURL, fakeResGroupID, fakeRegion string) (*CloudClient, error) {
 	noAuth, err := core.NewNoAuthAuthenticator()
 	if err != nil {
@@ -189,7 +188,7 @@ func FakeIBMCloudClient(fakeURL, fakeResGroupID, fakeRegion string) (*CloudClien
 	return &client, nil
 }
 
-// GetZonesOfRegion returns zones of specified region
+// GetZonesOfRegion returns zones of specified region.
 func (c CloudClient) GetZonesOfRegion(region string) ([]string, error) {
 	zones := []string{}
 	zoneCollection, _, err := c.vpcService.ListRegionZones(&vpcv1.ListRegionZonesOptions{RegionName: core.StringPtr(region)})

--- a/pkg/ibm/security_group.go
+++ b/pkg/ibm/security_group.go
@@ -39,7 +39,7 @@ const (
 	outboundType = "outbound"
 )
 
-// SecurityGroupRule defines the entries of a security group rule
+// SecurityGroupRule defines the entries of a security group rule.
 type SecurityGroupRule struct {
 	ID         string // Unique identifier of this rule
 	SgID       string // Unique ID of the security group to which this rule belongs
@@ -53,19 +53,19 @@ type SecurityGroupRule struct {
 	Egress     bool   // The rule affects to outbound traffic (true) or inbound (false)
 }
 
-// mapping paraglider traffic directions to booleans
+// mapping paraglider traffic directions to booleans.
 var paragliderToIBMDirection = map[paragliderpb.Direction]bool{
 	paragliderpb.Direction_OUTBOUND: true,
 	paragliderpb.Direction_INBOUND:  false,
 }
 
-// mapping booleans paraglider traffic directions
+// mapping booleans paraglider traffic directions.
 var ibmToParagliderDirection = map[bool]paragliderpb.Direction{
 	true:  paragliderpb.Direction_OUTBOUND,
 	false: paragliderpb.Direction_INBOUND,
 }
 
-// mapping integers determined by the IANA standard to IBM protocols
+// mapping integers determined by the IANA standard to IBM protocols.
 var paragliderToIBMprotocol = map[int32]string{
 	-1: "all",
 	1:  "icmp",
@@ -73,7 +73,7 @@ var paragliderToIBMprotocol = map[int32]string{
 	17: "udp",
 }
 
-// mapping IBM protocols to integers determined by the IANA standard
+// mapping IBM protocols to integers determined by the IANA standard.
 var ibmToParagliderProtocol = map[string]int32{
 	"all":  -1,
 	"icmp": 1,
@@ -83,7 +83,8 @@ var ibmToParagliderProtocol = map[string]int32{
 
 // creates security group in the specified VPC and tags it.
 func (c *CloudClient) createSecurityGroup(
-	vpcID string) (*vpcv1.SecurityGroup, error) {
+	vpcID string,
+) (*vpcv1.SecurityGroup, error) {
 	sgTags := []string{vpcID}
 
 	vpcIdentity := vpcv1.VPCIdentityByID{ID: &vpcID}
@@ -116,7 +117,7 @@ func (c *CloudClient) getDefaultSecurityGroup(vpcID string) (*vpcv1.DefaultSecur
 	return vpc, nil
 }
 
-// GetSecurityRulesOfSG gets the rules of security groups
+// GetSecurityRulesOfSG gets the rules of security groups.
 func (c *CloudClient) GetSecurityRulesOfSG(sgID string) ([]SecurityGroupRule, error) {
 	options := &vpcv1.ListSecurityGroupRulesOptions{}
 	options.SetSecurityGroupID(sgID)
@@ -127,10 +128,10 @@ func (c *CloudClient) GetSecurityRulesOfSG(sgID string) ([]SecurityGroupRule, er
 	return c.translateSecurityGroupRules(rules.Rules, sgID)
 }
 
-// returns SecurityGroupRule objects, converted from abstract rules
+// returns SecurityGroupRule objects, converted from abstract rules.
 func (c *CloudClient) translateSecurityGroupRules(
-	ibmRules []vpcv1.SecurityGroupRuleIntf, sgID string) ([]SecurityGroupRule, error) {
-
+	ibmRules []vpcv1.SecurityGroupRuleIntf, sgID string,
+) ([]SecurityGroupRule, error) {
 	rules := make([]SecurityGroupRule, len(ibmRules))
 	for i, ibmRule := range ibmRules {
 		rule, err := c.translateSecurityGroupRule(ibmRule, sgID)
@@ -143,9 +144,10 @@ func (c *CloudClient) translateSecurityGroupRules(
 	return rules, nil
 }
 
-// translateSecurityGroupRule returns a SecurityGroupRule converted from vpcv1.SecurityGroupRuleIntf based on its concrete type
+// translateSecurityGroupRule returns a SecurityGroupRule converted from vpcv1.SecurityGroupRuleIntf based on its concrete type.
 func (c *CloudClient) translateSecurityGroupRule(
-	ibmRule vpcv1.SecurityGroupRuleIntf, sgID string) (*SecurityGroupRule, error) {
+	ibmRule vpcv1.SecurityGroupRuleIntf, sgID string,
+) (*SecurityGroupRule, error) {
 	switch ibmRule.(type) {
 	case *vpcv1.SecurityGroupRuleSecurityGroupRuleProtocolAll:
 		return c.translateSecurityGroupRuleGroupRuleProtocolAll(ibmRule, sgID)
@@ -158,10 +160,10 @@ func (c *CloudClient) translateSecurityGroupRule(
 }
 
 // translateSecurityGroupRuleGroupRuleProtocolAll returns SecurityGroupRule object converted from
-// SecurityGroupRuleIntf, whose concrete type is SecurityGroupRuleSecurityGroupRuleProtocolAll
+// SecurityGroupRuleIntf, whose concrete type is SecurityGroupRuleSecurityGroupRuleProtocolAll.
 func (c *CloudClient) translateSecurityGroupRuleGroupRuleProtocolAll(
-	ibmRule vpcv1.SecurityGroupRuleIntf, sgID string) (*SecurityGroupRule, error) {
-
+	ibmRule vpcv1.SecurityGroupRuleIntf, sgID string,
+) (*SecurityGroupRule, error) {
 	ibmRuleProtoAll := ibmRule.(*vpcv1.SecurityGroupRuleSecurityGroupRuleProtocolAll)
 	remote, remoteType, err := c.translateSecurityGroupRuleRemote(ibmRuleProtoAll.Remote)
 	if err != nil {
@@ -182,19 +184,17 @@ func (c *CloudClient) translateSecurityGroupRuleGroupRuleProtocolAll(
 }
 
 // translateSecurityGroupRuleGroupRuleProtocolICMP returns SecurityGroupRule object converted from
-// SecurityGroupRuleIntf, whose concrete type is SecurityGroupRuleSecurityGroupRuleProtocolIcmp
+// SecurityGroupRuleIntf, whose concrete type is SecurityGroupRuleSecurityGroupRuleProtocolIcmp.
 func (c *CloudClient) translateSecurityGroupRuleGroupRuleProtocolICMP(
-	ibmRule vpcv1.SecurityGroupRuleIntf, sgID string) (*SecurityGroupRule, error) {
-
+	ibmRule vpcv1.SecurityGroupRuleIntf, sgID string,
+) (*SecurityGroupRule, error) {
 	ibmRuleIcmp := ibmRule.(*vpcv1.SecurityGroupRuleSecurityGroupRuleProtocolIcmp)
 	remote, remoteType, err := c.translateSecurityGroupRuleRemote(ibmRuleIcmp.Remote)
 	if err != nil {
 		return nil, err
 	}
-	isEgress := false
-	if *ibmRuleIcmp.Direction == outboundType {
-		isEgress = true
-	}
+	isEgress := *ibmRuleIcmp.Direction == outboundType
+
 	icmpCode := int64(-1)
 	if ibmRuleIcmp.Code != nil { // rule allows specific icmp code
 		icmpCode = *ibmRuleIcmp.Code
@@ -221,19 +221,17 @@ func (c *CloudClient) translateSecurityGroupRuleGroupRuleProtocolICMP(
 }
 
 // translateSecurityGroupRuleGroupRuleProtocolTCPUDP returns SecurityGroupRule object converted from
-// SecurityGroupRuleIntf, whose concrete type is SecurityGroupRuleSecurityGroupRuleProtocolTcpudp
+// SecurityGroupRuleIntf, whose concrete type is SecurityGroupRuleSecurityGroupRuleProtocolTcpudp.
 func (c *CloudClient) translateSecurityGroupRuleGroupRuleProtocolTCPUDP(
-	ibmRule vpcv1.SecurityGroupRuleIntf, sgID string) (*SecurityGroupRule, error) {
-
+	ibmRule vpcv1.SecurityGroupRuleIntf, sgID string,
+) (*SecurityGroupRule, error) {
 	ibmRuleTCPUDP := ibmRule.(*vpcv1.SecurityGroupRuleSecurityGroupRuleProtocolTcpudp)
 	remote, remoteType, err := c.translateSecurityGroupRuleRemote(ibmRuleTCPUDP.Remote)
 	if err != nil {
 		return nil, err
 	}
-	isEgress := false
-	if *ibmRuleTCPUDP.Direction == "outbound" {
-		isEgress = true
-	}
+	isEgress := *ibmRuleTCPUDP.Direction == "outbound"
+
 	rule := SecurityGroupRule{
 		ID:         *ibmRuleTCPUDP.ID,
 		Protocol:   *ibmRuleTCPUDP.Protocol,
@@ -250,10 +248,10 @@ func (c *CloudClient) translateSecurityGroupRuleGroupRuleProtocolTCPUDP(
 	return &rule, nil
 }
 
-// returns remote(IP/CIDR address) and remote-type(IP/CIDR) of an abstract rule
+// returns remote(IP/CIDR address) and remote-type(IP/CIDR) of an abstract rule.
 func (c *CloudClient) translateSecurityGroupRuleRemote(
-	ibmRuleRemoteIntf vpcv1.SecurityGroupRuleRemoteIntf) (string, string, error) {
-
+	ibmRuleRemoteIntf vpcv1.SecurityGroupRuleRemoteIntf,
+) (string, string, error) {
 	switch v := ibmRuleRemoteIntf.(type) {
 	// According to the docs, the interface should map to a specific type,
 	// but in this case it seems to just map to a generic "remote" where pointers may be nil
@@ -292,7 +290,6 @@ func (c *CloudClient) AddSecurityGroupRule(rule SecurityGroupRule) (string, erro
 }
 
 func (c *CloudClient) addSecurityGroupRule(sgID string, prototype vpcv1.SecurityGroupRulePrototypeIntf) (string, error) {
-
 	options := vpcv1.CreateSecurityGroupRuleOptions{
 		SecurityGroupID:            &sgID,
 		SecurityGroupRulePrototype: prototype,
@@ -304,7 +301,7 @@ func (c *CloudClient) addSecurityGroupRule(sgID string, prototype vpcv1.Security
 	return c.getIBMRuleID(res), err
 }
 
-// returns an IBM abstract rule object, converted from a SecurityGroupRule
+// returns an IBM abstract rule object, converted from a SecurityGroupRule.
 func (c *CloudClient) translateRuleProtocol(rule SecurityGroupRule) (vpcv1.SecurityGroupRulePrototypeIntf, error) {
 	var remotePrototype vpcv1.SecurityGroupRuleRemotePrototypeIntf
 	if len(rule.Remote) == 0 {
@@ -362,7 +359,7 @@ func (c *CloudClient) translateRuleProtocol(rule SecurityGroupRule) (vpcv1.Secur
 	return prototype, nil
 }
 
-// Adds rule represented by the SecurityGroupRule object to its security group
+// Adds rule represented by the SecurityGroupRule object to its security group.
 func (c *CloudClient) UpdateSecurityGroupRule(rule SecurityGroupRule) error {
 	prototype, err := c.translateRuleProtocol(rule)
 	if err != nil {
@@ -381,7 +378,6 @@ func (c *CloudClient) UpdateSecurityGroupRule(rule SecurityGroupRule) error {
 }
 
 func (c *CloudClient) updateSecurityGroupRule(sgID string, ruleID string, patch map[string]interface{}) error {
-
 	options := vpcv1.UpdateSecurityGroupRuleOptions{
 		SecurityGroupID:        &sgID,
 		ID:                     &ruleID,
@@ -391,7 +387,7 @@ func (c *CloudClient) updateSecurityGroupRule(sgID string, ruleID string, patch 
 	return err
 }
 
-// DeleteSecurityGroupRule deletes a rule from the security group
+// DeleteSecurityGroupRule deletes a rule from the security group.
 func (c *CloudClient) DeleteSecurityGroupRule(sgID, ruleID string) error {
 	options := vpcv1.DeleteSecurityGroupRuleOptions{
 		SecurityGroupID: &sgID,
@@ -423,7 +419,7 @@ func IsRemoteInCIDR(remote, cidr string) (bool, error) {
 }
 
 // GetRemoteType returns IBM specific keyword returned by vpc1 SDK,
-// indicating the type of remote an SG rule permits
+// indicating the type of remote an SG rule permits.
 func GetRemoteType(remote string) (string, error) {
 	ip := net.ParseIP(remote)
 	if ip != nil {
@@ -437,7 +433,7 @@ func GetRemoteType(remote string) (string, error) {
 }
 
 // returns IBM specific keyword returned by vpc1 SDK,
-// indicating the traffic direction an SG rule permits
+// indicating the traffic direction an SG rule permits.
 func getEgressDirection(egress bool) *string {
 	if egress {
 		return core.StringPtr(outboundType)
@@ -520,15 +516,15 @@ func IBMToParagliderRules(rules []SecurityGroupRule) ([]*paragliderpb.PermitList
 			Protocol:  ibmToParagliderProtocol[rule.Protocol],
 		}
 		paragliderRules = append(paragliderRules, permitListRule)
-
 	}
 	return paragliderRules, nil
 }
 
 // returns IBM SecurityGroupRule, converted from specified paraglider rule
-// NOTE: with the current PermitListRule we can't translate ICMP rules with specific type or code
+// NOTE: with the current PermitListRule we can't translate ICMP rules with specific type or code.
 func ParagliderToIBMRules(securityGroupID string, rules []*paragliderpb.PermitListRule) (
-	[]SecurityGroupRule, error) {
+	[]SecurityGroupRule, error,
+) {
 	var sgRules []SecurityGroupRule
 	for _, rule := range rules {
 		if len(rule.Targets) == 0 {
@@ -565,10 +561,10 @@ func ParagliderToIBMRules(securityGroupID string, rules []*paragliderpb.PermitLi
 }
 
 // returns rules in IBM cloud format to paraglider format
-// NOTE: with the current PermitListRule we can't translate ICMP rules with specific type or code
+// NOTE: with the current PermitListRule we can't translate ICMP rules with specific type or code.
 func ParagliderToIBMRule(securityGroupID string, pgRule *paragliderpb.PermitListRule) (
-	[]SecurityGroupRule, error) {
-
+	[]SecurityGroupRule, error,
+) {
 	if len(pgRule.Targets) == 0 {
 		return nil, fmt.Errorf("PermitListRule is missing target value. Rule:%+v", pgRule)
 	}

--- a/pkg/ibm/subnets.go
+++ b/pkg/ibm/subnets.go
@@ -28,7 +28,8 @@ const subnetType = "subnet"
 
 // CreateSubnet creates subnet in specified vpc and zone.
 func (c *CloudClient) CreateSubnet(
-	vpcID, zone, addressSpace string, tags []string) (*vpcv1.Subnet, error) {
+	vpcID, zone, addressSpace string, tags []string,
+) (*vpcv1.Subnet, error) {
 	zone = strings.TrimSpace(zone)
 
 	zoneIdentity := vpcv1.ZoneIdentity{Name: &zone}
@@ -127,7 +128,8 @@ func (c *CloudClient) IsRemoteInVPC(vpcID string, remote string) (bool, error) {
 // returns true if any of the specified vpc's subnets' address spaces overlap with given cidr
 // NOTE: before invoking this function Set VPC client to the region the VPC is located in.
 func (c *CloudClient) DoSubnetsInVPCOverlapCIDR(vpcID string,
-	CIDR string) (bool, error) {
+	CIDR string,
+) (bool, error) {
 	subnets, err := c.GetSubnetsInVpcRegionBound(vpcID)
 	if err != nil {
 		return true, err

--- a/pkg/ibm/tagging.go
+++ b/pkg/ibm/tagging.go
@@ -67,7 +67,7 @@ func (c *CloudClient) attachTag(CRN *string, tags []string) error {
 	return fmt.Errorf("failed to tag resource CRN %v", *CRN)
 }
 
-// areTagsAttached returns an error if resource's tags aren't updated (visible to global search service) in the alloted time
+// areTagsAttached returns an error if resource's tags aren't updated (visible to global search service) in the alloted time.
 func (c *CloudClient) areTagsAttached(CRN *string, tags []string) error {
 	maxAttempts := 30 // retries number to tag a resource
 
@@ -94,7 +94,7 @@ func (c *CloudClient) areTagsAttached(CRN *string, tags []string) error {
 // GetParagliderTaggedResources returns slice of IDs of tagged resources
 // Arg resourceType: type of VPC resource, e.g. subnet, security group, instance.
 // Arg tags: labels set by dev, e.g. {<vpcID>,<deploymentID>}
-// Args customQueryMap: map of attributes to filter by, e.g. {"region":"<regionName>"}
+// Args customQueryMap: map of attributes to filter by, e.g. {"region":"<regionName>"}.
 func (c *CloudClient) GetParagliderTaggedResources(resourceType taggedResourceType, tags []string, customQuery resourceQuery) ([]resourceData, error) {
 	// parse tags
 	var tagsStr string
@@ -129,7 +129,7 @@ func (c *CloudClient) GetParagliderTaggedResources(resourceType taggedResourceTy
 	return resourceList, nil
 }
 
-// returns IDs of resources filtered by tags and query
+// returns IDs of resources filtered by tags and query.
 func (c *CloudClient) getParagliderResourceByTags(resourceType string, tags string, customQueryStr string) ([]resourceData, error) {
 	var taggedResources []resourceData
 
@@ -192,5 +192,5 @@ func (c *CloudClient) getTaggedResources(query string) (*globalsearchv2.ScanResu
 		time.Sleep(5 * time.Second)
 	}
 	utils.Log.Printf("Failed to fetch tagged resource with with query %v", query)
-	return nil, fmt.Errorf("Failed to fetch tagged resource")
+	return nil, fmt.Errorf("failed to fetch tagged resource")
 }

--- a/pkg/ibm/transit_gateway.go
+++ b/pkg/ibm/transit_gateway.go
@@ -38,13 +38,14 @@ const (
 )
 
 // creates a global transit gateway (global routing) at the specified region and
-// tags it with the specified namespace
+// tags it with the specified namespace.
 func (c *CloudClient) CreateTransitGW(region string) (*transitgatewayapisv1.TransitGateway, error) {
 	createTransitGatewayOptions := &transitgatewayapisv1.CreateTransitGatewayOptions{
 		Location:      &region, // location is mandatory even on global transmit GW.
 		Global:        core.BoolPtr(true),
 		ResourceGroup: (*transitgatewayapisv1.ResourceGroupIdentity)(c.resourceGroup),
-		Name:          core.StringPtr("Paraglider-transit-gw-" + uuid.New().String()[:8])}
+		Name:          core.StringPtr("Paraglider-transit-gw-" + uuid.New().String()[:8]),
+	}
 	transitGateway, _, err := c.transitGW.CreateTransitGateway(createTransitGatewayOptions)
 	if err != nil {
 		return nil, err
@@ -60,7 +61,7 @@ func (c *CloudClient) CreateTransitGW(region string) (*transitgatewayapisv1.Tran
 	return transitGateway, nil
 }
 
-// returns connections of the transit gateway
+// returns connections of the transit gateway.
 func (c *CloudClient) GetTransitGWConnections(gwID string) ([]TransitConnection, error) {
 	var connections []TransitConnection
 	listTransitGatewayConnectionsOptions := c.transitGW.NewListTransitGatewayConnectionsOptions(gwID)
@@ -76,7 +77,7 @@ func (c *CloudClient) GetTransitGWConnections(gwID string) ([]TransitConnection,
 	return connections, nil
 }
 
-// adds VPC as a connection to an existing Transit Gateway
+// adds VPC as a connection to an existing Transit Gateway.
 func (c *CloudClient) AddTransitGWConnection(transitGatewayID string, vpcCRN string) (TransitConnection, error) {
 	connectionName := generateResourceName(connectionType)
 	createConnectionOptions := &transitgatewayapisv1.CreateTransitGatewayConnectionOptions{
@@ -94,7 +95,7 @@ func (c *CloudClient) AddTransitGWConnection(transitGatewayID string, vpcCRN str
 	return TransitConnection{ID: *res.ID, Name: *res.Name, VPCCRN: *res.NetworkID}, nil
 }
 
-// deletes a gateway matching the specified ID
+// deletes a gateway matching the specified ID.
 func (c *CloudClient) DeleteTransitGW(gwID string) error {
 	// gateway's connection must be removed before the GW can be deleted
 	err := c.RemoveTransitGWConnections(gwID)
@@ -155,12 +156,11 @@ func (c *CloudClient) pollConnectionDeleted(connectionID string, gwID string) (b
 		// sleep to avoid busy waiting
 		time.Sleep(10 * time.Second)
 	}
-	return false, fmt.Errorf("Connection with ID: %v wasn't deleted in the alloted time frame", connectionID)
+	return false, fmt.Errorf("connection with ID: %v wasn't deleted in the alloted time frame", connectionID)
 }
 
 // removes the specified connection from the specified transit gateway.
 func (c *CloudClient) RemoveTransitGWConnection(connection string, transitGW string) error {
-
 	deleteConnectionOptions := &transitgatewayapisv1.DeleteTransitGatewayConnectionOptions{
 		TransitGatewayID: &transitGW,
 		ID:               &connection,

--- a/pkg/ibm/utils.go
+++ b/pkg/ibm/utils.go
@@ -41,11 +41,11 @@ const (
 	VM       taggedResourceType = "instance"
 	CLUSTER  taggedResourceType = "k8-cluster"
 	ENDPOINT taggedResourceType = "endpoint-gateway"
-	// Security group of a specific instance
+	// Security group of a specific instance.
 	SG taggedResourceType = "security-group"
-	// transit gateway for vpc-peering
+	// transit gateway for vpc-peering.
 	GATEWAY taggedResourceType = "gateway"
-	// public gateway for accessing public IP endpoints
+	// public gateway for accessing public IP endpoints.
 	PGATEWAY taggedResourceType = "public-gateway"
 	VPN      taggedResourceType = "vpn"
 	ANY      taggedResourceType = "*"
@@ -54,13 +54,13 @@ const (
 	endpointsURL    = "https://control.cloud-object-storage.cloud.ibm.com/v2/endpoints" // url containing constantly updated endpoints of regions.
 	publicSSHKey    = ".ibm/keys/paraglider-key.pub"
 	privateSSHKey   = ".ibm/keys/paraglider-key"
-	// paragliderResourcePrefix is used to prefix a resource's name
+	// paragliderResourcePrefix is used to prefix a resource's name.
 	paragliderResourcePrefix = "paraglider"
-	// paragliderTag is the default tag attached to all paraglider resources
+	// paragliderTag is the default tag attached to all paraglider resources.
 	paragliderTag = "pg"
 )
 
-// taggedResourceType indicates the type of tagged resource to fetch
+// taggedResourceType indicates the type of tagged resource to fetch.
 type taggedResourceType string
 
 // cache of regions, initialized by GetRegions(). Shouldn't be accessed directly outside of file.
@@ -82,19 +82,19 @@ type resourceData struct {
 	Zone   string
 }
 
-// resourceIDInfo defines the necessary fields of a resource sent in a request
+// resourceIDInfo defines the necessary fields of a resource sent in a request.
 type resourceIDInfo struct {
 	ResourceGroup string `json:"resourcegroup"`
 	Zone          string `json:"zone"`
 	ResourceID    string `json:"resourceid"`
 }
 
-// returns url of IBM region
+// returns url of IBM region.
 func endpointURL(region string) string {
 	return fmt.Sprintf("https://%s.iaas.cloud.ibm.com/v1", region)
 }
 
-// crn2Id returns ID of resource based on its CRN
+// crn2Id returns ID of resource based on its CRN.
 func crn2Id(crn string) string {
 	index := strings.LastIndex(crn, ":")
 	if index == -1 {
@@ -103,17 +103,17 @@ func crn2Id(crn string) string {
 	return crn[index+1:]
 }
 
-// generateResourceName returns unique paraglider resource name
+// generateResourceName returns unique paraglider resource name.
 func generateResourceName(name string) string {
 	return fmt.Sprintf("%v-%v-%v", paragliderResourcePrefix, name, uuid.New().String()[:8])
 }
 
-// isParagliderResource returns if a given resource (e.g. permit list) belongs to paraglider
+// isParagliderResource returns if a given resource (e.g. permit list) belongs to paraglider.
 func isParagliderResource(name string) bool {
 	return strings.HasPrefix(name, paragliderResourcePrefix)
 }
 
-// TODO cleanup k8s clusters
+// TODO cleanup k8s clusters.
 func TerminateParagliderDeployments(region string) error {
 	if os.Getenv("INVISINETS_TEST_PERSIST") == "1" {
 		utils.Log.Printf("Skipped IBM resource cleanup function - INVISINETS_TEST_PERSIST is set to 1")
@@ -177,7 +177,7 @@ func getClientMapKey(resGroup, region string) string {
 }
 
 // returns ResourceIDInfo out of an agreed upon formatted string:
-// "/resourcegroup/{ResourceGroupName}/zone/{zone}/resourcetype/{ResourceID}"
+// "/resourcegroup/{ResourceGroupName}/zone/{zone}/resourcetype/{ResourceID}".
 func getResourceMeta(deploymentID string) (resourceIDInfo, error) {
 	parts := strings.Split(deploymentID, "/")
 
@@ -233,8 +233,7 @@ func getZoneFromDesc(resourceDesc []byte) (string, error) {
 		return defaultZone, nil
 	}
 
-	return "", fmt.Errorf("failed to unmarshal resource description:%+v", err)
-
+	return "", fmt.Errorf("failed to unmarshal resource description:%+w", err)
 }
 
 func setRuleValToStore(ctx context.Context, client paragliderpb.ControllerClient, key, value, namespace string) error {
@@ -256,7 +255,6 @@ func getRuleValFromStore(ctx context.Context, client paragliderpb.ControllerClie
 		Namespace: namespace,
 	}
 	resp, err := client.GetValue(ctx, getVal)
-
 	if err != nil {
 		return "", err
 	}
@@ -283,7 +281,7 @@ func getRegions() ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer response.Body.Close()
+	defer func() { _ = response.Body.Close() }()
 	responseBody, err := io.ReadAll(response.Body)
 	if err != nil {
 		return nil, err
@@ -299,7 +297,7 @@ func getRegions() ([]string, error) {
 	return regionCache, nil
 }
 
-// doesSliceContain returns true if a slice contains an item
+// doesSliceContain returns true if a slice contains an item.
 func doesSliceContain[T comparable](slice []T, target T) bool {
 	for _, val := range slice {
 		if val == target {
@@ -309,21 +307,21 @@ func doesSliceContain[T comparable](slice []T, target T) bool {
 	return false
 }
 
-// isRegionValid returns true if region is a valid IBM region
+// isRegionValid returns true if region is a valid IBM region.
 func isRegionValid(region string) (bool, error) {
 	regions, err := getRegions()
 	if err != nil {
 		return false, err
 	}
-	return doesSliceContain(regions[:], region), nil
+	return doesSliceContain(regions, region), nil
 }
 
-// returns region of string with region validation
+// returns region of string with region validation.
 func ZoneToRegion(zone string) (string, error) {
 	lastIndex := strings.LastIndex(zone, "-")
 	if lastIndex == -1 {
 		// Hyphen not found, handle this situation
-		return "", fmt.Errorf("Wrong format for zone: missing hyphen.")
+		return "", fmt.Errorf("wrong format for zone: missing hyphen")
 	}
 	region := zone[:lastIndex]
 
@@ -335,7 +333,7 @@ func ZoneToRegion(zone string) (string, error) {
 }
 
 // areStructsEqual returns true if two given structs of the same type have matching fields values
-// on all types except those listed in fieldsToExclude
+// on all types except those listed in fieldsToExclude.
 func areStructsEqual(s1, s2 interface{}, fieldsToExclude []string) bool {
 	v1 := reflect.ValueOf(s1)
 	v2 := reflect.ValueOf(s2)
@@ -378,12 +376,12 @@ func getStructHash(s interface{}, fieldsToExclude []string) (uint64, error) {
 				return 0, err
 			}
 		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-			_, err := h.Write([]byte(fmt.Sprint(f.Int())))
+			_, err := fmt.Fprint(h, f.Int())
 			if err != nil {
 				return 0, err
 			}
 		case reflect.Bool:
-			_, err := h.Write([]byte(fmt.Sprint(f.Bool())))
+			_, err := fmt.Fprint(h, f.Bool())
 			if err != nil {
 				return 0, err
 			}
@@ -399,7 +397,7 @@ func getStructHash(s interface{}, fieldsToExclude []string) (uint64, error) {
 	return h.Sum64(), nil
 }
 
-// GetIBMResourceGroupID returns resource group ID defined in environment variable PARAGLIDER_IBM_RESOURCE_GROUP_ID
+// GetIBMResourceGroupID returns resource group ID defined in environment variable PARAGLIDER_IBM_RESOURCE_GROUP_ID.
 func GetIBMResourceGroupID() string {
 	resourceGroupID := os.Getenv("PARAGLIDER_IBM_RESOURCE_GROUP_ID")
 	if resourceGroupID == "" {

--- a/pkg/ibm/vpc.go
+++ b/pkg/ibm/vpc.go
@@ -62,7 +62,7 @@ func (c *CloudClient) CreateVPC(tags []string, exclusive bool) (*vpcv1.VPC, erro
 	return vpc, nil
 }
 
-// TerminateVPC terminates a vpc, deleting its associated instances and subnets
+// TerminateVPC terminates a vpc, deleting its associated instances and subnets.
 func (c *CloudClient) TerminateVPC(vpcID string) error {
 	// Fetch instances of specified VPC
 	instanceList, _, err := c.vpcService.ListInstances(&vpcv1.ListInstancesOptions{
@@ -108,7 +108,7 @@ func (c *CloudClient) TerminateVPC(vpcID string) error {
 	return nil
 }
 
-// GetVPCByID returns vpc data of specified vpc
+// GetVPCByID returns vpc data of specified vpc.
 func (c *CloudClient) GetVPCByID(vpcID string) (*vpcv1.VPC, error) {
 	vpc, response, err := c.vpcService.GetVPC(&vpcv1.GetVPCOptions{
 		ID: &vpcID,
@@ -120,7 +120,7 @@ func (c *CloudClient) GetVPCByID(vpcID string) (*vpcv1.VPC, error) {
 	return vpc, nil
 }
 
-// returns CIDR of VPC
+// returns CIDR of VPC.
 func (c *CloudClient) GetVpcCIDR(vpcID string) ([]string, error) {
 	// aggregate addresses of subnets in VPC
 	subnets, err := c.GetSubnetsInVpcRegionBound(vpcID)
@@ -128,7 +128,7 @@ func (c *CloudClient) GetVpcCIDR(vpcID string) ([]string, error) {
 		utils.Log.Printf("error while aggregating addresses of subnets to fetch VPC's CIDR: %+v", err)
 		return nil, err
 	}
-	var addresses = make([]string, len(subnets))
+	addresses := make([]string, len(subnets))
 	for i, subnet := range subnets {
 		address, err := c.GetSubnetCIDR(*subnet.ID)
 		if err != nil {

--- a/pkg/ibm/vpn.go
+++ b/pkg/ibm/vpn.go
@@ -26,12 +26,13 @@ import (
 	utils "github.com/paraglider-project/paraglider/pkg/utils"
 )
 
-const routeType = "route"
-const vpnConnectionType = "vpn-connection"
+const (
+	routeType         = "route"
+	vpnConnectionType = "vpn-connection"
+)
 
-// CreateRouteBasedVPN creates a route based VPN and returns its public IPs
+// CreateRouteBasedVPN creates a route based VPN and returns its public IPs.
 func (c *CloudClient) CreateRouteBasedVPN(namespace string) ([]string, error) {
-
 	// fetch the the specified namespace's VPC in the region
 	vpcData, err := c.GetParagliderTaggedResources(VPC, []string{namespace}, resourceQuery{Region: c.region})
 	if err != nil {
@@ -39,7 +40,7 @@ func (c *CloudClient) CreateRouteBasedVPN(namespace string) ([]string, error) {
 		return nil, err
 	}
 	if len(vpcData) == 0 {
-		return nil, fmt.Errorf("No VPC located at the region specified for VPN deployment")
+		return nil, fmt.Errorf("no VPC located at the region specified for VPN deployment")
 	}
 
 	subnets, err := c.GetSubnetsInVpcRegionBound(vpcData[0].ID)
@@ -73,7 +74,7 @@ func (c *CloudClient) CreateRouteBasedVPN(namespace string) ([]string, error) {
 			}
 			if len(vpn) == 0 {
 				utils.Log.Printf("Failed to fetch existing VPN in region %v. Possible tagging/global search issue.", c.region)
-				return nil, fmt.Errorf("Failed to fetch existing VPN in region %v", c.region)
+				return nil, fmt.Errorf("failed to fetch existing VPN in region %v", c.region)
 			}
 			utils.Log.Printf("Retrieving already deployed VPN gateway of VPC %v\n", vpcData[0].ID)
 			ipAddresses, err := c.GetVPNIPs(vpn[0].ID) // array lookup is safe since a VPN exists
@@ -118,11 +119,9 @@ func (c *CloudClient) pollVPNStatus(vpnId string, readyOrDeleted bool) error {
 	sleepDuration := 10 * time.Second
 	utils.Log.Printf("\nPolling VPN status. Process might take up to %v seconds", attempts*(int(sleepDuration/time.Second)))
 	for attempt := 1; attempt <= attempts; attempt += 1 {
-
 		vpnData, _, err := c.vpcService.GetVPNGateway(c.vpcService.NewGetVPNGatewayOptions(
 			vpnId,
 		))
-
 		if err != nil {
 			if readyOrDeleted { // received err while waiting for ready status
 				utils.Log.Printf("Error occurred while waiting for VPN %v for status update: %+v", vpnId, err)
@@ -219,7 +218,7 @@ func (c *CloudClient) createRoutes(routingTableID, vpcID, VPNConnectionID string
 	return nil
 }
 
-// returns a connection (of the provided VPN) matching the specified peer VPN gateway IP address
+// returns a connection (of the provided VPN) matching the specified peer VPN gateway IP address.
 func (c *CloudClient) getVPNConnectionMatchingPeerIP(VPNGatewayID, peerGWAddress string) (*vpcv1.VPNGatewayConnectionRouteModeVPNGatewayConnectionStaticRouteMode, error) {
 	vpnGatewayConnections, _, err := c.vpcService.ListVPNGatewayConnections(
 		&vpcv1.ListVPNGatewayConnectionsOptions{VPNGatewayID: &VPNGatewayID},
@@ -245,7 +244,7 @@ func (c *CloudClient) getVPNConnectionMatchingPeerIP(VPNGatewayID, peerGWAddress
 // - peerGatewayIP - the remote VPN the newly created connection will connect to.
 // - preSharedKey - pre-shared key for authentication between the 2 VPN connections.
 // - destinationCIDR - traffic destined to this CIDR will be redirect to the newly created connection via newly created routing table routes
-// - peerCloud - cloud residing the peer VPN gateway this connection is set to bridge
+// - peerCloud - cloud residing the peer VPN gateway this connection is set to bridge.
 func (c *CloudClient) CreateVPNConnectionRouteBased(VPNGatewayID, peerGatewayIP, preSharedKey, peerCloud string, destinationCIDRs []string) error {
 	var connectionID string
 
@@ -274,7 +273,6 @@ func (c *CloudClient) CreateVPNConnectionRouteBased(VPNGatewayID, peerGatewayIP,
 		},
 	}
 	connectionInterface, _, err := c.vpcService.CreateVPNGatewayConnection(connectionConfig)
-
 	if err != nil {
 		// check if connection already exists.
 		if strings.Contains(err.Error(), "duplicate") { // Note: relying on error string, since status code is shared with multiple errors.
@@ -334,7 +332,7 @@ func (c *CloudClient) pollVPNConnectionDeleted(VPNGatewayID, connectionID string
 		}
 		time.Sleep(10 * time.Second)
 	}
-	return fmt.Errorf("Connection with ID: %v failed to delete in the alloted time frame", connectionID)
+	return fmt.Errorf("connection with ID: %v failed to delete in the alloted time frame", connectionID)
 }
 
 // Polls a VPN connection status. Returns an error if connection fails to delete within the alloted time frame.
@@ -348,7 +346,6 @@ func (c *CloudClient) pollRouteDeleted(vpcID, routingTableID string, route vpcv1
 			*route.ID,
 		)
 		_, _, err := c.vpcService.GetVPCRoutingTableRoute(options)
-
 		if err != nil {
 			// route deleted successfully
 			utils.Log.Printf("route at %v deleted successfully in attempt No. %v", routeZone, attempt)
@@ -359,9 +356,8 @@ func (c *CloudClient) pollRouteDeleted(vpcID, routingTableID string, route vpcv1
 	return fmt.Errorf("route named: %v failed to delete in the alloted time frame", *route.Name)
 }
 
-// Deletes routes (from the VPC that the specified VPN resides in) directing traffic to the specified connection
+// Deletes routes (from the VPC that the specified VPN resides in) directing traffic to the specified connection.
 func (c *CloudClient) DeleteRoutesDependentOnConnection(VPNGatewayID string, connection *vpcv1.VPNGatewayConnectionRouteModeVPNGatewayConnectionStaticRouteMode) error {
-
 	// get the routing table of the VPC where the VPN gateway resides
 	vpnGateway, _, err := c.vpcService.GetVPNGateway(c.vpcService.NewGetVPNGatewayOptions(VPNGatewayID))
 	if err != nil {
@@ -387,7 +383,7 @@ func (c *CloudClient) DeleteRoutesDependentOnConnection(VPNGatewayID string, con
 	for _, route := range routeCollection.Routes {
 		routeNextHop, isNextHopToVpnConnection := route.NextHop.(*vpcv1.RouteNextHop)
 		if !isNextHopToVpnConnection {
-			return fmt.Errorf("Expected next hop to reference a VPN connection, instead (likely) references an IP address.")
+			return fmt.Errorf("expected next hop to reference a VPN connection, instead (likely) references an IP address")
 		}
 		if *routeNextHop.ID == *connection.ID {
 			_, err = c.vpcService.DeleteVPCRoute(&vpcv1.DeleteVPCRouteOptions{
@@ -416,7 +412,7 @@ func (c *CloudClient) DeleteRoutesDependentOnConnection(VPNGatewayID string, con
 	return nil
 }
 
-// deletes the specified VPN along with its connections their associated routes
+// deletes the specified VPN along with its connections their associated routes.
 func (c *CloudClient) DeleteVPN(VPNGatewayID string) error {
 	vpnConnections, _, err := c.vpcService.ListVPNGatewayConnections(
 		&vpcv1.ListVPNGatewayConnectionsOptions{VPNGatewayID: core.StringPtr(VPNGatewayID)})
@@ -437,7 +433,6 @@ func (c *CloudClient) DeleteVPN(VPNGatewayID string) error {
 		// set connection for deletion
 		_, err = c.vpcService.DeleteVPNGatewayConnection(
 			&vpcv1.DeleteVPNGatewayConnectionOptions{VPNGatewayID: &VPNGatewayID, ID: connection.ID})
-
 		if err != nil {
 			utils.Log.Printf("Failed to delete VPN connection %v, with error: %+v", *connection.ID, err)
 			return err
@@ -487,7 +482,7 @@ func (c *CloudClient) GetVPNsInNamespaceRegion(namespace, region string) ([]reso
 	return vpns, nil
 }
 
-// returns an IKE policy ID that's compatible with the specified peer cloud
+// returns an IKE policy ID that's compatible with the specified peer cloud.
 func (c *CloudClient) getOrCreateIKEPolicy(peerCloud string) (*string, error) {
 	// return an existing IPSec policy for the specified cloud if one exists in the region
 	existingPolicy, err := c.getIKEPolicy(peerCloud)
@@ -522,7 +517,7 @@ func (c *CloudClient) getOrCreateIKEPolicy(peerCloud string) (*string, error) {
 	return ikePolicy.ID, nil
 }
 
-// returns existing IKE policy for the peer cloud
+// returns existing IKE policy for the peer cloud.
 func (c *CloudClient) getIKEPolicy(peerCloud string) (*vpcv1.IkePolicy, error) {
 	ikePolicies, _, err := c.vpcService.ListIkePolicies(&vpcv1.ListIkePoliciesOptions{})
 	if err != nil {
@@ -538,7 +533,7 @@ func (c *CloudClient) getIKEPolicy(peerCloud string) (*vpcv1.IkePolicy, error) {
 	return nil, nil
 }
 
-// returns an IPsec policy ID that's compatible with the specified peer cloud
+// returns an IPsec policy ID that's compatible with the specified peer cloud.
 func (c *CloudClient) getOrCreateIPSecPolicy(peerCloud string) (*string, error) {
 	// return an existing IPSec policy for the specified cloud if one exists in the region
 	existingPolicy, err := c.getIPSecPolicy(peerCloud)
@@ -571,7 +566,7 @@ func (c *CloudClient) getOrCreateIPSecPolicy(peerCloud string) (*string, error) 
 	return ipsecPolicy.ID, nil
 }
 
-// returns existing IPSec policy for the peer cloud
+// returns existing IPSec policy for the peer cloud.
 func (c *CloudClient) getIPSecPolicy(peerCloud string) (*vpcv1.IPsecPolicy, error) {
 	ipSecPolicies, _, err := c.vpcService.ListIpsecPolicies(&vpcv1.ListIpsecPoliciesOptions{})
 	if err != nil {
@@ -592,7 +587,6 @@ func (c *CloudClient) getIPSecPolicy(peerCloud string) (*vpcv1.IPsecPolicy, erro
 // - routing conflict - occurs when 2 rules share the same zone, destination and priority.
 // - rule duplication - if specified rule matches a rule on the following fields: destination, zone and nextHopConnection.
 func (c *CloudClient) getAvailablePriority(routeData *vpcv1.CreateVPCRoutingTableRouteOptions) (bool, int64, error) {
-
 	const numOfPriorities = 5
 	// keeps tracks of available priorities for given rule, e.g. if rule[i]==false, priority i isn't available.
 	availablePriority := make(map[int64]bool, numOfPriorities)
@@ -633,5 +627,5 @@ func (c *CloudClient) getAvailablePriority(routeData *vpcv1.CreateVPCRoutingTabl
 	}
 
 	// rule doesn't exist, but no available priority found
-	return false, -1, fmt.Errorf("No available priority found to create a route in zone: %v, destination: %v, to connectionID: %v", routeZone, routeDestination, routeConnectionID)
+	return false, -1, fmt.Errorf("no available priority found to create a route in zone: %v, destination: %v, to connectionID: %v", routeZone, routeDestination, routeConnectionID)
 }

--- a/pkg/kvstore/kvstore.go
+++ b/pkg/kvstore/kvstore.go
@@ -68,7 +68,7 @@ func (s *kvStoreServer) Delete(ctx context.Context, req *storepb.DeleteRequest) 
 	return &storepb.DeleteResponse{}, nil
 }
 
-// Setup and run the server
+// Setup and run the server.
 func Setup(dbPort int, serverPort int, clearKeys bool) {
 	client := redis.NewClient(&redis.Options{
 		Addr:     fmt.Sprintf("localhost:%d", dbPort),
@@ -88,7 +88,7 @@ func Setup(dbPort int, serverPort int, clearKeys bool) {
 	grpcServer := grpc.NewServer(opts...)
 	storepb.RegisterKVStoreServer(grpcServer, NewKVStoreServer(client))
 	fmt.Printf("Serving KV Store at localhost:%d", serverPort)
-	go func(){
+	go func() {
 		err = grpcServer.Serve(lis)
 		if err != nil {
 			fmt.Println(err.Error())

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -94,7 +94,7 @@ type ResourceID struct {
 	Id string `json:"id,omitempty"`
 }
 
-// Return a string usable with Sprintf for inserting URL params
+// Return a string usable with Sprintf for inserting URL params.
 func GetFormatterString(url string) string {
 	new_tokens := []string{}
 	for _, token := range strings.Split(string(url), "/") {
@@ -111,7 +111,7 @@ func createErrorResponse(message string) gin.H {
 	return gin.H{"error": message}
 }
 
-// Returns whether the string provided is a valid IP/CIDR
+// Returns whether the string provided is a valid IP/CIDR.
 func isIpAddrOrCidr(value string) bool {
 	if strings.Contains(value, "/") {
 		_, err := netip.ParsePrefix(value)
@@ -122,7 +122,7 @@ func isIpAddrOrCidr(value string) bool {
 	}
 }
 
-// Retrieve the IPs from a list of name mappings
+// Retrieve the IPs from a list of name mappings.
 func getIPsFromResolvedTag(mappings []*tagservicepb.TagMapping) []string {
 	ips := make([]string, len(mappings))
 	for i, mapping := range mappings {
@@ -131,7 +131,7 @@ func getIPsFromResolvedTag(mappings []*tagservicepb.TagMapping) []string {
 	return ips
 }
 
-// Check if rules given by the user have tags (requirement) and remove any targets they contain (should only be written by the orchestrator)
+// Check if rules given by the user have tags (requirement) and remove any targets they contain (should only be written by the orchestrator).
 func checkAndCleanRule(rule *paragliderpb.PermitListRule) (*paragliderpb.PermitListRule, *Warning, error) {
 	if len(rule.Tags) == 0 {
 		return nil, nil, fmt.Errorf("rule %s contains no tags", rule.Name)
@@ -143,12 +143,12 @@ func checkAndCleanRule(rule *paragliderpb.PermitListRule) (*paragliderpb.PermitL
 	return rule, nil, nil
 }
 
-// Format a subscriber name so that when the value is looked up, it is clear which cloud and namespace the URI belongs to
+// Format a subscriber name so that when the value is looked up, it is clear which cloud and namespace the URI belongs to.
 func createSubscriberName(namespace string, cloud string, uri string) string {
 	return namespace + ">" + cloud + ">" + uri
 }
 
-// Parse subscriber names from database to get the namespace, cloud and URI
+// Parse subscriber names from database to get the namespace, cloud and URI.
 func parseSubscriberName(sub string) (string, string, string) {
 	if strings.Contains(sub, ">") {
 		tokens := strings.Split(sub, ">")
@@ -173,13 +173,13 @@ func isTagValid(tag *tagservicepb.TagMapping) bool {
 	return tag.Ip != nil
 }
 
-// Get the URI of a tag
+// Get the URI of a tag.
 func (s *ControllerServer) getTagUri(tag string) (string, error) {
 	conn, err := grpc.NewClient(s.localTagService, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		return "", fmt.Errorf("could not contact tag server: %s", err.Error())
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 
 	// Send RPC to get tag
 	client := tagservicepb.NewTagServiceClient(conn)
@@ -194,7 +194,7 @@ func (s *ControllerServer) getTagUri(tag string) (string, error) {
 	return *response.Tag.Uri, nil
 }
 
-// Get URL params for a resource and resolve the resource name if needed
+// Get URL params for a resource and resolve the resource name if needed.
 func (s *ControllerServer) getAndValidateResourceURLParams(c *gin.Context, resolveTag bool) (*ResourceInfo, string, error) {
 	tag := c.Param("resourceName")
 	cloud := c.Param("cloud")
@@ -218,7 +218,7 @@ func (s *ControllerServer) getAndValidateResourceURLParams(c *gin.Context, resol
 	}
 }
 
-// Takes a set of permit list rules and returns the same list with all tags referenced in the original rules resolved to IPs
+// Takes a set of permit list rules and returns the same list with all tags referenced in the original rules resolved to IPs.
 func (s *ControllerServer) resolvePermitListRules(rules []*paragliderpb.PermitListRule, resource *ResourceInfo, subscribe bool) ([]*paragliderpb.PermitListRule, error) {
 	for _, rule := range rules {
 		// Check rule validity and clean fields
@@ -233,7 +233,7 @@ func (s *ControllerServer) resolvePermitListRules(rules []*paragliderpb.PermitLi
 				if err != nil {
 					return nil, fmt.Errorf("could not contact tag server: %s", err.Error())
 				}
-				defer conn.Close()
+				defer func() { _ = conn.Close() }()
 
 				// Send RPC to resolve tag
 				client := tagservicepb.NewTagServiceClient(conn)
@@ -245,8 +245,10 @@ func (s *ControllerServer) resolvePermitListRules(rules []*paragliderpb.PermitLi
 				// Subscribe self to tag
 				if subscribe {
 					_, err := client.Subscribe(context.Background(),
-						&tagservicepb.SubscribeRequest{Subscription: &tagservicepb.Subscription{TagName: tag,
-							Subscriber: createSubscriberName(resource.namespace, resource.cloud, resource.uri)}})
+						&tagservicepb.SubscribeRequest{Subscription: &tagservicepb.Subscription{
+							TagName:    tag,
+							Subscriber: createSubscriberName(resource.namespace, resource.cloud, resource.uri),
+						}})
 					if err != nil {
 						return nil, fmt.Errorf("could not subscribe to tag: %s", err.Error())
 					}
@@ -261,14 +263,14 @@ func (s *ControllerServer) resolvePermitListRules(rules []*paragliderpb.PermitLi
 	return rules, nil
 }
 
-// Get permit list with ID from plugin
+// Get permit list with ID from plugin.
 func (s *ControllerServer) _permitListGet(namespace string, resourceId string, pluginAddress string) (*paragliderpb.GetPermitListResponse, error) {
 	// Connect to the cloud plugin
 	conn, err := grpc.NewClient(pluginAddress, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		return nil, err
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 
 	// Send the GetPermitList RPC
 	client := paragliderpb.NewCloudPluginClient(conn)
@@ -282,7 +284,7 @@ func (s *ControllerServer) _permitListGet(namespace string, resourceId string, p
 	return response, nil
 }
 
-// Get specified PermitList from given cloud
+// Get specified PermitList from given cloud.
 func (s *ControllerServer) permitListGet(c *gin.Context) {
 	resourceInfo, cloudClient, err := s.getAndValidateResourceURLParams(c, true)
 	if err != nil {
@@ -299,7 +301,7 @@ func (s *ControllerServer) permitListGet(c *gin.Context) {
 	c.JSON(http.StatusOK, response.Rules)
 }
 
-// Add rules to a resource specified in the permit list in the given cloud
+// Add rules to a resource specified in the permit list in the given cloud.
 func (s *ControllerServer) _permitListRulesAdd(req *paragliderpb.AddPermitListRulesRequest, resource *ResourceInfo, pluginAddress string) (*paragliderpb.AddPermitListRulesResponse, error) {
 	// Resolve tags referenced in rules
 	rules, err := s.resolvePermitListRules(req.Rules, resource, true)
@@ -312,7 +314,7 @@ func (s *ControllerServer) _permitListRulesAdd(req *paragliderpb.AddPermitListRu
 	if err != nil {
 		return nil, err
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 
 	// Send RPC to create rules
 	client := paragliderpb.NewCloudPluginClient(conn)
@@ -324,7 +326,7 @@ func (s *ControllerServer) _permitListRulesAdd(req *paragliderpb.AddPermitListRu
 	return response, nil
 }
 
-// Add permit list rules to specified resource
+// Add permit list rules to specified resource.
 func (s *ControllerServer) permitListRulesBulkAdd(c *gin.Context) {
 	resourceInfo, cloudClient, err := s.getAndValidateResourceURLParams(c, true)
 	if err != nil {
@@ -348,7 +350,7 @@ func (s *ControllerServer) permitListRulesBulkAdd(c *gin.Context) {
 	}
 }
 
-// Add a single rule to a resource permit list
+// Add a single rule to a resource permit list.
 func (s *ControllerServer) permitListRuleAdd(c *gin.Context) {
 	resourceInfo, cloudClient, err := s.getAndValidateResourceURLParams(c, true)
 	if err != nil {
@@ -363,7 +365,7 @@ func (s *ControllerServer) permitListRuleAdd(c *gin.Context) {
 		return
 	}
 
-	if c.Request.Method == "PUT" {
+	if c.Request.Method == http.MethodPut {
 		// Get rule name from URL
 		ruleName := c.Param("ruleName")
 		if ruleName == "" {
@@ -382,7 +384,7 @@ func (s *ControllerServer) permitListRuleAdd(c *gin.Context) {
 	}
 }
 
-// Add permit list rules to all resources within a tag
+// Add permit list rules to all resources within a tag.
 func (s *ControllerServer) permitListRuleAddTag(c *gin.Context) {
 	tag := c.Param("tag")
 
@@ -399,7 +401,7 @@ func (s *ControllerServer) permitListRuleAddTag(c *gin.Context) {
 		c.AbortWithStatusJSON(400, createErrorResponse(err.Error()))
 		return
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 
 	// Send RPC to resolve tag
 	client := tagservicepb.NewTagServiceClient(conn)
@@ -434,7 +436,7 @@ func (s *ControllerServer) permitListRuleAddTag(c *gin.Context) {
 				c.AbortWithStatusJSON(400, createErrorResponse(err.Error()))
 				return
 			}
-			defer conn.Close()
+			defer func() { _ = conn.Close() }()
 
 			initializedClientConns[cloud] = conn
 		}
@@ -449,7 +451,7 @@ func (s *ControllerServer) permitListRuleAddTag(c *gin.Context) {
 	}
 }
 
-// Delete permit list rules to from resources within a tag
+// Delete permit list rules to from resources within a tag.
 func (s *ControllerServer) permitListRuleDeleteTag(c *gin.Context) {
 	tag := c.Param("tag")
 
@@ -466,7 +468,7 @@ func (s *ControllerServer) permitListRuleDeleteTag(c *gin.Context) {
 		c.AbortWithStatusJSON(400, createErrorResponse(err.Error()))
 		return
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 
 	// Send RPC to resolve tag
 	client := tagservicepb.NewTagServiceClient(conn)
@@ -496,7 +498,7 @@ func (s *ControllerServer) permitListRuleDeleteTag(c *gin.Context) {
 			c.AbortWithStatusJSON(400, createErrorResponse(err.Error()))
 			return
 		}
-		defer conn.Close()
+		defer func() { _ = conn.Close() }()
 
 		// Send RPC to add rule
 		client := paragliderpb.NewCloudPluginClient(conn)
@@ -508,7 +510,7 @@ func (s *ControllerServer) permitListRuleDeleteTag(c *gin.Context) {
 	}
 }
 
-// Find the tags dereferenced between two versions of a permit list
+// Find the tags dereferenced between two versions of a permit list.
 func diffTagReferences(beforeList []*paragliderpb.PermitListRule, afterList []*paragliderpb.PermitListRule) []string {
 	beforeListSet := make(map[string]bool)
 	afterListSet := make(map[string]bool)
@@ -540,7 +542,7 @@ func diffTagReferences(beforeList []*paragliderpb.PermitListRule, afterList []*p
 	return tagsDereferenced
 }
 
-// Check whether any tags have been dereferenced by the permit list and unsubscribe from any that have
+// Check whether any tags have been dereferenced by the permit list and unsubscribe from any that have.
 func (s *ControllerServer) checkAndUnsubscribe(resource *ResourceInfo, beforeList []*paragliderpb.PermitListRule, afterList []*paragliderpb.PermitListRule) error {
 	// Find the dereferenced tags
 	tagsToUnsubscribe := diffTagReferences(beforeList, afterList)
@@ -555,7 +557,7 @@ func (s *ControllerServer) checkAndUnsubscribe(resource *ResourceInfo, beforeLis
 	if err != nil {
 		return err
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 	client := tagservicepb.NewTagServiceClient(conn)
 
 	// Send RPC to unsubscribe from each tag
@@ -569,7 +571,7 @@ func (s *ControllerServer) checkAndUnsubscribe(resource *ResourceInfo, beforeLis
 	return nil
 }
 
-// Delete permit list rules to specified resource
+// Delete permit list rules to specified resource.
 func (s *ControllerServer) permitListRulesDelete(c *gin.Context) {
 	resourceInfo, cloudClient, err := s.getAndValidateResourceURLParams(c, true)
 	if err != nil {
@@ -590,7 +592,7 @@ func (s *ControllerServer) permitListRulesDelete(c *gin.Context) {
 		c.AbortWithStatusJSON(400, createErrorResponse(err.Error()))
 		return
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 	client := paragliderpb.NewCloudPluginClient(conn)
 
 	// First, get the original list
@@ -624,7 +626,7 @@ func (s *ControllerServer) permitListRulesDelete(c *gin.Context) {
 	}
 }
 
-// Delete a single rule from a resource permit list
+// Delete a single rule from a resource permit list.
 func (s *ControllerServer) permitListRuleDelete(c *gin.Context) {
 	resourceInfo, cloudClient, err := s.getAndValidateResourceURLParams(c, true)
 	if err != nil {
@@ -645,7 +647,7 @@ func (s *ControllerServer) permitListRuleDelete(c *gin.Context) {
 		c.AbortWithStatusJSON(400, createErrorResponse(err.Error()))
 		return
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 	client := paragliderpb.NewCloudPluginClient(conn)
 
 	// First, get the original list
@@ -679,7 +681,7 @@ func (s *ControllerServer) permitListRuleDelete(c *gin.Context) {
 	}
 }
 
-// Get used address spaces from a specified cloud
+// Get used address spaces from a specified cloud.
 func (s *ControllerServer) getAddressSpaces(cloud string) ([]*paragliderpb.AddressSpaceMapping, error) {
 	// Ensure correct cloud name
 	cloudClient, ok := s.pluginAddresses[cloud]
@@ -692,7 +694,7 @@ func (s *ControllerServer) getAddressSpaces(cloud string) ([]*paragliderpb.Addre
 	if err != nil {
 		return nil, fmt.Errorf("unable to connect to cloud plugin: %s", err.Error())
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 
 	// Send the RPC to get the address spaces
 	client := paragliderpb.NewCloudPluginClient(conn)
@@ -704,7 +706,7 @@ func (s *ControllerServer) getAddressSpaces(cloud string) ([]*paragliderpb.Addre
 	return resp.AddressSpaceMappings, err
 }
 
-// Update local address space map by getting used address spaces from each cloud plugin
+// Update local address space map by getting used address spaces from each cloud plugin.
 func (s *ControllerServer) updateUsedAddressSpaces() error {
 	// Call each cloud to get address spaces used
 	for _, cloud := range s.config.CloudPlugins {
@@ -717,7 +719,7 @@ func (s *ControllerServer) updateUsedAddressSpaces() error {
 	return nil
 }
 
-// Get a new address block for a new virtual network
+// Get a new address block for a new virtual network.
 func (s *ControllerServer) FindUnusedAddressSpaces(c context.Context, req *paragliderpb.FindUnusedAddressSpacesRequest) (*paragliderpb.FindUnusedAddressSpacesResponse, error) {
 	s.addressRequest.Lock()
 	defer s.addressRequest.Unlock()
@@ -741,7 +743,7 @@ func (s *ControllerServer) FindUnusedAddressSpaces(c context.Context, req *parag
 			reqSize = int64(requestedAddressSpaces[i])
 		}
 		var aBlock *ipaddr.IPAddress
-		// Iterate to allocate the first usunsed block that can accomodate
+		// Iterate to allocate the first usunsed block that can accommodate
 		for _, block := range unusedBlocks {
 			if reqSize < block.GetCount().Int64() {
 				aBlock = allocBlock(block, reqSize)
@@ -765,7 +767,7 @@ func (s *ControllerServer) FindUnusedAddressSpaces(c context.Context, req *parag
 	return &paragliderpb.FindUnusedAddressSpacesResponse{AddressSpaces: respAddressSpaces}, nil
 }
 
-// Gets unused address spaces across all clouds
+// Gets unused address spaces across all clouds.
 func (s *ControllerServer) GetUsedAddressSpaces(c context.Context, _ *emptypb.Empty) (*paragliderpb.GetUsedAddressSpacesResponse, error) {
 	err := s.updateUsedAddressSpaces()
 	if err != nil {
@@ -778,20 +780,20 @@ func (s *ControllerServer) GetUsedAddressSpaces(c context.Context, _ *emptypb.Em
 	return &paragliderpb.GetUsedAddressSpacesResponse{AddressSpaceMappings: s.usedAddressSpaces}, nil
 }
 
-// Get used ASNs from a specified cloud
+// Get used ASNs from a specified cloud.
 func (s *ControllerServer) getUsedAsns(cloud string) (*paragliderpb.GetUsedAsnsResponse, error) {
 	// Ensure correct cloud name
 	cloudClient, ok := s.pluginAddresses[cloud]
 	if !ok {
-		return nil, errors.New("Invalid cloud name")
+		return nil, errors.New("invalid cloud name")
 	}
 
 	// Connect to cloud plugin
 	conn, err := grpc.NewClient(cloudClient, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
-		return nil, fmt.Errorf("Unable to connect to cloud plugin: %s", err.Error())
+		return nil, fmt.Errorf("unable to connect to cloud plugin: %s", err.Error())
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 
 	// Send the RPC to get the ASNs
 	client := paragliderpb.NewCloudPluginClient(conn)
@@ -805,7 +807,7 @@ func (s *ControllerServer) updateUsedAsns() error {
 	for _, cloud := range s.config.CloudPlugins {
 		asnList, err := s.getUsedAsns(cloud.Name)
 		if err != nil {
-			return fmt.Errorf("Could not retrieve address spaces for cloud %s (error: %s)", cloud, err.Error())
+			return fmt.Errorf("could not retrieve address spaces for cloud %s (error: %s)", cloud, err.Error())
 		}
 		s.usedAsns = append(s.usedAsns, asnList.Asns...)
 	}
@@ -850,20 +852,20 @@ func (s *ControllerServer) FindUnusedAsn(c context.Context, _ *paragliderpb.Find
 	return resp, nil
 }
 
-// Get used BGP peering IP addresses from a specified cloud
+// Get used BGP peering IP addresses from a specified cloud.
 func (s *ControllerServer) getUsedBgpPeeringIpAddresses(cloud string) (*paragliderpb.GetUsedBgpPeeringIpAddressesResponse, error) {
 	// Ensure correct cloud name
 	cloudClient, ok := s.pluginAddresses[cloud]
 	if !ok {
-		return nil, errors.New("Invalid cloud name")
+		return nil, errors.New("invalid cloud name")
 	}
 
 	// Connect to cloud plugin
 	conn, err := grpc.NewClient(cloudClient, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
-		return nil, fmt.Errorf("Unable to connect to cloud plugin: %s", err.Error())
+		return nil, fmt.Errorf("unable to connect to cloud plugin: %s", err.Error())
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 
 	// Send the RPC to get the BGP peering IP addresses
 	client := paragliderpb.NewCloudPluginClient(conn)
@@ -877,14 +879,14 @@ func (s *ControllerServer) updateUsedBgpPeeringIpAddresses(namespace string) err
 	for _, cloud := range s.config.CloudPlugins {
 		bgpPeeringIpAddressesList, err := s.getUsedBgpPeeringIpAddresses(cloud.Name)
 		if err != nil {
-			return fmt.Errorf("Could not retrieve address spaces for cloud %s (error: %s)", cloud, err.Error())
+			return fmt.Errorf("could not retrieve address spaces for cloud %s (error: %s)", cloud, err.Error())
 		}
 		s.usedBgpPeeringIpAddresses[cloud.Name] = bgpPeeringIpAddressesList.IpAddresses
 	}
 	return nil
 }
 
-// Not a public RPC (hence private) used by cloud plugins but follows the same pattern as FindUnusedAsn
+// Not a public RPC (hence private) used by cloud plugins but follows the same pattern as FindUnusedAsn.
 func (s *ControllerServer) findUnusedBgpPeeringIpAddresses(ctx context.Context, cloud1 string, cloud2 string, namespace string) ([]string, error) {
 	// Retrieve all used peering IPs from all clouds
 	err := s.updateUsedBgpPeeringIpAddresses(namespace)
@@ -948,7 +950,7 @@ func (s *ControllerServer) findUnusedBgpPeeringIpAddresses(ctx context.Context, 
 	return ips, nil
 }
 
-// Generates a shared key for VPN connections
+// Generates a shared key for VPN connections.
 func generateSharedKey() string {
 	const length = 24
 	// characters allowed in the random string
@@ -978,7 +980,7 @@ func (s *ControllerServer) getCloudDeployment(cloud, namespace string) string {
 	return ""
 }
 
-// Connects two clouds with VPN gateways
+// Connects two clouds with VPN gateways.
 func (s *ControllerServer) ConnectClouds(ctx context.Context, req *paragliderpb.ConnectCloudsRequest) (*paragliderpb.ConnectCloudsResponse, error) {
 	var isBGPDisabledConnection bool
 	var addressSpaceCloudA, addressSpaceCloudB string // address space of a resource to be served by a VPN created/fetched by this method.
@@ -1000,7 +1002,7 @@ func (s *ControllerServer) ConnectClouds(ctx context.Context, req *paragliderpb.
 		if err != nil {
 			return nil, fmt.Errorf("unable to connect to cloud plugin: %w", err)
 		}
-		defer cloudAConn.Close()
+		defer func() { _ = cloudAConn.Close() }()
 		cloudAClient := paragliderpb.NewCloudPluginClient(cloudAConn)
 
 		cloudBClientAddress, ok := s.pluginAddresses[req.CloudB]
@@ -1011,7 +1013,7 @@ func (s *ControllerServer) ConnectClouds(ctx context.Context, req *paragliderpb.
 		if err != nil {
 			return nil, fmt.Errorf("unable to connect to cloud plugin: %w", err)
 		}
-		defer cloudAConn.Close()
+		defer func() { _ = cloudAConn.Close() }()
 		cloudBClient := paragliderpb.NewCloudPluginClient(cloudBconn)
 
 		ctx := context.Background()
@@ -1105,7 +1107,7 @@ func (s *ControllerServer) ConnectClouds(ctx context.Context, req *paragliderpb.
 	return nil, fmt.Errorf("clouds %s and %s are not supported for multi-cloud connecting", req.CloudA, req.CloudB)
 }
 
-// Gets all deployments (in Paraglider) format for a given cloud
+// Gets all deployments (in Paraglider) format for a given cloud.
 func (s *ControllerServer) getParagliderDeployments(cloud string) []*paragliderpb.ParagliderDeployment {
 	pgDeployments := []*paragliderpb.ParagliderDeployment{}
 	for namespace, cloudDeployments := range s.config.Namespaces {
@@ -1141,13 +1143,13 @@ func (s *ControllerServer) handleCreateOrAttachResource(c *gin.Context) {
 
 	// Create resource if req. body JSON contains "description"
 	if err := c.ShouldBindBodyWithJSON(&resourceToCreate); err == nil && resourceToCreate.Description != "" {
-		if c.Request.Method == "POST" {
+		if c.Request.Method == http.MethodPost {
 			resourceInfo.name = resourceToCreate.Name
 		}
 
 		s.resourceCreate(c, resourceInfo, cloudClient, &resourceToCreate)
 	} else if err := c.ShouldBindBodyWithJSON(&resourceToAttach); err == nil && resourceToAttach.Id != "" {
-		if c.Request.Method != "POST" {
+		if c.Request.Method != http.MethodPost {
 			c.AbortWithStatusJSON(400, createErrorResponse("Only POST method is allowed for attaching resources"))
 			return
 		}
@@ -1159,7 +1161,7 @@ func (s *ControllerServer) handleCreateOrAttachResource(c *gin.Context) {
 	}
 }
 
-// Check the resource is valid to be created or attached at the orchestrator level
+// Check the resource is valid to be created or attached at the orchestrator level.
 func (s *ControllerServer) preCreateOrAttach(c *gin.Context, resourceInfo *ResourceInfo) error {
 	// Check if tag already exists
 	tagName := getTagName(resourceInfo.namespace, resourceInfo.cloud, resourceInfo.name)
@@ -1173,7 +1175,7 @@ func (s *ControllerServer) preCreateOrAttach(c *gin.Context, resourceInfo *Resou
 		c.AbortWithStatusJSON(400, createErrorResponse(err.Error()))
 		return err
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 
 	client := tagservicepb.NewTagServiceClient(conn)
 	resp, err := client.GetTag(context.Background(), &tagservicepb.GetTagRequest{TagName: tagName})
@@ -1185,7 +1187,7 @@ func (s *ControllerServer) preCreateOrAttach(c *gin.Context, resourceInfo *Resou
 	return nil
 }
 
-// Create resource in specified cloud region
+// Create resource in specified cloud region.
 func (s *ControllerServer) resourceCreate(c *gin.Context, resourceInfo *ResourceInfo, cloudClient string, resourceToCreate *paragliderpb.ResourceDescriptionString) {
 	// Create connection to cloud plugin
 	conn, err := grpc.NewClient(cloudClient, grpc.WithTransportCredentials(insecure.NewCredentials()))
@@ -1193,7 +1195,7 @@ func (s *ControllerServer) resourceCreate(c *gin.Context, resourceInfo *Resource
 		c.AbortWithStatusJSON(400, createErrorResponse(err.Error()))
 		return
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 
 	// Send RPC to create the resource
 	resource := paragliderpb.CreateResourceRequest{
@@ -1230,7 +1232,7 @@ func (s *ControllerServer) resourceAttach(c *gin.Context, resourceInfo *Resource
 		c.AbortWithStatusJSON(400, createErrorResponse(err.Error()))
 		return
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 
 	// Send RPC to attach resource
 	attachResourceReq := paragliderpb.AttachResourceRequest{
@@ -1261,7 +1263,7 @@ func (s *ControllerServer) createTag(c *gin.Context, resourceInfo *ResourceInfo,
 		c.AbortWithStatusJSON(400, createErrorResponse(err.Error()))
 		return ""
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 
 	tagName := getTagName(resourceInfo.namespace, resourceInfo.cloud, resourceInfo.name)
 	tagClient := tagservicepb.NewTagServiceClient(conn)
@@ -1274,7 +1276,7 @@ func (s *ControllerServer) createTag(c *gin.Context, resourceInfo *ResourceInfo,
 	return tagName
 }
 
-// List all tags from local tag service
+// List all tags from local tag service.
 func (s *ControllerServer) listTags(c *gin.Context) {
 	// Call listTags locally
 	conn, err := grpc.NewClient(s.localTagService, grpc.WithTransportCredentials(insecure.NewCredentials()))
@@ -1282,7 +1284,7 @@ func (s *ControllerServer) listTags(c *gin.Context) {
 		c.AbortWithStatusJSON(400, createErrorResponse(err.Error()))
 		return
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 
 	// Send RPC to list tags
 	client := tagservicepb.NewTagServiceClient(conn)
@@ -1294,7 +1296,7 @@ func (s *ControllerServer) listTags(c *gin.Context) {
 	c.JSON(http.StatusOK, response.Tags)
 }
 
-// Get tag from local tag service
+// Get tag from local tag service.
 func (s *ControllerServer) getTag(c *gin.Context) {
 	// Call getTag locally
 	conn, err := grpc.NewClient(s.localTagService, grpc.WithTransportCredentials(insecure.NewCredentials()))
@@ -1302,7 +1304,7 @@ func (s *ControllerServer) getTag(c *gin.Context) {
 		c.AbortWithStatusJSON(400, createErrorResponse(err.Error()))
 		return
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 
 	// Send RPC to get tag
 	tag := c.Param("tag")
@@ -1316,7 +1318,7 @@ func (s *ControllerServer) getTag(c *gin.Context) {
 	c.JSON(http.StatusOK, response.Tag)
 }
 
-// Resolve tag down to IP/URI(s) from local tag service
+// Resolve tag down to IP/URI(s) from local tag service.
 func (s *ControllerServer) resolveTag(c *gin.Context) {
 	// Call resolveTag locally
 	conn, err := grpc.NewClient(s.localTagService, grpc.WithTransportCredentials(insecure.NewCredentials()))
@@ -1324,7 +1326,7 @@ func (s *ControllerServer) resolveTag(c *gin.Context) {
 		c.AbortWithStatusJSON(400, createErrorResponse(err.Error()))
 		return
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 
 	// Send RPC to get tag
 	tag := c.Param("tag")
@@ -1338,7 +1340,7 @@ func (s *ControllerServer) resolveTag(c *gin.Context) {
 	c.JSON(http.StatusOK, response.Tags)
 }
 
-// Clear targets from rules provided by the user
+// Clear targets from rules provided by the user.
 func clearRuleTargets(rules []*paragliderpb.PermitListRule) []*paragliderpb.PermitListRule {
 	for _, rule := range rules {
 		rule.Targets = []string{}
@@ -1346,14 +1348,14 @@ func clearRuleTargets(rules []*paragliderpb.PermitListRule) []*paragliderpb.Perm
 	return rules
 }
 
-// Update subscribers to a tag about membership changes
+// Update subscribers to a tag about membership changes.
 func (s *ControllerServer) updateSubscribers(tag string) error {
 	// Get the subscribers to the tag
 	conn, err := grpc.NewClient(s.localTagService, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		return err
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 
 	client := tagservicepb.NewTagServiceClient(conn)
 	response, err := client.GetSubscribers(context.Background(), &tagservicepb.GetSubscribersRequest{TagName: tag})
@@ -1386,7 +1388,7 @@ func (s *ControllerServer) updateSubscribers(tag string) error {
 	return nil
 }
 
-// Set tag mapping in local db and update subscribers to membership change
+// Set tag mapping in local db and update subscribers to membership change.
 func (s *ControllerServer) setTag(c *gin.Context) {
 	// Parse data
 	var tag tagservicepb.TagMapping
@@ -1401,7 +1403,7 @@ func (s *ControllerServer) setTag(c *gin.Context) {
 		c.AbortWithStatusJSON(400, createErrorResponse(err.Error()))
 		return
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 
 	client := tagservicepb.NewTagServiceClient(conn)
 	_, err = client.SetTag(context.Background(), &tagservicepb.SetTagRequest{Tag: &tag})
@@ -1418,7 +1420,7 @@ func (s *ControllerServer) setTag(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{})
 }
 
-// Delete tag (all mappings under it) in local db and update subscribers to membership change
+// Delete tag (all mappings under it) in local db and update subscribers to membership change.
 func (s *ControllerServer) deleteTag(c *gin.Context) {
 	tagName := c.Param("tag")
 
@@ -1428,7 +1430,7 @@ func (s *ControllerServer) deleteTag(c *gin.Context) {
 		c.AbortWithStatusJSON(400, createErrorResponse(err.Error()))
 		return
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 
 	client := tagservicepb.NewTagServiceClient(conn)
 	_, err = client.DeleteTag(context.Background(), &tagservicepb.DeleteTagRequest{TagName: tagName})
@@ -1447,7 +1449,7 @@ func (s *ControllerServer) deleteTag(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{})
 }
 
-// Delete members of tag in local db and update subscribers to membership change
+// Delete members of tag in local db and update subscribers to membership change.
 func (s *ControllerServer) deleteTagMember(c *gin.Context) {
 	parentTag := c.Param("tag")
 	memberTag := c.Param("member")
@@ -1459,7 +1461,7 @@ func (s *ControllerServer) deleteTagMember(c *gin.Context) {
 		c.AbortWithStatusJSON(400, createErrorResponse(err.Error()))
 		return
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 
 	client := tagservicepb.NewTagServiceClient(conn)
 	_, err = client.DeleteTagMember(context.Background(), &tagservicepb.DeleteTagMemberRequest{ParentTag: parentTag, ChildTag: memberTag})
@@ -1477,18 +1479,18 @@ func (s *ControllerServer) deleteTagMember(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{})
 }
 
-// List all configured namespaces
+// List all configured namespaces.
 func (s *ControllerServer) listNamespaces(c *gin.Context) {
 	c.JSON(http.StatusOK, s.config.Namespaces)
 }
 
-// Get a value from the KV store
+// Get a value from the KV store.
 func (s *ControllerServer) GetValue(c context.Context, req *paragliderpb.GetValueRequest) (*paragliderpb.GetValueResponse, error) {
 	conn, err := grpc.NewClient(s.localKVStoreService, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		return nil, err
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 
 	client := storepb.NewKVStoreClient(conn)
 
@@ -1499,13 +1501,13 @@ func (s *ControllerServer) GetValue(c context.Context, req *paragliderpb.GetValu
 	return &paragliderpb.GetValueResponse{Value: response.Value}, nil
 }
 
-// Set a value in the KV store
+// Set a value in the KV store.
 func (s *ControllerServer) SetValue(c context.Context, req *paragliderpb.SetValueRequest) (*paragliderpb.SetValueResponse, error) {
 	conn, err := grpc.NewClient(s.localKVStoreService, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		return nil, err
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 
 	client := storepb.NewKVStoreClient(conn)
 
@@ -1516,13 +1518,13 @@ func (s *ControllerServer) SetValue(c context.Context, req *paragliderpb.SetValu
 	return &paragliderpb.SetValueResponse{}, nil
 }
 
-// Delete a value in the KV store
+// Delete a value in the KV store.
 func (s *ControllerServer) DeleteValue(c context.Context, req *paragliderpb.DeleteValueRequest) (*paragliderpb.DeleteValueResponse, error) {
 	conn, err := grpc.NewClient(s.localKVStoreService, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		return nil, err
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 
 	client := storepb.NewKVStoreClient(conn)
 
@@ -1534,14 +1536,14 @@ func (s *ControllerServer) DeleteValue(c context.Context, req *paragliderpb.Dele
 	return &paragliderpb.DeleteValueResponse{}, nil
 }
 
-// Setup with config file
+// Setup with config file.
 func SetupWithFile(configPath string, background bool) {
 	// Read the config
 	f, err := os.Open(configPath)
 	if err != nil {
 		fmt.Println(err.Error())
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	var cfg config.Config
 	decoder := yaml.NewDecoder(f)
@@ -1553,7 +1555,7 @@ func SetupWithFile(configPath string, background bool) {
 	Setup(cfg, background)
 }
 
-// Setup and run the server
+// Setup and run the server.
 func Setup(cfg config.Config, background bool) {
 	// Populate server info
 	server := ControllerServer{
@@ -1573,12 +1575,14 @@ func Setup(cfg config.Config, background bool) {
 			if err != nil {
 				return
 			}
-			defer conn.Close()
+			defer func() { _ = conn.Close() }()
 
 			// Send feature flags
 			client := paragliderpb.NewCloudPluginClient(conn)
-			cloudFlags := &paragliderpb.PluginFlags{KubernetesClustersEnabled: cfg.FeatureFlags[c.Name].KubernetesClustersEnabled,
-				PrivateEndpointsEnabled: cfg.FeatureFlags[c.Name].PrivateEndpointsEnabled, AttachResourceEnabled: cfg.FeatureFlags[c.Name].AttachResourceEnabled}
+			cloudFlags := &paragliderpb.PluginFlags{
+				KubernetesClustersEnabled: cfg.FeatureFlags[c.Name].KubernetesClustersEnabled,
+				PrivateEndpointsEnabled:   cfg.FeatureFlags[c.Name].PrivateEndpointsEnabled, AttachResourceEnabled: cfg.FeatureFlags[c.Name].AttachResourceEnabled,
+			}
 			_, err = client.SetFlags(context.Background(), &paragliderpb.SetFlagsRequest{Flags: cloudFlags})
 			if err != nil {
 				fmt.Println(err.Error())

--- a/pkg/orchestrator/orchestrator_test.go
+++ b/pkg/orchestrator/orchestrator_test.go
@@ -46,8 +46,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const defaultNamespace = "default"
-const exampleCloudName = "example"
+const (
+	defaultNamespace = "default"
+	exampleCloudName = "example"
+)
 
 var portNum = 10000
 
@@ -138,7 +140,8 @@ func TestPermitListRulesAdd(t *testing.T) {
 		Direction: paragliderpb.Direction_INBOUND,
 		SrcPort:   1,
 		DstPort:   2,
-		Protocol:  1}
+		Protocol:  1,
+	}
 	rulesList := []*paragliderpb.PermitListRule{rule}
 	jsonValue, _ := json.Marshal(rulesList)
 
@@ -168,7 +171,8 @@ func TestPermitListRulesAdd(t *testing.T) {
 		Direction: paragliderpb.Direction_INBOUND,
 		SrcPort:   1,
 		DstPort:   2,
-		Protocol:  1}
+		Protocol:  1,
+	}
 	rulesList = []*paragliderpb.PermitListRule{rule}
 	jsonValue, _ = json.Marshal(rulesList)
 
@@ -221,7 +225,8 @@ func TestPermitListRulePut(t *testing.T) {
 		Direction: paragliderpb.Direction_INBOUND,
 		SrcPort:   1,
 		DstPort:   2,
-		Protocol:  1}
+		Protocol:  1,
+	}
 	jsonValue, _ := json.Marshal(rule)
 
 	url := fmt.Sprintf(GetFormatterString(PermitListRulePUTURL), defaultNamespace, exampleCloudName, name, rule.Name)
@@ -249,7 +254,8 @@ func TestPermitListRulePut(t *testing.T) {
 		Direction: paragliderpb.Direction_INBOUND,
 		SrcPort:   1,
 		DstPort:   2,
-		Protocol:  1}
+		Protocol:  1,
+	}
 	jsonValue, _ = json.Marshal(rule)
 
 	url = fmt.Sprintf(GetFormatterString(PermitListRulePUTURL), defaultNamespace, exampleCloudName, name, rule.Name)
@@ -301,7 +307,8 @@ func TestPermitListRulePost(t *testing.T) {
 		Direction: paragliderpb.Direction_INBOUND,
 		SrcPort:   1,
 		DstPort:   2,
-		Protocol:  1}
+		Protocol:  1,
+	}
 	jsonValue, _ := json.Marshal(rule)
 
 	url := fmt.Sprintf(GetFormatterString(PermitListRulePOSTURL), defaultNamespace, exampleCloudName, name)
@@ -330,7 +337,8 @@ func TestPermitListRulePost(t *testing.T) {
 		Direction: paragliderpb.Direction_INBOUND,
 		SrcPort:   1,
 		DstPort:   2,
-		Protocol:  1}
+		Protocol:  1,
+	}
 	jsonValue, _ = json.Marshal(rule)
 
 	url = fmt.Sprintf(GetFormatterString(PermitListRulePOSTURL), defaultNamespace, exampleCloudName, name)
@@ -375,13 +383,14 @@ func TestPermitListRuleTagAdd(t *testing.T) {
 
 	// Well-formed request
 	tags := []string{"1.1.1.1"}
-	rule := []*paragliderpb.PermitListRule{&paragliderpb.PermitListRule{
+	rule := []*paragliderpb.PermitListRule{{
 		Name:      "rulename",
 		Tags:      tags,
 		Direction: paragliderpb.Direction_INBOUND,
 		SrcPort:   1,
 		DstPort:   2,
-		Protocol:  1}}
+		Protocol:  1,
+	}}
 	jsonValue, _ := json.Marshal(rule)
 
 	url := fmt.Sprintf(GetFormatterString(RuleOnTagURL), defaultNamespace+"."+exampleCloudName+"."+faketagservice.ValidTagName)
@@ -1193,7 +1202,8 @@ func TestResolvePermitListRules(t *testing.T) {
 		Direction: paragliderpb.Direction_INBOUND,
 		SrcPort:   1,
 		DstPort:   2,
-		Protocol:  1}
+		Protocol:  1,
+	}
 	rulesList := []*paragliderpb.PermitListRule{rule}
 	expectedRule := &paragliderpb.PermitListRule{
 		Name:      "rulename",
@@ -1202,7 +1212,8 @@ func TestResolvePermitListRules(t *testing.T) {
 		Direction: paragliderpb.Direction_INBOUND,
 		SrcPort:   1,
 		DstPort:   2,
-		Protocol:  1}
+		Protocol:  1,
+	}
 	expectedRulesList := []*paragliderpb.PermitListRule{expectedRule}
 	resource := &ResourceInfo{uri: "uri", cloud: exampleCloudName, namespace: defaultNamespace}
 
@@ -1235,7 +1246,8 @@ func TestCheckAndCleanRule(t *testing.T) {
 		Direction: paragliderpb.Direction_INBOUND,
 		SrcPort:   1,
 		DstPort:   2,
-		Protocol:  1}
+		Protocol:  1,
+	}
 
 	cleanRule, _, err := checkAndCleanRule(rule)
 	assert.Nil(t, err)
@@ -1249,7 +1261,8 @@ func TestCheckAndCleanRule(t *testing.T) {
 		Direction: paragliderpb.Direction_INBOUND,
 		SrcPort:   1,
 		DstPort:   2,
-		Protocol:  1}
+		Protocol:  1,
+	}
 
 	_, _, err = checkAndCleanRule(badRule)
 	assert.NotNil(t, err)
@@ -1262,7 +1275,8 @@ func TestCheckAndCleanRule(t *testing.T) {
 		Direction: paragliderpb.Direction_INBOUND,
 		SrcPort:   1,
 		DstPort:   2,
-		Protocol:  1}
+		Protocol:  1,
+	}
 
 	cleanRule, warning, err := checkAndCleanRule(badRule)
 	assert.Nil(t, err)
@@ -1295,19 +1309,19 @@ func TestCreateSubscriberName(t *testing.T) {
 
 func TestDiffTagReferences(t *testing.T) {
 	beforePermitList := []*paragliderpb.PermitListRule{
-		&paragliderpb.PermitListRule{
+		{
 			Tags: []string{"tag1", "1.2.3.4"},
 		},
-		&paragliderpb.PermitListRule{
+		{
 			Tags: []string{"tag1", "tag2", "tag3"},
 		},
 	}
 
 	afterPermitList := []*paragliderpb.PermitListRule{
-		&paragliderpb.PermitListRule{
+		{
 			Tags: []string{"tag1", "1.2.3.4"},
 		},
-		&paragliderpb.PermitListRule{
+		{
 			Tags: []string{"tag3"},
 		},
 	}
@@ -1329,19 +1343,19 @@ func TestCheckAndUnsubscribe(t *testing.T) {
 	resource := ResourceInfo{uri: "uri", cloud: exampleCloudName, namespace: defaultNamespace}
 
 	beforePermitList := []*paragliderpb.PermitListRule{
-		&paragliderpb.PermitListRule{
+		{
 			Tags: []string{faketagservice.ValidTagName + "1", "1.2.3.4"},
 		},
-		&paragliderpb.PermitListRule{
+		{
 			Tags: []string{faketagservice.ValidTagName + "1", faketagservice.ValidTagName + "2", faketagservice.ValidTagName + "2"},
 		},
 	}
 
 	afterPermitList := []*paragliderpb.PermitListRule{
-		&paragliderpb.PermitListRule{
+		{
 			Tags: []string{faketagservice.ValidTagName + "1", "1.2.3.4"},
 		},
-		&paragliderpb.PermitListRule{
+		{
 			Tags: []string{faketagservice.ValidTagName + "3"},
 		},
 	}
@@ -1352,25 +1366,25 @@ func TestCheckAndUnsubscribe(t *testing.T) {
 
 func TestClearRuleTargets(t *testing.T) {
 	permitList := []*paragliderpb.PermitListRule{
-		&paragliderpb.PermitListRule{
+		{
 			Targets: []string{"1.2.3.4"},
 		},
-		&paragliderpb.PermitListRule{
+		{
 			Targets: []string{"1.2.3.4", "2.3.4.5"},
 		},
-		&paragliderpb.PermitListRule{
+		{
 			Tags: []string{"1.2.3.4", "2.3.4.5"},
 		},
 	}
 
 	expectedPermitList := []*paragliderpb.PermitListRule{
-		&paragliderpb.PermitListRule{
+		{
 			Targets: []string{},
 		},
-		&paragliderpb.PermitListRule{
+		{
 			Targets: []string{},
 		},
-		&paragliderpb.PermitListRule{
+		{
 			Targets: []string{},
 			Tags:    []string{"1.2.3.4", "2.3.4.5"},
 		},

--- a/pkg/orchestrator/orchestrator_utils.go
+++ b/pkg/orchestrator/orchestrator_utils.go
@@ -22,7 +22,7 @@ import (
 	paragliderpb "github.com/paraglider-project/paraglider/pkg/paragliderpb"
 )
 
-// Private ASN ranges (RFC 6996)
+// Private ASN ranges (RFC 6996).
 const (
 	MIN_PRIVATE_ASN_2BYTE uint32 = 64512
 	MAX_PRIVATE_ASN_2BYTE uint32 = 65534

--- a/pkg/tag_service/tag_service.go
+++ b/pkg/tag_service/tag_service.go
@@ -41,7 +41,7 @@ func getSubscriptionKey(tagName string) string {
 	return "SUB:" + tagName
 }
 
-// Returns true if the string is a valid IP or CIDR
+// Returns true if the string is a valid IP or CIDR.
 func isIpAddrOrCidr(value string) bool {
 	if strings.Contains(value, "/") {
 		_, err := netip.ParsePrefix(value)
@@ -52,12 +52,12 @@ func isIpAddrOrCidr(value string) bool {
 	}
 }
 
-// Determines if a tag is a descendent of another tag
+// Determines if a tag is a descendent of another tag.
 func (s *tagServiceServer) isDescendent(c context.Context, tag string, potentialChild string) (bool, error) {
 	// Only do SMEMBERS if the tag is a set, otherwise it cannot be a parent
 	valType, err := s.client.Type(c, tag).Result()
 	if err != nil {
-		return false, fmt.Errorf("isDescendent TYPE %s: %v", tag, err)
+		return false, fmt.Errorf("isDescendent TYPE %s: %w", tag, err)
 	}
 	if valType != "set" {
 		return false, nil
@@ -65,7 +65,7 @@ func (s *tagServiceServer) isDescendent(c context.Context, tag string, potential
 
 	childrenTags, err := s.client.SMembers(c, tag).Result()
 	if err != nil {
-		return false, fmt.Errorf("isDescendent %s: %v", tag, err)
+		return false, fmt.Errorf("isDescendent %s: %w", tag, err)
 	}
 	for _, child := range childrenTags {
 		if child == potentialChild {
@@ -73,7 +73,7 @@ func (s *tagServiceServer) isDescendent(c context.Context, tag string, potential
 		}
 		isDescendent, err := s.isDescendent(c, child, potentialChild)
 		if err != nil {
-			return false, fmt.Errorf("isDescendent %s: %v", tag, err)
+			return false, fmt.Errorf("isDescendent %s: %w", tag, err)
 		}
 		if isDescendent {
 			return true, nil
@@ -95,19 +95,19 @@ func isLeafTagMapping(tag *tagservicepb.TagMapping) (bool, error) {
 func (s *tagServiceServer) isLeafTag(c context.Context, tag string) (bool, error) {
 	recordType, err := s.client.Type(c, tag).Result()
 	if err != nil {
-		return false, fmt.Errorf("isLeafTag TYPE %s: %v", tag, err)
+		return false, fmt.Errorf("isLeafTag TYPE %s: %w", tag, err)
 	}
 	return recordType == "hash", nil
 }
 
-// Record tag by storing mapping to URI and IP
+// Record tag by storing mapping to URI and IP.
 func (s *tagServiceServer) _setLeafTag(c context.Context, tag *tagservicepb.TagMapping) error {
 	exists, err := s.client.HExists(c, tag.Name, "uri").Result()
 	if err != nil {
 		return err
 	}
 	if exists {
-		return fmt.Errorf("Cannot set tag %s as a leaf tag because it already exists.", tag.Name)
+		return fmt.Errorf("cannot set tag %s as a leaf tag because it already exists", tag.Name)
 	}
 
 	uri := ""
@@ -126,17 +126,17 @@ func (s *tagServiceServer) _setLeafTag(c context.Context, tag *tagservicepb.TagM
 	return nil
 }
 
-// Set tag relationship by adding child tag to parent tag's set
+// Set tag relationship by adding child tag to parent tag's set.
 func (s *tagServiceServer) SetTag(c context.Context, req *tagservicepb.SetTagRequest) (*tagservicepb.SetTagResponse, error) {
 	// If tag is leaf entry (no children), set as a hash record and return
 	isLeaf, err := isLeafTagMapping(req.Tag)
 	if err != nil {
-		return &tagservicepb.SetTagResponse{}, fmt.Errorf("SetTag: %v", err)
+		return &tagservicepb.SetTagResponse{}, fmt.Errorf("SetTag: %w", err)
 	}
 	if isLeaf {
 		err := s._setLeafTag(c, req.Tag)
 		if err != nil {
-			return &tagservicepb.SetTagResponse{}, fmt.Errorf("SetTag: %v", err)
+			return &tagservicepb.SetTagResponse{}, fmt.Errorf("SetTag: %w", err)
 		}
 		return &tagservicepb.SetTagResponse{}, nil
 	}
@@ -146,7 +146,7 @@ func (s *tagServiceServer) SetTag(c context.Context, req *tagservicepb.SetTagReq
 	for _, child := range req.Tag.ChildTags {
 		parentTagIsDescendent, err := s.isDescendent(c, child, req.Tag.Name)
 		if err != nil {
-			return &tagservicepb.SetTagResponse{}, fmt.Errorf("SetTag: %v", err)
+			return &tagservicepb.SetTagResponse{}, fmt.Errorf("SetTag: %w", err)
 		}
 		if parentTagIsDescendent {
 			return &tagservicepb.SetTagResponse{}, nil
@@ -156,25 +156,25 @@ func (s *tagServiceServer) SetTag(c context.Context, req *tagservicepb.SetTagReq
 	// Add the tags
 	err = s.client.SAdd(c, req.Tag.Name, req.Tag.ChildTags).Err()
 	if err != nil {
-		return &tagservicepb.SetTagResponse{}, fmt.Errorf("SetTag: %v", err)
+		return &tagservicepb.SetTagResponse{}, fmt.Errorf("SetTag: %w", err)
 	}
 
 	return &tagservicepb.SetTagResponse{}, nil
 }
 
-// Get the members of a tag
+// Get the members of a tag.
 func (s *tagServiceServer) GetTag(c context.Context, req *tagservicepb.GetTagRequest) (*tagservicepb.GetTagResponse, error) {
 	// Determine if the tag is a leaf tag or not
 	isLeaf, err := s.isLeafTag(c, req.TagName)
 	if err != nil {
-		return nil, fmt.Errorf("GetTag %s: %v", req.TagName, err)
+		return nil, fmt.Errorf("GetTag %s: %w", req.TagName, err)
 	}
 
 	// If it is, retrieve the hash record
 	if isLeaf {
 		info, err := s.client.HGetAll(c, req.TagName).Result()
 		if err != nil {
-			return nil, fmt.Errorf("GetTag %s: %v", req.TagName, err)
+			return nil, fmt.Errorf("GetTag %s: %w", req.TagName, err)
 		}
 		uri := info["uri"]
 		ip := info["ip"]
@@ -184,12 +184,12 @@ func (s *tagServiceServer) GetTag(c context.Context, req *tagservicepb.GetTagReq
 	// Otherwise, retrieve set of child tags
 	childrenTags, err := s.client.SMembers(c, req.TagName).Result()
 	if err != nil {
-		return nil, fmt.Errorf("GetTag %s: %v", req.TagName, err)
+		return nil, fmt.Errorf("GetTag %s: %w", req.TagName, err)
 	}
 	return &tagservicepb.GetTagResponse{Tag: &tagservicepb.TagMapping{Name: req.TagName, ChildTags: childrenTags}}, nil
 }
 
-// Resolve a list of tags into all base-level IPs
+// Resolve a list of tags into all base-level IPs.
 func (s *tagServiceServer) _resolveTags(c context.Context, tags []string, resolvedTags []*tagservicepb.TagMapping) ([]*tagservicepb.TagMapping, error) {
 	for _, tag := range tags {
 		// If the tag is an IP, it is already resolved
@@ -201,7 +201,7 @@ func (s *tagServiceServer) _resolveTags(c context.Context, tags []string, resolv
 			// Get the tag record type since may be hash (if name value) or set (if parent tag)
 			valType, err := s.client.Type(c, tag).Result()
 			if err != nil {
-				return nil, fmt.Errorf("ResolveTag TYPE %s: %v", tag, err)
+				return nil, fmt.Errorf("ResolveTag TYPE %s: %w", tag, err)
 			}
 
 			if valType == "none" { // The tag is not present
@@ -209,7 +209,7 @@ func (s *tagServiceServer) _resolveTags(c context.Context, tags []string, resolv
 			} else if valType == "hash" { // The tag is a name record
 				info, err := s.client.HGetAll(c, tag).Result()
 				if err != nil {
-					return nil, fmt.Errorf("ResolveTag HGETALL %s: %v", tag, err)
+					return nil, fmt.Errorf("ResolveTag HGETALL %s: %w", tag, err)
 				}
 				uri := info["uri"]
 				ip := info["ip"]
@@ -217,12 +217,12 @@ func (s *tagServiceServer) _resolveTags(c context.Context, tags []string, resolv
 			} else { // The tag has children that may also need resolved
 				childrenTags, err := s.client.SMembers(c, tag).Result()
 				if err != nil {
-					return nil, fmt.Errorf("ResolveTag SMEMBERS %s: %v", tag, err)
+					return nil, fmt.Errorf("ResolveTag SMEMBERS %s: %w", tag, err)
 				}
 
 				resolvedChildTags, err := s._resolveTags(c, childrenTags, resolvedTags)
 				if err != nil {
-					return nil, fmt.Errorf("ResolveTag %s: %v", tag, err)
+					return nil, fmt.Errorf("ResolveTag %s: %w", tag, err)
 				}
 				resolvedTags = append(resolvedTags, resolvedChildTags...)
 			}
@@ -231,7 +231,7 @@ func (s *tagServiceServer) _resolveTags(c context.Context, tags []string, resolv
 	return resolvedTags, nil
 }
 
-// Resolve a tag down to all the IPs in it
+// Resolve a tag down to all the IPs in it.
 func (s *tagServiceServer) ResolveTag(c context.Context, req *tagservicepb.ResolveTagRequest) (*tagservicepb.ResolveTagResponse, error) {
 	var emptyTagList []*tagservicepb.TagMapping
 	resolvedTags, err := s._resolveTags(c, []string{req.TagName}, emptyTagList)
@@ -242,7 +242,7 @@ func (s *tagServiceServer) ResolveTag(c context.Context, req *tagservicepb.Resol
 	return &tagservicepb.ResolveTagResponse{Tags: resolvedTags}, nil
 }
 
-// Resolve a list of tags into all base-level IPs
+// Resolve a list of tags into all base-level IPs.
 func (s *tagServiceServer) ListTags(c context.Context, req *tagservicepb.ListTagsRequest) (*tagservicepb.ListTagsResponse, error) {
 	var resolvedTagList []*tagservicepb.TagMapping
 	tags := s.client.Keys(c, "*").Val()
@@ -259,16 +259,16 @@ func (s *tagServiceServer) ListTags(c context.Context, req *tagservicepb.ListTag
 	return &tagservicepb.ListTagsResponse{Tags: resolvedTagList}, nil
 }
 
-// Delete a member of a tag
+// Delete a member of a tag.
 func (s *tagServiceServer) DeleteTagMember(c context.Context, req *tagservicepb.DeleteTagMemberRequest) (*tagservicepb.DeleteTagMemberResponse, error) {
 	err := s.client.SRem(c, req.ParentTag, req.ChildTag).Err()
 	if err != nil {
-		return &tagservicepb.DeleteTagMemberResponse{}, fmt.Errorf("DeleteTagMember %s: %v", req.ParentTag, err)
+		return &tagservicepb.DeleteTagMemberResponse{}, fmt.Errorf("DeleteTagMember %s: %w", req.ParentTag, err)
 	}
 	return &tagservicepb.DeleteTagMemberResponse{}, nil
 }
 
-// Delete a leaf record for a tag
+// Delete a leaf record for a tag.
 func (s *tagServiceServer) _deleteLeafTag(c context.Context, tag *tagservicepb.TagMapping) error {
 	keys, err := s.client.HKeys(c, tag.Name).Result()
 	if err != nil {
@@ -282,17 +282,17 @@ func (s *tagServiceServer) _deleteLeafTag(c context.Context, tag *tagservicepb.T
 	return nil
 }
 
-// Delete a tag and its relationship to its children tags
+// Delete a tag and its relationship to its children tags.
 func (s *tagServiceServer) DeleteTag(c context.Context, req *tagservicepb.DeleteTagRequest) (*tagservicepb.DeleteTagResponse, error) {
 	// If the tag is a leaf tag, delete the hash record
 	isLeaf, err := s.isLeafTag(c, req.TagName)
 	if err != nil {
-		return &tagservicepb.DeleteTagResponse{}, fmt.Errorf("DeleteTag %s: %v", req.TagName, err)
+		return &tagservicepb.DeleteTagResponse{}, fmt.Errorf("DeleteTag %s: %w", req.TagName, err)
 	}
 	if isLeaf {
 		err := s._deleteLeafTag(c, &tagservicepb.TagMapping{Name: req.TagName})
 		if err != nil {
-			return &tagservicepb.DeleteTagResponse{}, fmt.Errorf("DeleteTag %s: %v", req.TagName, err)
+			return &tagservicepb.DeleteTagResponse{}, fmt.Errorf("DeleteTag %s: %w", req.TagName, err)
 		}
 		return &tagservicepb.DeleteTagResponse{}, nil
 	}
@@ -300,53 +300,53 @@ func (s *tagServiceServer) DeleteTag(c context.Context, req *tagservicepb.Delete
 	// Delete all children in mapping
 	childrenTags, err := s.client.SMembers(c, req.TagName).Result()
 	if err != nil {
-		return &tagservicepb.DeleteTagResponse{}, fmt.Errorf("DeleteTag %s: %v", req.TagName, err)
+		return &tagservicepb.DeleteTagResponse{}, fmt.Errorf("DeleteTag %s: %w", req.TagName, err)
 	}
 
 	err = s.client.SRem(c, req.TagName, childrenTags).Err()
 	if err != nil {
-		return &tagservicepb.DeleteTagResponse{}, fmt.Errorf("DeleteTag %s: %v", req.TagName, err)
+		return &tagservicepb.DeleteTagResponse{}, fmt.Errorf("DeleteTag %s: %w", req.TagName, err)
 	}
 	return &tagservicepb.DeleteTagResponse{}, nil
 }
 
-// Subscribe to a tag
+// Subscribe to a tag.
 func (s *tagServiceServer) Subscribe(c context.Context, req *tagservicepb.SubscribeRequest) (*tagservicepb.SubscribeResponse, error) {
 	err := s.client.SAdd(c, getSubscriptionKey(req.Subscription.TagName), req.Subscription.Subscriber).Err()
 	if err != nil {
-		return &tagservicepb.SubscribeResponse{}, fmt.Errorf("Subscribe: %v", err)
+		return &tagservicepb.SubscribeResponse{}, fmt.Errorf("Subscribe: %w", err)
 	}
 
 	return &tagservicepb.SubscribeResponse{}, nil
 }
 
-// Unsubscribe from a tag
+// Unsubscribe from a tag.
 func (s *tagServiceServer) Unsubscribe(c context.Context, req *tagservicepb.UnsubscribeRequest) (*tagservicepb.UnsubscribeResponse, error) {
 	err := s.client.SRem(c, getSubscriptionKey(req.Subscription.TagName), req.Subscription.Subscriber).Err()
 	if err != nil {
-		return &tagservicepb.UnsubscribeResponse{}, fmt.Errorf("Unsubscribe: %v", err)
+		return &tagservicepb.UnsubscribeResponse{}, fmt.Errorf("Unsubscribe: %w", err)
 	}
 
 	return &tagservicepb.UnsubscribeResponse{}, nil
 }
 
-// Get all subscribers to a tag
+// Get all subscribers to a tag.
 func (s *tagServiceServer) GetSubscribers(c context.Context, req *tagservicepb.GetSubscribersRequest) (*tagservicepb.GetSubscribersResponse, error) {
 	subs, err := s.client.SMembers(c, getSubscriptionKey(req.TagName)).Result()
 	if err != nil {
-		return nil, fmt.Errorf("GetSubscribers: %v", err)
+		return nil, fmt.Errorf("GetSubscribers: %w", err)
 	}
 
 	return &tagservicepb.GetSubscribersResponse{Subscribers: subs}, nil
 }
 
-// Create a server for the tag service
+// Create a server for the tag service.
 func newServer(database *redis.Client) *tagServiceServer {
 	s := &tagServiceServer{client: database}
 	return s
 }
 
-// Setup and run the server
+// Setup and run the server.
 func Setup(dbPort int, serverPort int, clearKeys bool) {
 	// Start the Redis server if it's not already running
 	pgrepCmd := exec.Command("pgrep", "redis-server")

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -27,12 +27,10 @@ import (
 	"github.com/paraglider-project/paraglider/pkg/paragliderpb"
 )
 
-var (
-	Log *log.Logger
-)
+var Log *log.Logger
 
 // Cloud names
-// TODO @seankimkdy: turn these into its own type and use enums
+// TODO @seankimkdy: turn these into its own type and use enums.
 const (
 	GCP   = "gcp"
 	AZURE = "azure"
@@ -40,7 +38,7 @@ const (
 	AWS   = "aws"
 )
 
-// Private address spaces as defined in RFC 1918
+// Private address spaces as defined in RFC 1918.
 var privateAddressSpaces = []netip.Prefix{
 	netip.MustParsePrefix("10.0.0.0/8"),
 	netip.MustParsePrefix("172.16.0.0/12"),
@@ -84,7 +82,7 @@ func IsPermitListRuleTagInAddressSpace(permitListRuleTag string, addressSpaces [
 	return false, nil
 }
 
-// Checks if an IP address is public
+// Checks if an IP address is public.
 func IsIpAddressPrivate(addressString string) (bool, error) {
 	var addr netip.Addr
 	var err error
@@ -117,7 +115,7 @@ type PeeringCloudInfo struct {
 // Retrieves the peering cloud info (name, namespace, deployment) for a given permit list rule
 // Notes
 // 1. this method may return duplicate PeeringCloudInfos, so it's the responsibility of the cloud plugin to gracefully handle duplicates
-// 2. peeringCloudInfo[i] will be nil if the target is a public IP address, so make sure to check for that
+// 2. peeringCloudInfo[i] will be nil if the target is a public IP address, so make sure to check for that.
 func GetPermitListRulePeeringCloudInfo(permitListRule *paragliderpb.PermitListRule, usedAddressSpaceMappings []*paragliderpb.AddressSpaceMapping) ([]*PeeringCloudInfo, error) {
 	peeringCloudInfos := make([]*PeeringCloudInfo, len(permitListRule.Targets))
 	for i, target := range permitListRule.Targets {
@@ -153,7 +151,7 @@ func GetPermitListRulePeeringCloudInfo(permitListRule *paragliderpb.PermitListRu
 	return peeringCloudInfos, nil
 }
 
-// Returns prefix with GitHub workflow run numbers for integration tests
+// Returns prefix with GitHub workflow run numbers for integration tests.
 func GetGitHubRunPrefix() string {
 	ghRunNumber := os.Getenv("GH_RUN_NUMBER")
 	if ghRunNumber != "" {
@@ -162,12 +160,12 @@ func GetGitHubRunPrefix() string {
 	return ""
 }
 
-// Checks if cloud1 and cloud2 match with target1 and target2 in any order
+// Checks if cloud1 and cloud2 match with target1 and target2 in any order.
 func MatchCloudProviders(cloud1, cloud2, target1, target2 string) bool {
 	return (cloud1 == target1 && cloud2 == target2) || (cloud1 == target2 && cloud2 == target1)
 }
 
-// Returns the number of VPN connections needed between cloud1 and cloud2
+// Returns the number of VPN connections needed between cloud1 and cloud2.
 func GetNumVpnConnections(cloud1, cloud2 string) int {
 	if MatchCloudProviders(cloud1, cloud2, AZURE, GCP) || MatchCloudProviders(cloud1, cloud2, AZURE, IBM) {
 		return 2
@@ -193,7 +191,7 @@ func DoCIDROverlap(cidr1, cidr2 string) (bool, error) {
 	return false, nil
 }
 
-// IsCIDRSubset returns true if cidr1 is a subset (including equal) to cidr2
+// IsCIDRSubset returns true if cidr1 is a subset (including equal) to cidr2.
 func IsCIDRSubset(cidr1, cidr2 string) (bool, error) {
 	firstIP1, netCidr1, err := net.ParseCIDR(cidr1)
 	// ParseCIDR() example from Docs: for CIDR="192.0.2.1/24"


### PR DESCRIPTION
Upgrade to Go 1.26 and golangci version 2. 

For the linters, I included a recommended set without very strict options. If we use more strict linters like `ll` which enforce line length, a lot of the code needs to be changed. We should probably do this in the future though.